### PR TITLE
Debounce opacity-driven color buffer rebuilds

### DIFF
--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -104,6 +104,16 @@ function RenderingControls() {
   )
 }
 
+function ColorBufferSpinner() {
+  const colorBufferLoading = useAppStore((s) => s.colorBufferLoading)
+  if (!colorBufferLoading) return null
+  return (
+    <div style={{ position: 'absolute', bottom: 16, right: 16, zIndex: 1 }}>
+      <Spin size="small" />
+    </div>
+  )
+}
+
 function Visualization() {
   const embeddingData = useAppStore((s) => s.embeddingData)
   const embeddingLoading = useAppStore((s) => s.embeddingLoading)
@@ -183,7 +193,7 @@ function Visualization() {
   )
 
   return (
-    <Content ref={containerRef} style={{ position: 'relative' }}>
+    <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
       {embeddingLoading && (
         <div style={{ position: 'absolute', top: 16, left: '50%', transform: 'translateX(-50%)', zIndex: 1 }}>
           <Spin />
@@ -197,7 +207,7 @@ function Visualization() {
         layers={layers}
         widgets={WIDGETS}
       />
-    </Content>
+    </div>
   )
 }
 
@@ -228,7 +238,10 @@ function View() {
     <>
       <Layout style={{ height: '100%', flex: 1, paddingBottom: PROFILE_BAR_HEIGHT }}>
         <Sidebar />
-        <Visualization />
+        <Content style={{ position: 'relative' }}>
+          <Visualization />
+          <ColorBufferSpinner />
+        </Content>
       </Layout>
       <ProfileBarWrapper />
     </>

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 
 // Mock the worker import before importing the store
 const mockPostMessage = vi.fn()
+let mockWorkerInstance: { onmessage: ((e: MessageEvent) => void) | null } | null = null
 vi.mock('../workers/colorBuffer.worker.ts?worker', () => {
   return {
     default: class MockWorker {
       onmessage: ((e: MessageEvent) => void) | null = null
+      constructor() {
+        mockWorkerInstance = this
+      }
       postMessage(...args: unknown[]) {
         mockPostMessage(...args)
       }
@@ -18,8 +22,13 @@ const { default: useAppStore } = await import('./useAppStore')
 
 describe('useAppStore', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     useAppStore.setState(useAppStore.getInitialState())
     mockPostMessage.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('initial state', () => {
@@ -35,6 +44,7 @@ describe('useAppStore', () => {
       expect(state.loading).toBe(false)
       expect(state.embeddingData).toBeNull()
       expect(state.colorBuffer).toBeNull()
+      expect(state.colorBufferLoading).toBe(false)
       expect(state.obsmKeys).toEqual([])
       expect(state.selectedEmbedding).toBeNull()
     })
@@ -63,13 +73,17 @@ describe('useAppStore', () => {
   })
 
   describe('setOpacity', () => {
-    it('updates opacity', () => {
+    it('updates opacity immediately', () => {
       useAppStore.getState().setOpacity(0.8)
       expect(useAppStore.getState().opacity).toBe(0.8)
     })
 
-    it('triggers rebuildColorBuffer when embeddingData exists', () => {
-      // Set up embeddingData so rebuildColorBuffer actually posts to worker
+    it('sets colorBufferLoading to true immediately', () => {
+      useAppStore.getState().setOpacity(0.5)
+      expect(useAppStore.getState().colorBufferLoading).toBe(true)
+    })
+
+    it('debounces rebuildColorBuffer — does not fire immediately', () => {
       useAppStore.setState({
         embeddingData: {
           positions: new Float32Array([0, 0, 1, 1]),
@@ -81,11 +95,52 @@ describe('useAppStore', () => {
 
       useAppStore.getState().setOpacity(0.5)
 
+      // Worker should NOT have been called yet (debounce pending)
+      expect(mockPostMessage).not.toHaveBeenCalled()
+    })
+
+    it('fires rebuildColorBuffer after debounce delay', () => {
+      useAppStore.setState({
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1]),
+          numPoints: 2,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+      })
+      mockPostMessage.mockClear()
+
+      useAppStore.getState().setOpacity(0.5)
+      vi.advanceTimersByTime(150)
+
       expect(mockPostMessage).toHaveBeenCalledWith({
         type: 'buildDefault',
         numPoints: 2,
         rgb: [100, 150, 255],
         alpha: 0.5,
+      })
+    })
+
+    it('coalesces rapid calls — only last opacity value fires', () => {
+      useAppStore.setState({
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1]),
+          numPoints: 2,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+      })
+      mockPostMessage.mockClear()
+
+      useAppStore.getState().setOpacity(0.3)
+      useAppStore.getState().setOpacity(0.5)
+      useAppStore.getState().setOpacity(0.8)
+      vi.advanceTimersByTime(150)
+
+      expect(mockPostMessage).toHaveBeenCalledTimes(1)
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        type: 'buildDefault',
+        numPoints: 2,
+        rgb: [100, 150, 255],
+        alpha: 0.8,
       })
     })
   })
@@ -114,6 +169,27 @@ describe('useAppStore', () => {
         rgb: [100, 150, 255],
         alpha: 0.7,
       })
+    })
+
+    it('worker response sets colorBufferLoading to false', () => {
+      useAppStore.setState({
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1]),
+          numPoints: 2,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+        colorBufferLoading: true,
+      })
+
+      // Trigger rebuildColorBuffer to set up worker.onmessage
+      useAppStore.getState().rebuildColorBuffer()
+
+      // Simulate the worker posting back a colorBuffer result
+      const fakeBuffer = new Uint8Array(8)
+      mockWorkerInstance!.onmessage!({ data: { type: 'colorBuffer', buffer: fakeBuffer } } as MessageEvent)
+
+      expect(useAppStore.getState().colorBufferLoading).toBe(false)
+      expect(useAppStore.getState().colorBuffer).toBe(fakeBuffer)
     })
   })
 })

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -48,6 +48,7 @@ export interface AppState {
 
   // Color buffer — Uint8Array(numPoints * 4), RGBA per point
   colorBuffer: Uint8Array | null
+  colorBufferLoading: boolean
 
   // Actions
   openDataset: (url: string) => Promise<void>
@@ -78,6 +79,10 @@ function getColorWorker(): Worker {
   return colorWorker
 }
 
+// Debounce timer for opacity-driven color buffer rebuilds
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+const DEBOUNCE_MS = 150
+
 const useAppStore = create<AppState>((set, get) => ({
   // Dataset
   datasetUrl: null,
@@ -98,8 +103,9 @@ const useAppStore = create<AppState>((set, get) => ({
   collisionRadiusScale: 0,
   setPointRadius: (v) => set({ pointRadius: v }),
   setOpacity: (v) => {
-    set({ opacity: v })
-    get().rebuildColorBuffer()
+    set({ opacity: v, colorBufferLoading: true })
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => get().rebuildColorBuffer(), DEBOUNCE_MS)
   },
   setAntialiasing: (v) => set({ antialiasing: v }),
   setCollisionEnabled: (v) => set({ collisionEnabled: v }),
@@ -112,6 +118,7 @@ const useAppStore = create<AppState>((set, get) => ({
 
   // Color buffer — Uint8Array(numPoints * 4), RGBA per point
   colorBuffer: null,
+  colorBufferLoading: false,
 
   // Actions
   openDataset: async (url) => {
@@ -179,7 +186,7 @@ const useAppStore = create<AppState>((set, get) => ({
     // One-shot listener for this build — replaces any previous listener
     worker.onmessage = (e) => {
       if (e.data.type === 'colorBuffer') {
-        set({ colorBuffer: e.data.buffer })
+        set({ colorBuffer: e.data.buffer, colorBufferLoading: false })
       }
     }
 


### PR DESCRIPTION
## Summary
- Debounce `rebuildColorBuffer` by 150ms when triggered by `setOpacity`, preventing burst worker messages and GPU re-uploads during rapid opacity changes
- Add `colorBufferLoading` state to track when the color buffer is being rebuilt
- Add a subtle `ColorBufferSpinner` in the plot corner, rendered as a sibling to `Visualization` (zero extra deck.gl re-renders)

Closes #142

## Test plan
- [x] `cd packages/highperformer && pnpm test` — all 30 tests pass
- [ ] Manual: rapidly change opacity, confirm no burst of GPU re-uploads via deck.gl StatsWidget