### PR TITLE
fix: prevent ProfileCollector CPU spike from non-czl measures

### DIFF
--- a/packages/zarrstore/src/ProfileCollector.ts
+++ b/packages/zarrstore/src/ProfileCollector.ts
@@ -49,6 +49,7 @@ export class ProfileCollector {
   constructor() {
     this.#observer = new PerformanceObserver((list) => {
       if (!this.enabled) return;
+      let added = false;
       for (const entry of list.getEntries()) {
         if (!entry.name.startsWith(MEASURE_PREFIX)) continue;
         const detail = (entry as PerformanceMeasure).detail as MeasureDetail;
@@ -66,9 +67,12 @@ export class ProfileCollector {
         if (detail.aborted) profileEntry.aborted = true;
         if (detail.label) profileEntry.label = detail.label;
         this.entries.push(profileEntry);
+        added = true;
       }
-      this.#version++;
-      this.#notify();
+      if (added) {
+        this.#version++;
+        this.#notify();
+      }
     });
     this.#observer.observe({ type: "measure", buffered: false });
   }


### PR DESCRIPTION
Closes #137

## Summary
- **Root cause:** `ProfileCollector`'s `PerformanceObserver` callback called `#version++` and `#notify()` unconditionally on every `measure` event in the page, even when zero `czl:`-prefixed entries matched
- **Effect:** Any `performance.measure()` from React DevTools, Vite HMR, or browser internals triggered `useSyncExternalStore` re-renders in `ProfileBar`, causing a runaway loop that spiked CPU to 95%+
- **Fix:** Only increment version and notify subscribers when at least one entry was actually added

## Test plan
- [x] All 33 zarrstore tests pass
- [ ] Load a dataset with ProfileBar mounted — verify CPU stays normal
- [ ] Verify profiler still records and displays czl: entries correctly