### PR TITLE
Skip CI for Dependabot PRs and allow manual triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,6 +18,7 @@ concurrency:
 
 jobs:
   test-zarrstore:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,6 +31,7 @@ jobs:
       - run: pnpm --filter @cbioportal-zarr-loader/zarrstore test
 
   test-app:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add workflow_dispatch to enable manual CI runs from the Actions tab. Add condition to skip test jobs when actor is dependabot[bot], which cascades to build and deploy via job dependencies.