### PR TITLE
feat: add postMessage debug logging and ready signal

### DIFF
--- a/packages/highperformer/.env.example
+++ b/packages/highperformer/.env.example
@@ -19,3 +19,6 @@ VITE_ENABLE_POSTMESSAGE=false
 # Comma-separated origin patterns for postMessage filtering (required when enabled)
 # Examples: https://*.cbioportal.org, https://localhost:3000, * (any origin, dev only)
 # VITE_POSTMESSAGE_ORIGIN=*
+
+# Enable verbose postMessage debug logging (default: false)
+# VITE_POSTMESSAGE_DEBUG=false

--- a/packages/highperformer/src/config/usePostMessage.ts
+++ b/packages/highperformer/src/config/usePostMessage.ts
@@ -54,6 +54,8 @@ export function usePostMessage(): void {
       return
     }
 
+    const debug = import.meta.env.VITE_POSTMESSAGE_DEBUG === 'true'
+
     const patterns =
       originEnv === '*'
         ? null
@@ -68,9 +70,24 @@ export function usePostMessage(): void {
       originEnv,
     )
 
+    // Signal to parent that the listener is ready
+    if (window.self !== window.top) {
+      window.parent.postMessage({ type: 'ready' }, '*')
+      if (debug) console.log('[postMessage:debug] Sent ready signal to parent')
+    }
+
     const listener = (event: MessageEvent) => {
+      if (debug) {
+        console.log('[postMessage:debug] Raw message received:', { origin: event.origin, data: event.data })
+      }
+
       const result = MessageSchema.safeParse(event.data)
-      if (!result.success) return
+      if (!result.success) {
+        if (debug && event.data && typeof event.data === 'object' && 'type' in event.data) {
+          console.log('[postMessage:debug] Message validation failed:', result.error.issues)
+        }
+        return
+      }
 
       if (patterns && !isOriginAllowed(event.origin, patterns)) {
         console.warn(
@@ -82,8 +99,20 @@ export function usePostMessage(): void {
 
       const { payload } = result.data
 
+      if (debug) {
+        console.log('[postMessage:debug] Valid message received:', {
+          type: result.data.type,
+          url: payload.url,
+          lastAppliedUrl: lastAppliedUrl.current,
+          isFirstMessage: payload.url !== lastAppliedUrl.current,
+          hasFilter: !!payload.filter,
+          filterIdCount: payload.filter?.ids.length ?? 0,
+        })
+      }
+
       // Different URL or first message: full applyConfig
       if (payload.url !== lastAppliedUrl.current) {
+        if (debug) console.log('[postMessage:debug] Applying full config (new URL or first message)')
         lastAppliedUrl.current = payload.url
         applyConfig(payload)
         return
@@ -93,6 +122,7 @@ export function usePostMessage(): void {
       const store = useAppStore
 
       if (payload.filter && payload.filter.ids.length > 0) {
+        if (debug) console.log('[postMessage:debug] Filter-only update:', payload.filter.ids.length, 'IDs on column', payload.filter.obsColumn)
         // Wait for dataset readiness before applying filter
         waitForStore(store, (s) => s.obsColumnNames.length > 0)
           .then(() => {
@@ -100,6 +130,7 @@ export function usePostMessage(): void {
               .getState()
               .selectByIds(payload.filter!.obsColumn, payload.filter!.ids)
             store.setState({ summaryContext: 'selections' })
+            if (debug) console.log('[postMessage:debug] Filter applied successfully')
           })
           .catch(() => {
             console.warn(
@@ -107,6 +138,7 @@ export function usePostMessage(): void {
             )
           })
       } else {
+        if (debug) console.log('[postMessage:debug] Clearing custom group (empty or missing filter)')
         // No filter or empty IDs: clear custom group
         store.getState().clearCustomGroup()
         store.setState({ summaryContext: 'all' })


### PR DESCRIPTION
## Summary

- Add `VITE_POSTMESSAGE_DEBUG=true` env var for verbose postMessage logging — logs raw messages, validation results, routing decisions, and filter application
- Send `{ type: "ready" }` signal to parent when the postMessage listener is registered (iframe only) — allows the parent to wait for readiness before sending the initial config

## Debug logs (when `VITE_POSTMESSAGE_DEBUG=true`)

- Raw message received (origin + data)
- Validation failures (for messages with a `type` field)
- Valid message details (URL, isFirstMessage, filter ID count)
- Routing path taken (full config / filter-only / clear)

## Ready signal

- Only sent when running inside an iframe (`window.self !== window.top`)
- Posts `{ type: "ready" }` to `window.parent` with `*` origin
- Parent can optionally listen for this before sending the initial config

## Test plan

- [x] 238 tests pass
- [ ] Set `VITE_POSTMESSAGE_DEBUG=true` in `.env.local`, verify debug logs appear in console