### PR TITLE
Coerce null values to NA

### DIFF
--- a/packages/app/src/hooks/useDotplotData.ts
+++ b/packages/app/src/hooks/useDotplotData.ts
@@ -6,14 +6,19 @@ export function useDotplotData(
   dotplotGeneExpressions: Record<string, Float32Array>,
   dotplotObsData: string[] | null,
 ) {
-  const groups = useMemo(() => {
-    if (!dotplotObsData) return [];
-    return [...new Set(dotplotObsData)].sort();
+  const normalizedObsData = useMemo(() => {
+    if (!dotplotObsData) return null;
+    return dotplotObsData.map((v) => (v == null ? "NA" : v));
   }, [dotplotObsData]);
 
+  const groups = useMemo(() => {
+    if (!normalizedObsData) return [];
+    return [...new Set(normalizedObsData)].sort();
+  }, [normalizedObsData]);
+
   const dotplotData = useMemo(
-    () => computeDotplotStats(dotplotGenes, dotplotGeneExpressions, dotplotObsData as string[], groups),
-    [dotplotGenes, dotplotGeneExpressions, dotplotObsData, groups],
+    () => computeDotplotStats(dotplotGenes, dotplotGeneExpressions, normalizedObsData as string[], groups),
+    [dotplotGenes, dotplotGeneExpressions, normalizedObsData, groups],
   );
 
   return { groups, dotplotData };

--- a/packages/app/src/utils/dotplotUtils.test.js
+++ b/packages/app/src/utils/dotplotUtils.test.js
@@ -124,6 +124,26 @@ describe("computeDotplotStats", () => {
     expect(typeB.fractionExpressing).toBeCloseTo(0.5);
   });
 
+  it("groups null obs values under NA", () => {
+    const genes = ["EGFR"];
+    const geneExpressions = {
+      EGFR: [1.0, 2.0, 3.0, 4.0, 5.0],
+    };
+    // Simulate obs data after null → "NA" coercion (done by useDotplotData)
+    const obs = ["TypeA", "NA", "TypeA", "NA", "TypeA"];
+    const grps = ["NA", "TypeA"];
+    const stats = computeDotplotStats(genes, geneExpressions, obs, grps);
+
+    expect(stats).toHaveLength(2);
+
+    const naGroup = stats.find((s) => s.group === "NA");
+    expect(naGroup.cellCount).toBe(2); // indices 1, 3
+    expect(naGroup.meanExpression).toBeCloseTo((2.0 + 4.0) / 2);
+
+    const typeA = stats.find((s) => s.group === "TypeA");
+    expect(typeA.cellCount).toBe(3); // indices 0, 2, 4
+  });
+
   it("ignores obs values not in groups list", () => {
     const obs = ["TypeA", "TypeA", "TypeC", "TypeC", "TypeA"];
     const genes = ["EGFR"];


### PR DESCRIPTION
Missing values get converted to null during the decode step and null.length call during the swap axis or show group labels does not exist.

The question becomes, should we filter out cells that contain null values? I think the answer is no, we should not filter out those cells with null values, we should cast them to NA.

MissingValues should be handled by schema validation or the preprocessing step during submission.