### PR TITLE
fix: always show category variable dropdown in Expression by Category

### DIFF
--- a/packages/highperformer/src/components/ExpressionDotPlot.tsx
+++ b/packages/highperformer/src/components/ExpressionDotPlot.tsx
@@ -510,7 +510,7 @@ export default function ExpressionDotPlot({ groups }: ExpressionDotPlotProps) {
     setModalOpen(true)
   }
 
-  const obsSelector = categoricalColumns.length > 1 ? (
+  const obsSelector = (
     <Select
       size="small"
       value={activeObs}
@@ -518,7 +518,7 @@ export default function ExpressionDotPlot({ groups }: ExpressionDotPlotProps) {
       options={categoricalColumns.map((c) => ({ value: c, label: c }))}
       style={{ minWidth: 120, fontSize: 11 }}
     />
-  ) : null
+  )
 
   const colorScaleSelector = (
     <Select


### PR DESCRIPTION
## Summary
- Always render the category variable dropdown in the Expression by Category dot plot, even when only one obs column is available
- Previously the dropdown was hidden with a single variable, giving users no indication of which category was being used

Closes #176