### PR TITLE
feat: add dataset dropdown to sidebar

### DIFF
--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -2,20 +2,7 @@ import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { Input, Button, List, Typography, Space } from 'antd'
 import { DeleteOutlined } from '@ant-design/icons'
-
-const STORAGE_KEY = 'highperformer:datasets'
-
-function loadDatasets(): string[] {
-  try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') || []
-  } catch {
-    return []
-  }
-}
-
-function saveDatasets(datasets: string[]) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(datasets))
-}
+import { loadDatasets, saveDatasets } from '../utils/datasets'
 
 function Home() {
   const [url, setUrl] = useState('')

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, useNavigate } from 'react-router-dom'
 import { InputNumber, Layout, Switch, Typography, Select, Spin } from 'antd'
 import { DeckGL } from '@deck.gl/react'
 import { OrthographicView } from '@deck.gl/core'
@@ -9,6 +9,7 @@ import { _StatsWidget as StatsWidget } from '@deck.gl/widgets'
 import { ProfileBar, PROFILE_BAR_HEIGHT, saveProfileSession } from '@cbioportal-zarr-loader/profiler'
 import useAppStore from '../store/useAppStore'
 import ColorBySection from '../components/ColorBySection'
+import { loadDatasets, saveDatasets } from '../utils/datasets'
 
 const { Sider, Content } = Layout
 
@@ -17,29 +18,54 @@ const WIDGETS = [new StatsWidget({ type: 'deck', framesPerUpdate: 5, placement: 
 // Fallback color when no color buffer is ready yet
 const FALLBACK_COLOR: [number, number, number, number] = [100, 150, 255, 77]
 
+function urlLabel(url: string): string {
+  return url.replace(/\/+$/, '').split('/').pop() ?? url
+}
+
 function Sidebar() {
+  const navigate = useNavigate()
   const datasetUrl = useAppStore((s) => s.datasetUrl)
   const loading = useAppStore((s) => s.loading)
+  const nObs = useAppStore((s) => s.nObs)
+  const nVar = useAppStore((s) => s.nVar)
   const obsmKeys = useAppStore((s) => s.obsmKeys)
   const selectedEmbedding = useAppStore((s) => s.selectedEmbedding)
   const setSelectedEmbedding = useAppStore((s) => s.setSelectedEmbedding)
 
-  const datasetName = datasetUrl
-    ? datasetUrl.replace(/\/+$/, '').split('/').pop()
-    : null
+  // Build dataset options from localStorage, ensuring current URL is included
+  const datasetOptions = useMemo(() => {
+    const saved = loadDatasets()
+    if (datasetUrl && !saved.includes(datasetUrl)) {
+      const updated = [datasetUrl, ...saved]
+      saveDatasets(updated)
+      return updated
+    }
+    return saved
+  }, [datasetUrl])
 
   const sectionStyle = { padding: '12px 16px', borderBottom: '1px solid #f0f0f0' } as const
   const labelStyle = { fontSize: 12, fontWeight: 600, color: '#666', textTransform: 'uppercase', marginBottom: 8 } as const
 
   return (
     <Sider width={280} theme="light" style={{ borderRight: '1px solid #f0f0f0', overflow: 'auto' }}>
-      {datasetName && (
-        <div style={sectionStyle}>
-          <Typography.Text type="secondary" ellipsis title={datasetUrl ?? undefined} style={{ display: 'block' }}>
-            {datasetName}
-          </Typography.Text>
+      <div style={sectionStyle}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', ...labelStyle }}>
+          <span>Dataset</span>
+          {nObs != null && (
+            <Typography.Text type="secondary" style={{ fontSize: 11, fontWeight: 400, textTransform: 'none' }}>
+              {nObs.toLocaleString()} cells &middot; {(nVar ?? 0).toLocaleString()} genes
+            </Typography.Text>
+          )}
         </div>
-      )}
+        <Select
+          style={{ width: '100%' }}
+          size="small"
+          placeholder="Select dataset"
+          value={datasetUrl}
+          onChange={(url: string) => navigate(`/view?url=${encodeURIComponent(url)}`)}
+          options={datasetOptions.map((url) => ({ label: urlLabel(url), value: url }))}
+        />
+      </div>
 
       <div style={sectionStyle}>
         <div style={labelStyle}>Embedding</div>

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -29,6 +29,8 @@ export interface AppState {
   loading: boolean
 
   // Metadata derived from adata (cached on load)
+  nObs: number | null
+  nVar: number | null
   obsmKeys: string[]
 
   // Embedding selection
@@ -138,6 +140,8 @@ const useAppStore = create<AppState>((set, get) => ({
   loading: false,
 
   // Metadata derived from adata (cached on load)
+  nObs: null,
+  nVar: null,
   obsmKeys: [],
 
   // Embedding selection
@@ -193,7 +197,7 @@ const useAppStore = create<AppState>((set, get) => ({
   openDataset: async (url) => {
     if (url === get().datasetUrl && get().adata) return
     set({
-      datasetUrl: url, loading: true, adata: null, obsmKeys: [],
+      datasetUrl: url, loading: true, adata: null, nObs: null, nVar: null, obsmKeys: [],
       selectedEmbedding: null, embeddingData: null, colorBuffer: null,
       colorMode: 'category', selectedObsColumn: null, selectedGene: null,
       obsColumnNames: [], varNames: [], categoryMap: [], expressionRange: null,
@@ -207,6 +211,8 @@ const useAppStore = create<AppState>((set, get) => ({
       const defaultKey = umap ?? obsmKeys[0] ?? null
       set({
         adata,
+        nObs: adata.nObs,
+        nVar: adata.nVar,
         obsmKeys,
         selectedEmbedding: defaultKey,
         loading: false,

--- a/packages/highperformer/src/utils/datasets.ts
+++ b/packages/highperformer/src/utils/datasets.ts
@@ -1,0 +1,13 @@
+export const STORAGE_KEY = 'highperformer:datasets'
+
+export function loadDatasets(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') || []
+  } catch {
+    return []
+  }
+}
+
+export function saveDatasets(datasets: string[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(datasets))
+}


### PR DESCRIPTION
## Summary
- Extract localStorage dataset helpers (`loadDatasets`, `saveDatasets`) into `utils/datasets.ts` and update `Home.tsx` imports
- Add `nObs`/`nVar` fields to the Zustand store, populated from `AnnDataStore` on dataset open
- Replace static dataset name in sidebar with a `Select` dropdown that loads options from localStorage and navigates on change
- Show cell and gene counts inline with the "DATASET" section label

## Test plan
- [x] All 72 existing tests pass (`pnpm test` in highperformer)
- [x] TypeScript compiles with no new errors (`tsc --noEmit`)
- [ ] Manual: open a dataset, verify dropdown appears with dataset name
- [ ] Manual: add a second dataset from Home page, verify both appear in dropdown
- [ ] Manual: switch datasets via dropdown, verify navigation and data reload
- [ ] Manual: verify cell/gene counts display next to "DATASET" label