### PR TITLE
Upgrade @visx/visx to 4.0.1-alpha.0 for React 19 support

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,7 @@
     "@deck.gl/core": "^9.2.10",
     "@deck.gl/layers": "^9.2.10",
     "@deck.gl/react": "^9.2.10",
-    "@visx/visx": "^3.12.0",
+    "@visx/visx": "4.0.1-alpha.0",
     "antd": "^6.3.1",
     "deck.gl": "^9.2.10",
     "react": "^19.2.4",

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -8,14 +8,14 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
+    "react": "^18.0.0 || ^19.0.0",
     "antd": "^6.0.0",
     "@ant-design/icons": "^6.0.0",
-    "@visx/axis": "^3.0.0",
-    "@visx/group": "^3.0.0",
-    "@visx/scale": "^3.0.0",
-    "@visx/shape": "^3.0.0",
-    "@visx/tooltip": "^3.0.0"
+    "@visx/axis": "^4.0.1-alpha.0",
+    "@visx/group": "^4.0.1-alpha.0",
+    "@visx/scale": "^4.0.1-alpha.0",
+    "@visx/shape": "^4.0.1-alpha.0",
+    "@visx/tooltip": "^4.0.1-alpha.0"
   },
   "devDependencies": {
     "vitest": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^9.2.10
         version: 9.2.10(@deck.gl/core@9.2.10)(@deck.gl/widgets@9.2.10(@deck.gl/core@9.2.10)(@luma.gl/core@9.2.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@visx/visx':
-        specifier: ^3.12.0
-        version: 3.12.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 4.0.1-alpha.0
+        version: 4.0.1-alpha.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       antd:
         specifier: ^6.3.1
         version: 6.3.1(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -112,28 +112,28 @@ importers:
     dependencies:
       '@ant-design/icons':
         specifier: ^6.0.0
-        version: 6.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+        version: 6.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@visx/axis':
-        specifier: ^3.0.0
-        version: 3.12.0(react@18.3.1)
+        specifier: ^4.0.1-alpha.0
+        version: 4.0.1-alpha.0(react@19.2.4)
       '@visx/group':
-        specifier: ^3.0.0
-        version: 3.12.0(react@18.3.1)
+        specifier: ^4.0.1-alpha.0
+        version: 4.0.1-alpha.0(react@19.2.4)
       '@visx/scale':
-        specifier: ^3.0.0
-        version: 3.12.0
+        specifier: ^4.0.1-alpha.0
+        version: 4.0.1-alpha.0
       '@visx/shape':
-        specifier: ^3.0.0
-        version: 3.12.0(react@18.3.1)
+        specifier: ^4.0.1-alpha.0
+        version: 4.0.1-alpha.0(react@19.2.4)
       '@visx/tooltip':
-        specifier: ^3.0.0
-        version: 3.12.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+        specifier: ^4.0.1-alpha.0
+        version: 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       antd:
         specifier: ^6.0.0
-        version: 6.2.3(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+        version: 6.2.3(luxon@3.7.2)(moment@2.30.1)(react@19.2.4)
       react:
-        specifier: ^18.0.0
-        version: 18.3.1
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.4
     devDependencies:
       jsdom:
         specifier: ^28.1.0
@@ -2853,9 +2853,6 @@ packages:
   '@types/d3-chord@3.0.6':
     resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
 
-  '@types/d3-cloud@1.2.5':
-    resolution: {integrity: sha512-vEIER9DsEBUOdpRiwCh3n1qE+cV6h4e1LhxhY2sLt+m8LPNAIkOOhTlqk0JDiBwD+ZPM8ynFAOU3AuPuVYBFBA==}
-
   '@types/d3-color@1.4.5':
     resolution: {integrity: sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g==}
 
@@ -2955,6 +2952,9 @@ packages:
   '@types/d3-shape@1.3.12':
     resolution: {integrity: sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==}
 
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -2984,9 +2984,6 @@ packages:
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
-
-  '@types/d3@3.5.53':
-    resolution: {integrity: sha512-8yKQA9cAS6+wGsJpBysmnhlaaxlN42Qizqkw+h2nILSlS+MAG2z4JdO6p+PJrJ+ACvimkmLJL281h157e52psQ==}
 
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
@@ -3212,177 +3209,177 @@ packages:
     resolution: {integrity: sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  '@visx/annotation@3.12.0':
-    resolution: {integrity: sha512-ZH6Y4jfrb47iEUV9O2itU9TATE5IPzhs5qvP6J7vmv26qkqwDcuE7xN3S3l9R70WjyEKGbpO8js4EijA3FJWkA==}
+  '@visx/annotation@4.0.1-alpha.0':
+    resolution: {integrity: sha512-XhRjY/4kl/k+kM07uOHLyd4WDlUWbLHnIP1Y2Dip8xhmDn3X1k7eV47sNBGWiJqAMrDrVJOU12QpwPkc/rJgWg==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/axis@3.12.0':
-    resolution: {integrity: sha512-8MoWpfuaJkhm2Yg+HwyytK8nk+zDugCqTT/tRmQX7gW4LYrHYLXFUXOzbDyyBakCVaUbUaAhVFxpMASJiQKf7A==}
+  '@visx/axis@4.0.1-alpha.0':
+    resolution: {integrity: sha512-XzRsZ5vt6QAFsYeFSQAQtmrSafjLUVNfdygOT8auPbborsgXKSVryCMyf6afWITMrmpOg2FlkaNx2H/VvW9PKg==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/bounds@3.12.0':
-    resolution: {integrity: sha512-peAlNCUbYaaZ0IO6c1lDdEAnZv2iGPDiLIM8a6gu7CaMhtXZJkqrTh+AjidNcIqITktrICpGxJE/Qo9D099dvQ==}
+  '@visx/bounds@4.0.1-alpha.0':
+    resolution: {integrity: sha512-YcFN3lAZfqocPaOVUmeGebinqfBUo+YPcBHzsQt1jaEvkcVBUhDRS6mai4tm6jUGvwW9nEAzqTQ1L343lqitYw==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
-      react-dom: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+      react-dom: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/brush@3.12.0':
-    resolution: {integrity: sha512-ceqQe/IlIi9X9FT/DuiO6b3l5YAGnux/aQMX8M1gvLdz4T8pXIW8nDv1OhqbZ7lmbQEUEEM9IexOkR9ix7pL+Q==}
+  '@visx/brush@4.0.1-alpha.0':
+    resolution: {integrity: sha512-+Ib2OHP64Cu0WxAvL5fkSQ9C6SnksJ2vqXMUiRg9MoP5CUAZW9/xOi/OBffxFrYgN5L402GMwz/uJi+OkPBXZg==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/clip-path@3.12.0':
-    resolution: {integrity: sha512-pjpjyoQ15lhOrgpDhxfWKAxC4IswzREHGOHhrdWtxQbPoGzVZvFH8HHvwRi4afL11uYDO10z235MDnaDwP8GnQ==}
+  '@visx/clip-path@4.0.1-alpha.0':
+    resolution: {integrity: sha512-A3LTXKfmqMmaq0S0SBWoq8A7YFhIqGr4PXGC1pMijm0e0QBtDZQCh2Bq0dbwcNDlM1og+iv2SsHJ80Py7nRAzA==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/curve@3.12.0':
-    resolution: {integrity: sha512-Ng1mefXIzoIoAivw7dJ+ZZYYUbfuwXgZCgQynShr6ZIVw7P4q4HeQfJP3W24ON+1uCSrzoycHSXRelhR9SBPcw==}
+  '@visx/curve@4.0.1-alpha.0':
+    resolution: {integrity: sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==}
 
-  '@visx/delaunay@3.12.0':
-    resolution: {integrity: sha512-bc8UCJ3l5G6lGnQt5AUo8GIZTm16vKpJycb/6IWHTDeBv4hJL0uahG5QKhy1d08T0cFtYQ3qv/xp5LQkwFxfsw==}
+  '@visx/delaunay@4.0.1-alpha.0':
+    resolution: {integrity: sha512-wAD5WQWrr0B4OO1tXc7Y04Bv1n8R4yV+vOAzHsSUBRdKv9ZihntHi2aHmeh6bw+XuSsT1a97I+n0qS9Fuji+hQ==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/drag@3.12.0':
-    resolution: {integrity: sha512-LXOoPVw//YPjpYhDJYBsCYDuv1QimsXjDV98duH0aCy4V94ediXMQpe2wHq4pnlDobLEB71FjOZMFrbFmqtERg==}
+  '@visx/drag@4.0.1-alpha.0':
+    resolution: {integrity: sha512-nEs1YfMlnB8O1Yt/u406HzclkqAy3K3HF6gmjI2hIp7S5Jw8UVNQE5c30EIWKpLLgN5oOBjSz9XeFJRdb0cNZA==}
     peerDependencies:
-      react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/event@3.12.0':
-    resolution: {integrity: sha512-9Lvw6qJ0Fi+y1vsC1WspfdIKCxHTb7oy59Uql1uBdPGT8zChP0vuxW0jQNQRDbKgoefj4pCXAFi8+MF1mEtVTw==}
+  '@visx/event@4.0.1-alpha.0':
+    resolution: {integrity: sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==}
 
-  '@visx/geo@3.12.0':
-    resolution: {integrity: sha512-/74NMEqGrAGXOKIdvuLsarUNs5liTjUs3XrgLb4UbSDMoo2itgQN6tCZuIxFKMdEBahfJl+s6pEVPLur5bH4vg==}
+  '@visx/geo@4.0.1-alpha.0':
+    resolution: {integrity: sha512-ZzeXrMgT1JjUZl1GaW3KecN2PkCCTDfYDeTD8+kvugC6umLKTsJ4+ii1GpjrgnPTtOBzZnJHCAknJ3mzaz/DRg==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/glyph@3.12.0':
-    resolution: {integrity: sha512-E9ST9MoPNyXQzjZxYYAGXT4CbBpnB90Qhx8UvUUM2/n/SZUNeH+m6UiB/CzT0jGK2b0lPHF91mlOiQ8JXBRhYg==}
+  '@visx/glyph@4.0.1-alpha.0':
+    resolution: {integrity: sha512-SKI8Cwk8mh4tP3T3/dZLta1oK5n+NA+TTHnA07M87iVSnpVJQeDqz5bHfK1IG9QMZnLCburnZoM6UEnNojHy8g==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/gradient@3.12.0':
-    resolution: {integrity: sha512-QRatjjdUEPbcp4pqRca1JlChpAnmmIAO3r3ZscLK7D1xEIANlIjzjl3uNgrmseYmBAYyPCcJH8Zru07R97ovOg==}
+  '@visx/gradient@4.0.1-alpha.0':
+    resolution: {integrity: sha512-HxkxLdThV/gPaulw+t7/ESo7AtqIBq9IlHIkHi7lQqXe0Yl+x8rpM3KYlYqEZjtihD9CeEaVJjBbdY7fQb54IA==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/grid@3.12.0':
-    resolution: {integrity: sha512-L4ex2ooSYhwNIxJ3XFIKRhoSvEGjPc2Y3YCrtNB4TV5Ofdj4q0UMOsxfrH23Pr8HSHuQhb6VGMgYoK0LuWqDmQ==}
+  '@visx/grid@4.0.1-alpha.0':
+    resolution: {integrity: sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/group@3.12.0':
-    resolution: {integrity: sha512-Dye8iS1alVXPv7nj/7M37gJe6sSKqJLH7x6sEWAsRQ9clI0kFvjbKcKgF+U3aAVQr0NCohheFV+DtR8trfK/Ag==}
+  '@visx/group@4.0.1-alpha.0':
+    resolution: {integrity: sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/heatmap@3.12.0':
-    resolution: {integrity: sha512-+YhXHfMvwQOMf9xMd15FUOoiKqf84o1UF0zsmnNsCC75MqFMpjvzc3DeoC37fi69iBIKchU8DjhVubvCE9N4jA==}
+  '@visx/heatmap@4.0.1-alpha.0':
+    resolution: {integrity: sha512-fxghd5MCLSDeLxlT8f0x6ulEcBPgJZg9VyLQvCwVNHwopm3DUkk6evPJOMlcpXJiESDXsHkhSNit42O2fIZBRA==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/hierarchy@3.12.0':
-    resolution: {integrity: sha512-+X1HOeLEOODxjAD7ixrWJ4KCVei4wFe8ra3dYU0uZ14RdPPgUeiuyBfdeXWZuAHM6Ix9qrryneatQjkC3h4mvA==}
+  '@visx/hierarchy@4.0.1-alpha.0':
+    resolution: {integrity: sha512-QuJx1cUezLw1KxH59R3ffPbGgKmQ/+0AsDAw8iAC4FTLxbPF8ruw4O51KPjC7X9kET85T1T2odzVsz+HIWBckg==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/legend@3.12.0':
-    resolution: {integrity: sha512-Tr6hdauEDXRXVNeNgIQ9JtCCrxn8Fbr8UCVlO9XsSxenk2hBC/2PIY5QPzpnKFEEEuH/C8vhj8T0JfFZV+D9zQ==}
+  '@visx/legend@4.0.1-alpha.0':
+    resolution: {integrity: sha512-8XbFQomA88NRrfZJqvB6fNoNXKnFsrvOk6Hvk57gNhpEn9QnNNDfD5IHKWLeQwl+b20pLYuD39ffKZ9tTbjEqw==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/marker@3.12.0':
-    resolution: {integrity: sha512-11aCWC13+PqbAatNgMVcm33J8PRNdyGiDbfMfwUXt5/FS2XLs2e1fjfhIwAxmCCLZ13FYlabrc1qnjnhwXbTVQ==}
+  '@visx/marker@4.0.1-alpha.0':
+    resolution: {integrity: sha512-OF2SIOWd8N907HzNIyEPxiAMEGAGs0SHHOoHnC+9rqKm8yKYDEE6tY4ZQ5/0q+pbvpTyqqQOrmELIFVWL3aTLA==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/mock-data@3.12.0':
-    resolution: {integrity: sha512-HI8LKdO3sU2tIBv16ZYRTc2JYsu0Ai/hQc7YUOBqbjhXUW993iCBe98pAgEdHDrSWqK2yvXY4En5ceBTAP34Jw==}
+  '@visx/mock-data@4.0.1-alpha.0':
+    resolution: {integrity: sha512-Xi1bv52WRKE/3oX/M3PkBlHIRJaooIPxXHdFj0pMFNiCCL7J3aZ18rD7kSTAYHXv6jV4P0MZMQPN5a7bFyA3xg==}
 
-  '@visx/network@3.12.0':
-    resolution: {integrity: sha512-mVWF9TQVpe6Qz95IJ+Pm+FB6xhdjzFGRKK7/qQFhjRloIJqVZkChAiBIua04Ux8BeyCt37wdFgQKFl6C2u3DXA==}
+  '@visx/network@4.0.1-alpha.0':
+    resolution: {integrity: sha512-WIkuOmT1qTFXIWBEWwI1PurAFeng0XeHY8hZgZx23AM/U9mu5JncO/kt5EUkC0Z3QWj9IZcluJnaY3b/DtuwJg==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/pattern@3.12.0':
-    resolution: {integrity: sha512-ZkNA/2TkULNiiY4cw2IkuQcQRp9zI3SQ0/JoZMQ+UmUvY5RNBcsdTmic7649egHq0FRYCbY0DDQVJicccW5JUg==}
+  '@visx/pattern@4.0.1-alpha.0':
+    resolution: {integrity: sha512-KCqHpjtHdu95uqamc5PIYG55Xp0w+7/Zz63k4eeZErwK1o0PN2rZiBiuodNtENL8NqIU2b5AP+XI/xXaUH0M4Q==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/point@3.12.0':
-    resolution: {integrity: sha512-I6UrHoJAEVbx3RORQNupgTiX5EzjuZpiwLPxn8L2mI5nfERotPKi1Yus12Cq2WtXqEBR/WgqTnoImlqOXBykcA==}
+  '@visx/point@4.0.1-alpha.0':
+    resolution: {integrity: sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==}
 
-  '@visx/react-spring@3.12.0':
-    resolution: {integrity: sha512-ehtmjFrUQx3g0mZ684M4LgI9UfQ84ZWD/m9tKfvXhEm1Vl8D4AjaZ4af1tTOg9S7vk2VlpxvVOVN7+t5pu0nSA==}
+  '@visx/react-spring@4.0.1-alpha.0':
+    resolution: {integrity: sha512-loO3V6BZuxX1USelydLiFTLt7zVAjmX6B1bBKAclL9XE9xnYfb4fmZVW5jSN6T7eOdcePVcs6lLfwcnjZVq+Sg==}
     peerDependencies:
-      '@react-spring/web': ^9.4.5
-      react: ^16.3.0-0 || ^17.0.0 || ^18.0.0
+      '@react-spring/web': ^9.7.5 || ^10.0.0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/responsive@3.12.0':
-    resolution: {integrity: sha512-GV1BTYwAGlk/K5c9vH8lS2syPnTuIqEacI7L6LRPbsuaLscXMNi+i9fZyzo0BWvAdtRV8v6Urzglo++lvAXT1Q==}
+  '@visx/responsive@4.0.1-alpha.0':
+    resolution: {integrity: sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/sankey@3.12.0':
-    resolution: {integrity: sha512-B3zIUejzv8ySGmcgJhqiy616llauT0CwvL7wWyTh2z3eCBkFOlPVF85NBrQq823w/0DkwoX8+LmLpKyelh6Vpw==}
+  '@visx/sankey@4.0.1-alpha.0':
+    resolution: {integrity: sha512-bzF3MHdJ9A/KdWiGK7vy64A9MK8HhNldAxeUTiQd5wELdvx8YMHOkU8AxtKACWHveaoakthnesgQjbrEGt4oeg==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/scale@3.12.0':
-    resolution: {integrity: sha512-+ubijrZ2AwWCsNey0HGLJ0YKNeC/XImEFsr9rM+Uef1CM3PNM43NDdNTrdBejSlzRq0lcfQPWYMYQFSlkLcPOg==}
+  '@visx/scale@4.0.1-alpha.0':
+    resolution: {integrity: sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==}
 
-  '@visx/shape@3.12.0':
-    resolution: {integrity: sha512-/1l0lrpX9tPic6SJEalryBKWjP/ilDRnQA+BGJTI1tj7i23mJ/J0t4nJHyA1GrL4QA/bM/qTJ35eyz5dEhJc4g==}
+  '@visx/shape@4.0.1-alpha.0':
+    resolution: {integrity: sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/text@3.12.0':
-    resolution: {integrity: sha512-0rbDYQlbuKPhBqXkkGYKFec1gQo05YxV45DORzr6hCyaizdJk1G+n9VkuKSHKBy1vVQhBA0W3u/WXd7tiODQPA==}
+  '@visx/text@4.0.1-alpha.0':
+    resolution: {integrity: sha512-wVLXR6DtaeU6TetPGsM3p6I/gCr48RFv1CZQ9+q21Q5G6CUDoObOpsIp+OR0yTlqkP3OSJYTmhsVdiU3LKkBxA==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/threshold@3.12.0':
-    resolution: {integrity: sha512-HpbJbFBKaFOM7FiMiOQwZhQAoDtd5+xSUZRlZ3U7N7TF3S2oVKIBRNlMakhcu0eick7UNvmCl7ZTW2lI65IX4g==}
+  '@visx/threshold@4.0.1-alpha.0':
+    resolution: {integrity: sha512-5CvS/BJuhmSlay+HrhR8wW3cWBaSjFhVoMkxvy0iKqWRKFtI8bkPrJAdBvPB1/k+4f5FiYwGupo07nbcQoXceA==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/tooltip@3.12.0':
-    resolution: {integrity: sha512-pWhsYhgl0Shbeqf80qy4QCB6zpq6tQtMQQxKlh3UiKxzkkfl+Metaf9p0/S0HexNi4vewOPOo89xWx93hBeh3A==}
+  '@visx/tooltip@4.0.1-alpha.0':
+    resolution: {integrity: sha512-N7SAGDHyxFonpsRMTTSbN6O5bh2CAjrX0TpAtpAuLVP6Q2pN3Y0jSGGhs6rZsyPYP6AnveeoV9jjXZAayTjsbA==}
     peerDependencies:
-      react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
-      react-dom: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+      react-dom: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/vendor@3.12.0':
-    resolution: {integrity: sha512-SVO+G0xtnL9dsNpGDcjCgoiCnlB3iLSM9KLz1sLbSrV7RaVXwY3/BTm2X9OWN1jH2a9M+eHt6DJ6sE6CXm4cUg==}
+  '@visx/vendor@4.0.0-alpha.0':
+    resolution: {integrity: sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==}
 
-  '@visx/visx@3.12.0':
-    resolution: {integrity: sha512-Lx8XKFUz8eyaR07jdUWcMcPYRp+sfrd3OsGw8uFIuZeAJ0hF6Ni7f7TVvyW1W5chlvCrL4/MGQTCjN/A8o3UZQ==}
+  '@visx/visx@4.0.1-alpha.0':
+    resolution: {integrity: sha512-7TKuCENtGUKBVdi6pl4hRmE6zms1fpIDzmgbHzRDrLk7dgtoJdQkiZKyuEp2/EPlonkNdqnyDI6G3RzrjRfBmg==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/voronoi@3.12.0':
-    resolution: {integrity: sha512-U3HWu6g5UjQchFDq8k/A4U9WrlN+80rAFPdGOUvIGOueQw9RmlZlNaeg8IJcQr2yk1s4O/VSpt3nR82zdINWMw==}
+  '@visx/voronoi@4.0.1-alpha.0':
+    resolution: {integrity: sha512-47bKapP/orjCHTSmcc35ujF3pmco5FXFT+VdCsDHdYUdOX/woy2LSJdKsi4qS+6EZCq4tieKsJBaDBGQARglWw==}
     peerDependencies:
-      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/wordcloud@3.12.0':
-    resolution: {integrity: sha512-TAo9w1Z65ddRM1OPmrELXNvDSOYf4MRO0+VAIX5FNFAc8v4FNmTJriSWc+A/FIZL+1svDOKnDP9SwF86NX4Alg==}
+  '@visx/wordcloud@4.0.1-alpha.0':
+    resolution: {integrity: sha512-SVjtILEw/e6a9RRlbcL/DZAyUElQqLUTgEibCufE7EQmW7mGx4VmgSAmp2VFQErDP++Uml0qd0PWWP9A8zrh8g==}
     peerDependencies:
-      react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/xychart@3.12.0':
-    resolution: {integrity: sha512-itJ7qvj/STpVmHesVyo2vPOataBM1mgSaf9R6/s4Bpe340wZldfCJ+IqRcNgdtbBagz1Hlr/sRnla4tWE2yw9A==}
+  '@visx/xychart@4.0.1-alpha.0':
+    resolution: {integrity: sha512-t8y3JpymFoV8+3G56NX61vtKLv3WPmBnE9daG5kZdz5MK8IaA5bnYT6z/LMMbljKK8hbQlBVAj2weRptLkquJA==}
     peerDependencies:
-      '@react-spring/web': ^9.4.5
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@react-spring/web': ^9.7.5 || ^10.0.0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
-  '@visx/zoom@3.12.0':
-    resolution: {integrity: sha512-JmxkOROPkjnMEdFGnnSKLo5BkFHgOkLe/N5KkWR02cA5bE+bmEkfAh7DJfrtVsPkqSPvwGH1TrMWWthJwoivPA==}
+  '@visx/zoom@4.0.1-alpha.0':
+    resolution: {integrity: sha512-f+Y3rI3Lhpn4wbkSQw3IPsqtcRbh/TcF4M4N5ETrciMXtkJVQNrYzzC6mgxN1fZcw2228oKZzNaMI7hpOLoPkw==}
     peerDependencies:
-      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
   '@vitejs/plugin-react@5.1.4':
     resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
@@ -4337,9 +4334,6 @@ packages:
 
   d3-shape@1.3.7:
     resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
-
-  d3-shape@2.1.0:
-    resolution: {integrity: sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==}
 
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
@@ -6695,10 +6689,6 @@ packages:
       react-dom:
         optional: true
 
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -7903,13 +7893,12 @@ snapshots:
     dependencies:
       '@ant-design/fast-color': 3.0.1
 
-  '@ant-design/cssinjs-utils@2.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@ant-design/cssinjs-utils@2.0.2(react@19.2.4)':
     dependencies:
-      '@ant-design/cssinjs': 2.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@ant-design/cssinjs': 2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@babel/runtime': 7.28.6
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   '@ant-design/cssinjs-utils@2.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -7919,28 +7908,15 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@ant-design/cssinjs@2.0.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@ant-design/cssinjs@2.0.3(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       csstype: 3.2.3
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-      stylis: 4.3.6
-
-  '@ant-design/cssinjs@2.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@emotion/hash': 0.8.0
-      '@emotion/unitless': 0.7.5
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      csstype: 3.2.3
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
       stylis: 4.3.6
 
   '@ant-design/cssinjs@2.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
@@ -7959,15 +7935,6 @@ snapshots:
 
   '@ant-design/icons-svg@4.4.2': {}
 
-  '@ant-design/icons@6.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ant-design/colors': 8.0.1
-      '@ant-design/icons-svg': 4.4.2
-      '@rc-component/util': 1.8.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@ant-design/icons@6.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@ant-design/colors': 8.0.1
@@ -7976,15 +7943,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@ant-design/react-slick@2.0.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      clsx: 2.1.1
-      json2mq: 0.2.0
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-      throttle-debounce: 5.0.2
 
   '@ant-design/react-slick@2.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10840,14 +10798,13 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
 
-  '@rc-component/cascader@1.11.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/cascader@1.11.0(react@19.2.4)':
     dependencies:
-      '@rc-component/select': 1.5.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tree': 1.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/select': 1.5.2(react@19.2.4)
+      '@rc-component/tree': 1.1.0(react@19.2.4)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/cascader@1.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10858,12 +10815,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/checkbox@1.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/checkbox@1.0.1(react@19.2.4)':
     dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/checkbox@2.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10871,15 +10827,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/collapse@1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/collapse@1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10890,13 +10837,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/color-picker@3.0.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/color-picker@3.0.3(react@19.2.4)':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/color-picker@3.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10906,26 +10852,19 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/context@2.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/context@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/dialog@1.8.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/dialog@1.8.3(react@19.2.4)':
     dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/dialog@1.8.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10936,14 +10875,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/drawer@1.4.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/drawer@1.4.1(react@19.2.4)':
     dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/drawer@1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10954,14 +10892,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/dropdown@1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/dropdown@1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10970,14 +10900,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/form@1.6.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/async-validator': 5.1.0
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/form@1.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/async-validator': 5.1.0
@@ -10985,15 +10907,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/image@1.6.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/image@1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11004,14 +10917,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/input-number@1.6.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/mini-decimal': 1.1.0
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/input-number@1.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/mini-decimal': 1.1.0
@@ -11020,30 +10925,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/input@1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/input@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/mentions@1.6.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/input': 1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/menu': 1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/textarea': 1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/mentions@1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11055,16 +10942,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/menu@1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/overflow': 1.0.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/menu@1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11080,19 +10957,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
 
-  '@rc-component/motion@1.1.6(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/motion@1.1.6(react@19.2.4)':
     dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
-  '@rc-component/motion@1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/motion@1.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11101,25 +10970,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/mutate-observer@2.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/mutate-observer@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/notification@1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/notification@1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11128,15 +10983,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/overflow@1.0.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/overflow@1.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11147,33 +10993,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/pagination@1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/pagination@1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/picker@1.9.0(dayjs@1.11.19)(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/overflow': 1.0.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-    optionalDependencies:
-      dayjs: 1.11.19
-      luxon: 3.7.2
-      moment: 2.30.1
 
   '@rc-component/picker@1.9.0(dayjs@1.11.19)(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11189,26 +11014,12 @@ snapshots:
       luxon: 3.7.2
       moment: 2.30.1
 
-  '@rc-component/portal@2.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/portal@2.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/progress@1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/progress@1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11217,24 +11028,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/qrcode@1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/qrcode@1.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/rate@1.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/rate@1.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11243,26 +11041,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/resize-observer@1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/resize-observer@1.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/segmented@1.3.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/segmented@1.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11273,15 +11056,14 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/select@1.5.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/select@1.5.2(react@19.2.4)':
     dependencies:
-      '@rc-component/overflow': 1.0.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/virtual-list': 1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/overflow': 1.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/virtual-list': 1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/select@1.6.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11293,26 +11075,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/slider@1.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/slider@1.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/steps@1.2.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/steps@1.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11321,29 +11089,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/switch@1.0.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/switch@1.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/table@1.9.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/context': 2.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/virtual-list': 1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/table@1.9.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11354,17 +11105,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/tabs@1.7.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/dropdown': 1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/menu': 1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/tabs@1.7.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11377,15 +11117,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/textarea@1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/input': 1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/textarea@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/input': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -11395,14 +11126,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/tooltip@1.4.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/tooltip@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -11410,15 +11133,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/tour@2.3.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/tour@2.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11429,14 +11143,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/tree-select@1.6.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/tree-select@1.6.0(react@19.2.4)':
     dependencies:
-      '@rc-component/select': 1.5.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tree': 1.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/select': 1.5.2(react@19.2.4)
+      '@rc-component/tree': 1.1.0(react@19.2.4)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/tree-select@1.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11447,14 +11160,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/tree@1.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@rc-component/tree@1.1.0(react@19.2.4)':
     dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/virtual-list': 1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/virtual-list': 1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
 
   '@rc-component/tree@1.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11464,16 +11176,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/trigger@3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/motion': 1.3.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/portal': 2.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/trigger@3.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11485,26 +11187,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@rc-component/upload@1.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
   '@rc-component/upload@1.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@rc-component/util': 1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@rc-component/util@1.8.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      is-mobile: 5.0.0
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-      react-is: 18.3.1
 
   '@rc-component/util@1.8.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11513,28 +11201,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-is: 18.3.1
 
-  '@rc-component/util@1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      is-mobile: 5.0.0
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-      react-is: 18.3.1
-
   '@rc-component/util@1.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       is-mobile: 5.0.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-is: 18.3.1
-
-  '@rc-component/virtual-list@1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
 
   '@rc-component/virtual-list@1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11908,10 +11580,6 @@ snapshots:
 
   '@types/d3-chord@3.0.6': {}
 
-  '@types/d3-cloud@1.2.5':
-    dependencies:
-      '@types/d3': 3.5.53
-
   '@types/d3-color@1.4.5': {}
 
   '@types/d3-color@3.1.0': {}
@@ -11991,7 +11659,7 @@ snapshots:
 
   '@types/d3-scale@4.0.2':
     dependencies:
-      '@types/d3-time': 3.0.0
+      '@types/d3-time': 3.0.4
 
   '@types/d3-scale@4.0.9':
     dependencies:
@@ -12002,6 +11670,10 @@ snapshots:
   '@types/d3-shape@1.3.12':
     dependencies:
       '@types/d3-path': 1.0.11
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
 
   '@types/d3-shape@3.1.8':
     dependencies:
@@ -12029,8 +11701,6 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
-
-  '@types/d3@3.5.53': {}
 
   '@types/d3@7.4.3':
     dependencies:
@@ -12361,328 +12031,236 @@ snapshots:
     dependencies:
       '@vaadin/vaadin-development-mode-detector': 2.0.7
 
-  '@visx/annotation@3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@visx/annotation@4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/drag': 3.12.0(react@19.2.4)
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/text': 3.12.0(react@19.2.4)
+      '@visx/drag': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/text': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
       react-use-measure: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react-dom
 
-  '@visx/axis@3.12.0(react@18.3.1)':
+  '@visx/axis@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@18.3.1)
-      '@visx/point': 3.12.0
-      '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@18.3.1)
-      '@visx/text': 3.12.0(react@18.3.1)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/point': 4.0.1-alpha.0
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/text': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
-      react: 18.3.1
-
-  '@visx/axis@3.12.0(react@19.2.4)':
-    dependencies:
-      '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/point': 3.12.0
-      '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@19.2.4)
-      '@visx/text': 3.12.0(react@19.2.4)
-      classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/bounds@3.12.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@visx/bounds@4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-
-  '@visx/bounds@3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      prop-types: 15.8.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@visx/brush@3.12.0(react@19.2.4)':
+  '@visx/brush@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
-      '@visx/drag': 3.12.0(react@19.2.4)
-      '@visx/event': 3.12.0
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@19.2.4)
+      '@visx/drag': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/event': 4.0.1-alpha.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/clip-path@3.12.0(react@19.2.4)':
+  '@visx/clip-path@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/curve@3.12.0':
+  '@visx/curve@4.0.1-alpha.0':
     dependencies:
-      '@types/d3-shape': 1.3.12
-      d3-shape: 1.3.7
+      '@visx/vendor': 4.0.0-alpha.0
 
-  '@visx/delaunay@3.12.0(react@19.2.4)':
+  '@visx/delaunay@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/vendor': 3.12.0
+      '@visx/vendor': 4.0.0-alpha.0
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/drag@3.12.0(react@19.2.4)':
+  '@visx/drag@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/event': 3.12.0
-      '@visx/point': 3.12.0
-      prop-types: 15.8.1
+      '@visx/event': 4.0.1-alpha.0
+      '@visx/point': 4.0.1-alpha.0
       react: 19.2.4
 
-  '@visx/event@3.12.0':
+  '@visx/event@4.0.1-alpha.0':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/point': 3.12.0
+      '@visx/point': 4.0.1-alpha.0
 
-  '@visx/geo@3.12.0(react@19.2.4)':
+  '@visx/geo@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/geojson': 7946.0.16
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/vendor': 3.12.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/vendor': 4.0.0-alpha.0
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/glyph@3.12.0(react@19.2.4)':
-    dependencies:
-      '@types/d3-shape': 1.3.12
-      '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
-      classnames: 2.5.1
-      d3-shape: 1.3.7
-      prop-types: 15.8.1
-      react: 19.2.4
-
-  '@visx/gradient@3.12.0(react@19.2.4)':
+  '@visx/glyph@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      prop-types: 15.8.1
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/vendor': 4.0.0-alpha.0
+      classnames: 2.5.1
       react: 19.2.4
 
-  '@visx/grid@3.12.0(react@19.2.4)':
+  '@visx/gradient@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/curve': 3.12.0
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/point': 3.12.0
-      '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@19.2.4)
-      classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/group@3.12.0(react@18.3.1)':
+  '@visx/grid@4.0.1-alpha.0(react@19.2.4)':
+    dependencies:
+      '@types/react': 19.2.14
+      '@visx/curve': 4.0.1-alpha.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/point': 4.0.1-alpha.0
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
+      classnames: 2.5.1
+      react: 19.2.4
+
+  '@visx/group@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
       classnames: 2.5.1
-      prop-types: 15.8.1
-      react: 18.3.1
-
-  '@visx/group@3.12.0(react@19.2.4)':
-    dependencies:
-      '@types/react': 19.2.14
-      classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/heatmap@3.12.0(react@19.2.4)':
+  '@visx/heatmap@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/hierarchy@3.12.0(react@19.2.4)':
+  '@visx/hierarchy@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/d3-hierarchy': 1.1.11
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
       d3-hierarchy: 1.1.9
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/legend@3.12.0(react@19.2.4)':
+  '@visx/legend@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/scale': 3.12.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/scale': 4.0.1-alpha.0
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/marker@3.12.0(react@19.2.4)':
+  '@visx/marker@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/shape': 3.12.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/mock-data@3.12.0':
+  '@visx/mock-data@4.0.1-alpha.0':
     dependencies:
       '@types/d3-random': 2.2.3
       d3-random: 2.2.2
 
-  '@visx/network@3.12.0(react@19.2.4)':
+  '@visx/network@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/pattern@3.12.0(react@19.2.4)':
+  '@visx/pattern@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/point@3.12.0': {}
+  '@visx/point@4.0.1-alpha.0': {}
 
-  '@visx/react-spring@3.12.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@visx/react-spring@4.0.1-alpha.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@react-spring/web': 9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react': 19.2.14
-      '@visx/axis': 3.12.0(react@19.2.4)
-      '@visx/grid': 3.12.0(react@19.2.4)
-      '@visx/scale': 3.12.0
-      '@visx/text': 3.12.0(react@19.2.4)
+      '@visx/axis': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/grid': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/text': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/responsive@3.12.0(react@19.2.4)':
+  '@visx/responsive@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/lodash': 4.17.23
       '@types/react': 19.2.14
       lodash: 4.17.23
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/sankey@3.12.0(react@19.2.4)':
+  '@visx/sankey@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/d3-sankey': 0.12.5
       '@types/react': 19.2.14
-      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/vendor': 4.0.0-alpha.0
       classnames: 2.5.1
       d3-sankey: 0.12.3
-      d3-shape: 1.3.7
       react: 19.2.4
 
-  '@visx/scale@3.12.0':
+  '@visx/scale@4.0.1-alpha.0':
     dependencies:
-      '@visx/vendor': 3.12.0
+      '@visx/vendor': 4.0.0-alpha.0
 
-  '@visx/shape@3.12.0(react@18.3.1)':
+  '@visx/shape@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
-      '@types/d3-path': 1.0.11
-      '@types/d3-shape': 1.3.12
       '@types/lodash': 4.17.23
       '@types/react': 19.2.14
-      '@visx/curve': 3.12.0
-      '@visx/group': 3.12.0(react@18.3.1)
-      '@visx/scale': 3.12.0
+      '@visx/curve': 4.0.1-alpha.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/vendor': 4.0.0-alpha.0
       classnames: 2.5.1
-      d3-path: 1.0.9
-      d3-shape: 1.3.7
       lodash: 4.17.23
-      prop-types: 15.8.1
-      react: 18.3.1
-
-  '@visx/shape@3.12.0(react@19.2.4)':
-    dependencies:
-      '@types/d3-path': 1.0.11
-      '@types/d3-shape': 1.3.12
-      '@types/lodash': 4.17.23
-      '@types/react': 19.2.14
-      '@visx/curve': 3.12.0
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/scale': 3.12.0
-      classnames: 2.5.1
-      d3-path: 1.0.9
-      d3-shape: 1.3.7
-      lodash: 4.17.23
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/text@3.12.0(react@18.3.1)':
+  '@visx/text@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/lodash': 4.17.23
       '@types/react': 19.2.14
       classnames: 2.5.1
       lodash: 4.17.23
-      prop-types: 15.8.1
-      react: 18.3.1
-      reduce-css-calc: 1.3.0
-
-  '@visx/text@3.12.0(react@19.2.4)':
-    dependencies:
-      '@types/lodash': 4.17.23
-      '@types/react': 19.2.14
-      classnames: 2.5.1
-      lodash: 4.17.23
-      prop-types: 15.8.1
       react: 19.2.4
       reduce-css-calc: 1.3.0
 
-  '@visx/threshold@3.12.0(react@19.2.4)':
+  '@visx/threshold@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/clip-path': 3.12.0(react@19.2.4)
-      '@visx/shape': 3.12.0(react@19.2.4)
+      '@visx/clip-path': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/tooltip@3.12.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@visx/tooltip@4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
-      '@visx/bounds': 3.12.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@visx/bounds': 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       classnames: 2.5.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-      react-use-measure: 2.1.7(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-
-  '@visx/tooltip@3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@types/react': 19.2.14
-      '@visx/bounds': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      classnames: 2.5.1
-      prop-types: 15.8.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-use-measure: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@visx/vendor@3.12.0':
+  '@visx/vendor@4.0.0-alpha.0':
     dependencies:
       '@types/d3-array': 3.0.3
       '@types/d3-color': 3.1.0
@@ -12690,7 +12268,9 @@ snapshots:
       '@types/d3-format': 3.0.1
       '@types/d3-geo': 3.1.0
       '@types/d3-interpolate': 3.0.1
+      '@types/d3-path': 3.1.1
       '@types/d3-scale': 4.0.2
+      '@types/d3-shape': 3.1.7
       '@types/d3-time': 3.0.0
       '@types/d3-time-format': 2.1.0
       d3-array: 3.2.1
@@ -12699,101 +12279,98 @@ snapshots:
       d3-format: 3.1.0
       d3-geo: 3.1.0
       d3-interpolate: 3.0.1
+      d3-path: 3.1.0
       d3-scale: 4.0.2
+      d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@visx/visx@3.12.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@visx/visx@4.0.1-alpha.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@visx/annotation': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@visx/axis': 3.12.0(react@19.2.4)
-      '@visx/bounds': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@visx/brush': 3.12.0(react@19.2.4)
-      '@visx/clip-path': 3.12.0(react@19.2.4)
-      '@visx/curve': 3.12.0
-      '@visx/delaunay': 3.12.0(react@19.2.4)
-      '@visx/drag': 3.12.0(react@19.2.4)
-      '@visx/event': 3.12.0
-      '@visx/geo': 3.12.0(react@19.2.4)
-      '@visx/glyph': 3.12.0(react@19.2.4)
-      '@visx/gradient': 3.12.0(react@19.2.4)
-      '@visx/grid': 3.12.0(react@19.2.4)
-      '@visx/group': 3.12.0(react@19.2.4)
-      '@visx/heatmap': 3.12.0(react@19.2.4)
-      '@visx/hierarchy': 3.12.0(react@19.2.4)
-      '@visx/legend': 3.12.0(react@19.2.4)
-      '@visx/marker': 3.12.0(react@19.2.4)
-      '@visx/mock-data': 3.12.0
-      '@visx/network': 3.12.0(react@19.2.4)
-      '@visx/pattern': 3.12.0(react@19.2.4)
-      '@visx/point': 3.12.0
-      '@visx/responsive': 3.12.0(react@19.2.4)
-      '@visx/sankey': 3.12.0(react@19.2.4)
-      '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@19.2.4)
-      '@visx/text': 3.12.0(react@19.2.4)
-      '@visx/threshold': 3.12.0(react@19.2.4)
-      '@visx/tooltip': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@visx/voronoi': 3.12.0(react@19.2.4)
-      '@visx/wordcloud': 3.12.0(react@19.2.4)
-      '@visx/xychart': 3.12.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@visx/zoom': 3.12.0(react@19.2.4)
+      '@visx/annotation': 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/axis': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/bounds': 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/brush': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/clip-path': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/curve': 4.0.1-alpha.0
+      '@visx/delaunay': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/drag': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/event': 4.0.1-alpha.0
+      '@visx/geo': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/glyph': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/gradient': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/grid': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/heatmap': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/hierarchy': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/legend': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/marker': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/mock-data': 4.0.1-alpha.0
+      '@visx/network': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/pattern': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/point': 4.0.1-alpha.0
+      '@visx/responsive': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/sankey': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/text': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/threshold': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/tooltip': 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/voronoi': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/wordcloud': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/xychart': 4.0.1-alpha.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/zoom': 4.0.1-alpha.0(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - '@react-spring/web'
       - react-dom
 
-  '@visx/voronoi@3.12.0(react@19.2.4)':
+  '@visx/voronoi@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/d3-voronoi': 1.1.12
       '@types/react': 19.2.14
       classnames: 2.5.1
       d3-voronoi: 1.1.4
-      prop-types: 15.8.1
       react: 19.2.4
 
-  '@visx/wordcloud@3.12.0(react@19.2.4)':
+  '@visx/wordcloud@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
-      '@types/d3-cloud': 1.2.5
-      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.4)
       d3-cloud: 1.2.8
       react: 19.2.4
 
-  '@visx/xychart@3.12.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@visx/xychart@4.0.1-alpha.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@react-spring/web': 9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/lodash': 4.17.23
       '@types/react': 19.2.14
-      '@visx/annotation': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@visx/axis': 3.12.0(react@19.2.4)
-      '@visx/event': 3.12.0
-      '@visx/glyph': 3.12.0(react@19.2.4)
-      '@visx/grid': 3.12.0(react@19.2.4)
-      '@visx/react-spring': 3.12.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@visx/responsive': 3.12.0(react@19.2.4)
-      '@visx/scale': 3.12.0
-      '@visx/shape': 3.12.0(react@19.2.4)
-      '@visx/text': 3.12.0(react@19.2.4)
-      '@visx/tooltip': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@visx/vendor': 3.12.0
-      '@visx/voronoi': 3.12.0(react@19.2.4)
+      '@visx/annotation': 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/axis': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/event': 4.0.1-alpha.0
+      '@visx/glyph': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/grid': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/react-spring': 4.0.1-alpha.0(@react-spring/web@9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@visx/responsive': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/text': 4.0.1-alpha.0(react@19.2.4)
+      '@visx/tooltip': 4.0.1-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/vendor': 4.0.0-alpha.0
+      '@visx/voronoi': 4.0.1-alpha.0(react@19.2.4)
       classnames: 2.5.1
       d3-interpolate-path: 2.2.1
-      d3-shape: 2.1.0
       lodash: 4.17.23
       mitt: 2.1.0
-      prop-types: 15.8.1
       react: 19.2.4
     transitivePeerDependencies:
       - react-dom
 
-  '@visx/zoom@3.12.0(react@19.2.4)':
+  '@visx/zoom@4.0.1-alpha.0(react@19.2.4)':
     dependencies:
       '@types/react': 19.2.14
       '@use-gesture/react': 10.3.1(react@19.2.4)
-      '@visx/event': 3.12.0
-      prop-types: 15.8.1
+      '@visx/event': 4.0.1-alpha.0
       react: 19.2.4
 
   '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))':
@@ -13039,56 +12616,55 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  antd@6.2.3(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@18.3.1))(react@18.3.1):
+  antd@6.2.3(luxon@3.7.2)(moment@2.30.1)(react@19.2.4):
     dependencies:
       '@ant-design/colors': 8.0.1
-      '@ant-design/cssinjs': 2.0.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@ant-design/cssinjs-utils': 2.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@ant-design/cssinjs': 2.0.3(react@19.2.4)
+      '@ant-design/cssinjs-utils': 2.0.2(react@19.2.4)
       '@ant-design/fast-color': 3.0.1
-      '@ant-design/icons': 6.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@ant-design/react-slick': 2.0.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@ant-design/icons': 6.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@ant-design/react-slick': 2.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@babel/runtime': 7.28.6
-      '@rc-component/cascader': 1.11.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/checkbox': 1.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/collapse': 1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/color-picker': 3.0.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/dialog': 1.8.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/drawer': 1.4.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/dropdown': 1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/form': 1.6.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/image': 1.6.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/input': 1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/input-number': 1.6.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/mentions': 1.6.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/menu': 1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/motion': 1.1.6(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/mutate-observer': 2.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/notification': 1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/pagination': 1.2.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/picker': 1.9.0(dayjs@1.11.19)(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/progress': 1.0.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/qrcode': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/rate': 1.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/segmented': 1.3.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/select': 1.5.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/slider': 1.0.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/steps': 1.2.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/switch': 1.0.3(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/table': 1.9.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tabs': 1.7.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/textarea': 1.1.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tooltip': 1.4.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tour': 2.3.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tree': 1.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/tree-select': 1.6.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/upload': 1.1.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      '@rc-component/util': 1.8.2(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@rc-component/cascader': 1.11.0(react@19.2.4)
+      '@rc-component/checkbox': 1.0.1(react@19.2.4)
+      '@rc-component/collapse': 1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/color-picker': 3.0.3(react@19.2.4)
+      '@rc-component/dialog': 1.8.3(react@19.2.4)
+      '@rc-component/drawer': 1.4.1(react@19.2.4)
+      '@rc-component/dropdown': 1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/form': 1.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/image': 1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/input': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/input-number': 1.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/mentions': 1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/menu': 1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/motion': 1.1.6(react@19.2.4)
+      '@rc-component/mutate-observer': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/notification': 1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/pagination': 1.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/picker': 1.9.0(dayjs@1.11.19)(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/progress': 1.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/qrcode': 1.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/rate': 1.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/resize-observer': 1.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/segmented': 1.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/select': 1.5.2(react@19.2.4)
+      '@rc-component/slider': 1.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/steps': 1.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/switch': 1.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/table': 1.9.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/tabs': 1.7.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/textarea': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/tooltip': 1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/tour': 2.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/tree': 1.1.0(react@19.2.4)
+      '@rc-component/tree-select': 1.6.0(react@19.2.4)
+      '@rc-component/trigger': 3.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/upload': 1.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rc-component/util': 1.8.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
       dayjs: 1.11.19
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
+      react: 19.2.4
       scroll-into-view-if-needed: 3.1.0
       throttle-debounce: 5.0.2
     transitivePeerDependencies:
@@ -13914,10 +13490,6 @@ snapshots:
   d3-selection@3.0.0: {}
 
   d3-shape@1.3.7:
-    dependencies:
-      d3-path: 1.0.9
-
-  d3-shape@2.1.0:
     dependencies:
       d3-path: 1.0.9
 
@@ -16661,11 +16233,6 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.2.4(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      scheduler: 0.27.0
-
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -16729,21 +16296,11 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
 
-  react-use-measure@2.1.7(react-dom@19.2.4(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      react-dom: 19.2.4(react@18.3.1)
-
   react-use-measure@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
-
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@19.2.4: {}
 


### PR DESCRIPTION
Update app dependency and profiler peer deps to visx 4.x which supports React 19. Fixes useState crash caused by dual React copies from visx 3.x only supporting React 16-18.