### PR TITLE
ci: allow localhost origins for postMessage in production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # Build highperformer (deployed to GitHub Pages)
+      # NOTE: localhost origins are allowed temporarily for local cBioPortal development.
+      # This will change once we move to utilize resource data.
       - run: pnpm --filter @cbioportal-cell-explorer/highperformer build
         env:
           VITE_BASE_URL: /cbioportal-cell-explorer/
           VITE_ENABLE_POSTMESSAGE: "true"
-          VITE_POSTMESSAGE_ORIGIN: "https://www.cbioportal.org, https://deploy-preview-*--cbioportalfrontend.netlify.app"
+          VITE_POSTMESSAGE_ORIGIN: "https://www.cbioportal.org, https://deploy-preview-*--cbioportalfrontend.netlify.app, http://localhost:*, https://localhost:*"
 
       # Build app (kept for reference, not deployed)
       # To switch back: uncomment this block, comment out highperformer build above,


### PR DESCRIPTION
## Summary

Add `http://localhost:*` and `https://localhost:*` to the allowed postMessage origins in the production build. This allows local cBioPortal development instances to embed the deployed cell explorer and send postMessage config updates.

**NOTE:** This is temporary — localhost origins will be removed once we move to utilize resource data.

## Security

Low risk — postMessage transport is one-way (parent → child) with no data sent back. The worst case is view state manipulation, which requires the user to be running the local server themselves.

## Test plan

- [ ] Local cBioPortal at `http://localhost:3000` can embed deployed cell explorer and send postMessage