### PR TITLE
feat: export GENE_SYMBOL_COLUMNS from zarrstore

### DIFF
--- a/packages/zarrstore/src/AnnDataStore.ts
+++ b/packages/zarrstore/src/AnnDataStore.ts
@@ -39,6 +39,19 @@ interface CachedOpts<T> {
   getLabel?: (result: T) => Promise<string | undefined> | string | undefined;
 }
 
+/** Common var column names that hold human-readable gene symbols (case-sensitive candidates). */
+export const GENE_SYMBOL_COLUMNS: readonly string[] = [
+  "gene_symbol",
+  "GeneSymbol",
+  "gene_symbols",
+  "feature_name",
+  "var_name",
+  "gene_name",
+  "gene_short_name",
+  "symbol",
+  "name",
+];
+
 export class AnnDataStore {
   #zarrStore: ZarrStore;
   #shape: number[];
@@ -327,18 +340,7 @@ export class AnnDataStore {
     return result;
   }
 
-  /** Common var column names that hold human-readable gene symbols (case-sensitive candidates). */
-  static readonly #GENE_SYMBOL_COLUMNS = [
-    "gene_symbol",
-    "GeneSymbol",
-    "gene_symbols",
-    "feature_name",
-    "var_name",
-    "gene_name",
-    "gene_short_name",
-    "symbol",
-    "name",
-  ];
+  static readonly #GENE_SYMBOL_COLUMNS = GENE_SYMBOL_COLUMNS;
 
   /**
    * Try to resolve a human-readable gene symbol for a var-index gene name.

--- a/packages/zarrstore/src/index.ts
+++ b/packages/zarrstore/src/index.ts
@@ -1,5 +1,5 @@
 export { ZarrStore } from "./ZarrStore";
-export { AnnDataStore } from "./AnnDataStore";
+export { AnnDataStore, GENE_SYMBOL_COLUMNS } from "./AnnDataStore";
 export { InstrumentedStore } from "./InstrumentedStore";
 export type { FetchStats } from "./InstrumentedStore";
 export { ProfileCollector } from "./ProfileCollector";


### PR DESCRIPTION
## Summary
- Move the gene symbol column name list from a private static field on `AnnDataStore` to an exported module-level constant (`GENE_SYMBOL_COLUMNS`)
- Re-export from `zarrstore/index.ts` so consumers can use it for auto-detection of gene label columns
- `AnnDataStore` internally references the same constant, so no behavior change

## Test plan
- [ ] `pnpm --filter zarrstore test` passes
- [ ] `pnpm --filter highperformer test` passes
- [ ] Existing gene symbol resolution in `AnnDataStore` still works (uses same list)