### PR TITLE
fix: remove close button from summary panel

### DIFF
--- a/packages/highperformer/src/components/SummaryPanel.tsx
+++ b/packages/highperformer/src/components/SummaryPanel.tsx
@@ -1,6 +1,6 @@
 import { startTransition, useMemo, useState } from 'react'
 import { Collapse, Segmented, Tooltip, Typography } from 'antd'
-import { BarChartOutlined, CloseOutlined, DotChartOutlined, InfoCircleOutlined, PieChartOutlined, SearchOutlined } from '@ant-design/icons'
+import { BarChartOutlined, DotChartOutlined, InfoCircleOutlined, PieChartOutlined, SearchOutlined } from '@ant-design/icons'
 import useAppStore from '../store/useAppStore'
 import type { SelectionGroup } from '../store/useAppStore'
 import GroupOverview from './GroupOverview'
@@ -30,7 +30,6 @@ interface SummaryPanelProps {
 
 export default function SummaryPanel({ collapsed, onExpand }: SummaryPanelProps) {
   const summaryPanelOpen = useAppStore((s) => s.summaryPanelOpen)
-  const setSummaryPanelOpen = useAppStore((s) => s.setSummaryPanelOpen)
   const selectionGroups = useAppStore((s) => s.selectionGroups)
   const summaryObsColumns = useAppStore((s) => s.summaryObsColumns)
   const summaryGenes = useAppStore((s) => s.summaryGenes)
@@ -179,10 +178,6 @@ export default function SummaryPanel({ collapsed, onExpand }: SummaryPanelProps)
         alignItems: 'center',
       }}>
         <Typography.Text strong style={{ fontSize: 14 }}>Summary</Typography.Text>
-        <CloseOutlined
-          style={{ fontSize: 12, cursor: 'pointer', color: '#999' }}
-          onClick={() => setSummaryPanelOpen(false)}
-        />
       </div>
 
       <div style={{ flex: 1, overflow: 'auto', padding: '12px 16px' }}>


### PR DESCRIPTION
## Summary
- Remove the close button from the summary panel since there is no way to reopen it once closed
- Clean up unused `CloseOutlined` import and `setSummaryPanelOpen` selector

## Test plan
- [ ] Open the app and verify the summary panel no longer has an X button
- [ ] Verify the summary panel still renders correctly