### PR TITLE
fix: include base URL in copy-to-clipboard shareable link

### DIFF
--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -209,7 +209,7 @@ function LeftSidebarContent() {
                   <LinkOutlined
                     style={{ fontSize: 11, marginLeft: 6, cursor: 'pointer', color: '#999' }}
                     onClick={() => {
-                      const link = `${window.location.origin}/view?url=${datasetUrl}`
+                      const link = `${window.location.origin}${import.meta.env.BASE_URL}view?url=${datasetUrl}`
                       navigator.clipboard.writeText(link)
                     }}
                   />


### PR DESCRIPTION
Closes #167

## Summary
- The copy shareable link button on the View page was missing the `VITE_BASE_URL` prefix, producing broken links on GitHub Pages deployments
- Use `import.meta.env.BASE_URL` (already used by the router) when constructing the link

## Test plan
- [ ] Deploy to GitHub Pages, open a dataset, click the link icon, verify the copied URL includes `/cbioportal-cell-explorer/` prefix