### PR TITLE
fix: dataset switching via dropdown broken after config param introduction

### DIFF
--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -696,25 +696,24 @@ function View() {
 
   const configApplied = useRef(false)
 
+  // Handle ?config= param (applied once on initial load)
   useEffect(() => {
-    if (configApplied.current) return
-
-    if (configParam) {
-      const config = parseConfig(configParam)
-      if (config) {
-        configApplied.current = true
-        if (!config.showLeftSidebar) setLeftCollapsed(true)
-        if (!config.showRightSidebar) setRightWidth(SIDEBAR_COLLAPSED_WIDTH)
-        applyConfig(config)
-        return
-      }
-    }
-
-    if (urlParam) {
+    if (!configParam || configApplied.current) return
+    const config = parseConfig(configParam)
+    if (config) {
       configApplied.current = true
-      openDataset(urlParam)
+      if (!config.showLeftSidebar) setLeftCollapsed(true)
+      if (!config.showRightSidebar) setRightWidth(SIDEBAR_COLLAPSED_WIDTH)
+      applyConfig(config)
     }
-  }, [configParam, urlParam, openDataset])
+  }, [configParam])
+
+  // Handle ?url= param — loads dataset on initial visit and when switching via dropdown
+  // Skipped when ?config= was used (applyConfig handles dataset loading)
+  useEffect(() => {
+    if (configParam) return
+    if (urlParam) openDataset(urlParam)
+  }, [urlParam, configParam, openDataset])
 
   if (loadingError) {
     const isEmbedded = window.self !== window.top


### PR DESCRIPTION
## Problem

After PR #191 introduced the `?config=` query param, switching datasets via the dropdown stopped working. The `configApplied` ref guard prevented the `?url=` effect from firing on subsequent navigations.

## Fix

Split the single `useEffect` into two:
1. **Config effect** — applies `?config=` once on initial load (guarded by ref)
2. **URL effect** — handles `?url=` for both initial load and dropdown navigation; skipped when `?config=` is present (since `applyConfig` handles dataset loading)

When the dropdown navigates to `/view?url=newDataset`, it drops the `?config=` param, so the URL effect fires normally.

## Test plan

- [x] 215 tests pass
- [ ] Load via `?config=` — works as before
- [ ] Load via `?url=` — works as before  
- [ ] Switch dataset via dropdown — now works again