### PR TITLE
fix: eliminate unnecessary v2 probing and HEAD requests on v3 stores

### DIFF
--- a/packages/zarrstore/src/AnnDataStore.ts
+++ b/packages/zarrstore/src/AnnDataStore.ts
@@ -285,7 +285,7 @@ export class AnnDataStore {
 
     let result: ArrayResult | SparseMatrix;
     if ((node.attrs?.["encoding-type"] as string)?.endsWith("_matrix")) {
-      result = await decodeSparseMatrix(node as ZarrGroup);
+      result = await decodeSparseMatrix(node as ZarrGroup, this.#zarrStore.openFn);
     } else if (sliceRange) {
       const [start, end] = sliceRange;
       const chunk = await zarr.get(node as ZarrArray, [zarr.slice(start, end), null]);
@@ -371,7 +371,7 @@ export class AnnDataStore {
 
         if ((node.attrs?.["encoding-type"] as string)?.endsWith("_matrix")) {
           // Sparse matrix - need to decode and extract column
-          const sparse = await decodeSparseMatrix(node as ZarrGroup);
+          const sparse = await decodeSparseMatrix(node as ZarrGroup, this.#zarrStore.openFn);
           const result = new Float32Array(this.#shape[0]);
           const data = sparse.data as ArrayLike<number>;
           const indices = sparse.indices as ArrayLike<number>;
@@ -407,7 +407,7 @@ export class AnnDataStore {
       "obs",
       async () => {
         const group = await this.#zarrStore.openGroup("obs");
-        return decodeDataframe(group);
+        return decodeDataframe(group, this.#zarrStore.openFn);
       },
       { getChunkInfo: () => this.#chunkInfoForIndex("obs") },
     );
@@ -422,7 +422,7 @@ export class AnnDataStore {
       cacheKey,
       async () => {
         const group = await this.#zarrStore.openGroup("obs");
-        return decodeColumn(group, name, undefined, signal);
+        return decodeColumn(group, name, this.#zarrStore.openFn, signal);
       },
       { getChunkInfo: () => this.#chunkInfoForColumn("obs", name) },
     );
@@ -442,16 +442,17 @@ export class AnnDataStore {
         const group = await this.#zarrStore.openGroup("obs");
         const indexKey = group.attrs["_index"] as string;
         // Index can be an array or a categorical group
+        const openFn = this.#zarrStore.openFn;
         try {
-          const arr = await zarr.open(group.resolve(indexKey), { kind: "array" });
-          const result = await readArray(arr);
+          const arr = await openFn(group.resolve(indexKey), { kind: "array" });
+          const result = await readArray(arr as zarr.Array<zarr.DataType, Readable>);
           return toStringArray(result.data);
         } catch {
           // It's a categorical group
-          const catGroup = await zarr.open(group.resolve(indexKey), {
+          const catGroup = await openFn(group.resolve(indexKey), {
             kind: "group",
           });
-          const decoded = await decodeCategorical(catGroup);
+          const decoded = await decodeCategorical(catGroup as zarr.Group<Readable>, openFn);
           return decoded.values;
         }
       },
@@ -464,7 +465,7 @@ export class AnnDataStore {
       "var",
       async () => {
         const group = await this.#zarrStore.openGroup("var");
-        return decodeDataframe(group);
+        return decodeDataframe(group, this.#zarrStore.openFn);
       },
       { getChunkInfo: () => this.#chunkInfoForIndex("var") },
     );
@@ -475,7 +476,7 @@ export class AnnDataStore {
       `var:${name}`,
       async () => {
         const group = await this.#zarrStore.openGroup("var");
-        return decodeColumn(group, name);
+        return decodeColumn(group, name, this.#zarrStore.openFn);
       },
       { getChunkInfo: () => this.#chunkInfoForColumn("var", name) },
     );
@@ -495,16 +496,17 @@ export class AnnDataStore {
         const group = await this.#zarrStore.openGroup("var");
         const indexKey = group.attrs["_index"] as string;
         // Index can be an array or a categorical group
+        const openFn = this.#zarrStore.openFn;
         try {
-          const arr = await zarr.open(group.resolve(indexKey), { kind: "array" });
-          const result = await readArray(arr);
+          const arr = await openFn(group.resolve(indexKey), { kind: "array" });
+          const result = await readArray(arr as zarr.Array<zarr.DataType, Readable>);
           return toStringArray(result.data);
         } catch {
           // It's a categorical group
-          const catGroup = await zarr.open(group.resolve(indexKey), {
+          const catGroup = await openFn(group.resolve(indexKey), {
             kind: "group",
           });
-          const decoded = await decodeCategorical(catGroup);
+          const decoded = await decodeCategorical(catGroup as zarr.Group<Readable>, openFn);
           return decoded.values;
         }
       },
@@ -542,7 +544,7 @@ export class AnnDataStore {
       `${path}:${key}`,
       async () => {
         const node = await this.#zarrStore.openGroup(`${path}/${key}`);
-        return decodeNode(node);
+        return decodeNode(node, this.#zarrStore.openFn);
       },
       {
         getChunkInfo: () =>
@@ -561,7 +563,7 @@ export class AnnDataStore {
           return readArray(arr, signal);
         } catch {
           const node = await this.#zarrStore.openGroup(`${path}/${key}`);
-          return decodeNode(node);
+          return decodeNode(node, this.#zarrStore.openFn);
         }
       },
       { getChunkInfo: () => this.#chunkInfoFromMetadata(`${path}/${key}`) },
@@ -583,7 +585,7 @@ export class AnnDataStore {
           } catch {
             // Group-encoded obsm (e.g. sparse) — fall back to full decode
             const node = await this.#zarrStore.openGroup(`obsm/${key}`);
-            return decodeNode(node);
+            return decodeNode(node, this.#zarrStore.openFn);
           }
         },
         { getChunkInfo: () => this.#chunkInfoFromMetadata(`obsm/${key}`) },

--- a/packages/zarrstore/src/ZarrStore.ts
+++ b/packages/zarrstore/src/ZarrStore.ts
@@ -13,6 +13,7 @@ export class ZarrStore {
   root: zarr.Group<Readable>;
   attrs: Record<string, unknown>;
   consolidatedMetadata: ConsolidatedMetadataMap | null;
+  zarrVersion: 2 | 3;
   #effectiveStore: InstrumentedStore | ConsolidatedStore;
 
   constructor(
@@ -20,16 +21,18 @@ export class ZarrStore {
     root: zarr.Group<Readable>,
     consolidatedMetadata: ConsolidatedMetadataMap | null = null,
     effectiveStore?: ConsolidatedStore,
+    zarrVersion: 2 | 3 = 2,
   ) {
     this.store = store;
     this.root = root;
     this.attrs = root.attrs;
     this.consolidatedMetadata = consolidatedMetadata;
+    this.zarrVersion = zarrVersion;
     this.#effectiveStore = effectiveStore ?? store;
   }
 
   static async open(url: string): Promise<ZarrStore> {
-    const fetchStore = new zarr.FetchStore(url);
+    const fetchStore = new zarr.FetchStore(url, { useSuffixRequest: true });
     const instrumented = new InstrumentedStore(fetchStore);
 
     let effectiveStore: ConsolidatedStore | undefined;
@@ -65,16 +68,32 @@ export class ZarrStore {
       }
     }
 
-    const root = await zarr.open(effectiveStore ?? instrumented, { kind: "group" });
-    return new ZarrStore(instrumented, root, consolidatedMetadata, effectiveStore);
+    const zarrVersion = rootBytes ? 3 : 2;
+    const openFn = zarrVersion === 3 ? zarr.open.v3 : zarr.open.v2;
+    const root = await openFn(effectiveStore ?? instrumented, { kind: "group" });
+    return new ZarrStore(instrumented, root, consolidatedMetadata, effectiveStore, zarrVersion);
+  }
+
+  #open(location: zarr.Location<Readable>, opts: { kind: "array" }): Promise<zarr.Array<zarr.DataType, Readable>>;
+  #open(location: zarr.Location<Readable>, opts: { kind: "group" }): Promise<zarr.Group<Readable>>;
+  #open(location: zarr.Location<Readable>, opts: { kind: "array" | "group" }): Promise<zarr.Array<zarr.DataType, Readable> | zarr.Group<Readable>> {
+    const openFn = this.zarrVersion === 3 ? zarr.open.v3 : zarr.open.v2;
+    return openFn(location, opts as { kind: "array" });
   }
 
   async openArray(path: string): Promise<zarr.Array<zarr.DataType, Readable>> {
-    return zarr.open(this.root.resolve(path), { kind: "array" });
+    return this.#open(this.root.resolve(path), { kind: "array" });
   }
 
   async openGroup(path: string): Promise<zarr.Group<Readable>> {
-    return zarr.open(this.root.resolve(path), { kind: "group" });
+    return this.#open(this.root.resolve(path), { kind: "group" });
+  }
+
+  /** Version-specific open function suitable for passing to decoders. */
+  get openFn(): (location: zarr.Location<Readable>, opts: { kind: "array" | "group" }) => Promise<zarr.Array<zarr.DataType, Readable> | zarr.Group<Readable>> {
+    return this.zarrVersion === 3
+      ? (loc, opts) => zarr.open.v3(loc, opts as { kind: "array" })
+      : (loc, opts) => zarr.open.v2(loc, opts as { kind: "array" });
   }
 
   snapshotFetchStats(): FetchStats {


### PR DESCRIPTION
## Summary

- Track `zarrVersion` (2|3) on `ZarrStore` and use version-specific openers (`zarr.open.v2`/`zarr.open.v3`) everywhere, eliminating v2 metadata probing (`.zattrs`, `.zgroup`, `.zarray` 404s) on v3 stores
- Pass `openFn` from `ZarrStore` through to all decoder calls in `AnnDataStore`, bypassing the `defaultOpen` v2-first fallback in `decoders.ts`
- Enable `useSuffixRequest` on `FetchStore` so zarrita uses `Range: bytes=-N` for shard index reads instead of HEAD+GET, eliminating ~200 failed HEAD requests on sharded v3 arrays

## Test plan

- [x] All 47 zarrstore tests pass
- [ ] Verify no `.zattrs`/`.zgroup`/`.zarray` 404s when loading a v3 dataset
- [ ] Verify no failed HEAD requests on sharded v3 chunk data
- [ ] Verify v2 datasets still load correctly (pbmc3k fixture)