### PR TITLE
fix: replace deprecated Space.Compact direction prop

### DIFF
--- a/packages/highperformer/src/components/SelectionToolbar.tsx
+++ b/packages/highperformer/src/components/SelectionToolbar.tsx
@@ -31,7 +31,7 @@ export default function SelectionToolbar() {
       flexDirection: 'column',
       gap: 4,
     }}>
-      <Space.Compact direction="vertical" size="small">
+      <Space.Compact orientation="vertical" size="small">
         <Tooltip title="Pan (Esc)" placement="right">
           <Button
             icon={<DragOutlined />}
@@ -56,7 +56,7 @@ export default function SelectionToolbar() {
       </Space.Compact>
 
       {hasSelection && (
-        <Space.Compact direction="vertical" size="small">
+        <Space.Compact orientation="vertical" size="small">
           <Tooltip title={selectionDisplayMode === 'dim' ? 'Hide unselected' : 'Dim unselected'} placement="right">
             <Button
               icon={selectionDisplayMode === 'dim' ? <EyeOutlined /> : <EyeInvisibleOutlined />}


### PR DESCRIPTION
## Summary
- Replace `direction="vertical"` with `orientation="vertical"` on two `Space.Compact` instances in `SelectionToolbar.tsx`
- Suppresses antd deprecation warning: `[antd: Space.Compact] \`direction\` is deprecated. Please use \`orientation\` instead.`

Closes #155

## Test plan
- [ ] Open app — no `Space.Compact` deprecation warning in console
- [ ] Selection toolbar renders vertically as before