### PR TITLE
fix: disable suffix range requests to avoid CORS preflight failures

### DIFF
--- a/packages/zarrstore/src/ZarrStore.ts
+++ b/packages/zarrstore/src/ZarrStore.ts
@@ -32,7 +32,13 @@ export class ZarrStore {
   }
 
   static async open(url: string): Promise<ZarrStore> {
-    const fetchStore = new zarr.FetchStore(url, { useSuffixRequest: true });
+    // useSuffixRequest: false — uses HEAD+GET instead of Range suffix requests.
+    // Range headers trigger CORS preflights (OPTIONS), which fail on CloudFront
+    // distributions that don't allow OPTIONS method. HEAD+GET adds one extra
+    // request per shard but avoids preflight entirely. To re-enable, CloudFront
+    // needs: OPTIONS in allowed methods, CORS-S3Origin request policy, and
+    // Origin in the cache key. See: https://github.com/cBioPortal/cbioportal-zarr-loader/issues/162
+    const fetchStore = new zarr.FetchStore(url, { useSuffixRequest: false });
     const instrumented = new InstrumentedStore(fetchStore);
 
     let effectiveStore: ConsolidatedStore | undefined;


### PR DESCRIPTION
## Summary

- Reverts `useSuffixRequest` to `false` in `ZarrStore.ts` to avoid CORS preflight failures on CloudFront
- `Range` headers trigger browser OPTIONS preflights, which CloudFront rejects (404) when OPTIONS is not in allowed methods
- Falls back to HEAD+GET for shard index reads (one extra request per shard, negligible impact)
- Restores compatibility with Zarr v3 sharded stores served through CloudFront (e.g. `final_crc_atlas`)

## Test plan

- [x] Verify `final_crc_atlas` v3 sharded store loads without CORS errors
- [x] Verify `spectrum_all_cells` v2 store still loads correctly
- [x] Verify local zarr stores still load correctly

Closes #162