### PR TITLE
Group Dependabot updates to reduce PR and CI noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,43 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      prod-dependencies:
+        dependency-type: production
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: npm
     directory: /packages/app
     schedule:
       interval: weekly
+    groups:
+      prod-dependencies:
+        dependency-type: production
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: npm
     directory: /packages/zarrstore
     schedule:
       interval: weekly
+    groups:
+      prod-dependencies:
+        dependency-type: production
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: npm
     directory: /docs
     schedule:
       interval: weekly
+    groups:
+      prod-dependencies:
+        dependency-type: production
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group npm dependencies by production/development type for each package directory, and group all GitHub Actions updates together. This reduces the number of individual PRs (and CI runs) from potentially 20+ per week down to ~9 or fewer.