### PR TITLE
fix: suppress normalized color attribute warning

### DIFF
--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -354,7 +354,7 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
   // Memoize layer data object — only recreate when position or color buffer changes
   const layerData = useMemo(() => {
     if (!embeddingData) return null
-    const attributes: Record<string, { value: Float32Array | Uint8Array; size: number }> = {
+    const attributes: Record<string, { value: Float32Array | Uint8Array; size: number; normalized?: boolean }> = {
       getPosition: { value: embeddingData.positions, size: 2 },
     }
 
@@ -365,7 +365,7 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
       : colorBuffer
 
     if (effectiveColor) {
-      attributes.getFillColor = { value: effectiveColor, size: 4 }
+      attributes.getFillColor = { value: effectiveColor, size: 4, normalized: true }
     }
     return { length: embeddingData.numPoints, attributes }
   }, [embeddingData, colorBuffer, selectionFilterBuffer, selectionDisplayMode])


### PR DESCRIPTION
## Summary
- Add `normalized: true` to the `getFillColor` binary attribute descriptor in `View.tsx`
- Suppresses the deck.gl warning `"Attribute instanceFillColors is normalized"` by making the implicit normalization explicit
- No behavior change — deck.gl was already normalizing the `Uint8Array` automatically

Closes #153

## Test plan
- [ ] Load dataset — no `instanceFillColors is normalized` warning in console
- [ ] Color by category/gene — colors render correctly as before