### PR TITLE
feat: integrate dataset catalog with auth and credential minting

### DIFF
--- a/.changeset/dataset-catalog-frontend.md
+++ b/.changeset/dataset-catalog-frontend.md
@@ -1,0 +1,6 @@
+---
+"@cbioportal-cell-explorer/zarrstore": minor
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add dataset catalog integration with credential minting for private zarr stores. ZarrStore.open() and AnnDataStore.open() accept optional overrides for auth headers. Home page shows tabbed Catalog/My URLs with status probing. UserAvatar component with popover sign-out. Support ?dataset=slug URL param and config serialization.

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -104,6 +104,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/datasources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Datasources */
+        get: operations["list_datasources_api_admin_datasources_get"];
+        put?: never;
+        /** Create Datasource */
+        post: operations["create_datasource_api_admin_datasources_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/datasources/{datasource_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Datasource */
+        put: operations["update_datasource_api_admin_datasources__datasource_id__put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/datasets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Dataset */
+        post: operations["create_dataset_api_admin_datasets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/datasets/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Dataset */
+        put: operations["update_dataset_api_admin_datasets__slug__put"];
+        post?: never;
+        /** Delete Dataset */
+        delete: operations["delete_dataset_api_admin_datasets__slug__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -138,10 +208,185 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/datasets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Datasets
+         * @description List datasets the caller can access.
+         */
+        get: operations["list_datasets_api_datasets_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/datasets/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dataset
+         * @description Get a single dataset by slug.
+         */
+        get: operations["get_dataset_api_datasets__slug__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/datasets/{slug}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Access Dataset
+         * @description Get access credentials for a dataset.
+         */
+        post: operations["access_dataset_api_datasets__slug__access_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** DatasetAdminResponse */
+        DatasetAdminResponse: {
+            /** Id */
+            id: string;
+            /** Datasource Id */
+            datasource_id: string;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            /** Path */
+            path: string;
+            /** Description */
+            description: string | null;
+            /** Is Public */
+            is_public: boolean;
+            /** Required Roles */
+            required_roles: string[];
+        };
+        /** DatasetCreate */
+        DatasetCreate: {
+            /** Datasource Id */
+            datasource_id: string;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            /** Path */
+            path: string;
+            /** Description */
+            description?: string | null;
+            /**
+             * Is Public
+             * @default false
+             */
+            is_public: boolean;
+            /**
+             * Required Roles
+             * @default []
+             */
+            required_roles: string[];
+        };
+        /** DatasetListResponse */
+        DatasetListResponse: {
+            /** Datasets */
+            datasets: components["schemas"]["DatasetResponse"][];
+        };
+        /** DatasetResponse */
+        DatasetResponse: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Is Public */
+            is_public: boolean;
+            /** Url */
+            url: string | null;
+        };
+        /** DatasetUpdate */
+        DatasetUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Path */
+            path?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Is Public */
+            is_public?: boolean | null;
+            /** Required Roles */
+            required_roles?: string[] | null;
+        };
+        /** DatasourceCreate */
+        DatasourceCreate: {
+            /** Name */
+            name: string;
+            type: components["schemas"]["DatasourceType"];
+            /** Base Url */
+            base_url: string;
+            /** Credential Ref */
+            credential_ref?: string | null;
+        };
+        /** DatasourceListResponse */
+        DatasourceListResponse: {
+            /** Datasources */
+            datasources: components["schemas"]["DatasourceResponse"][];
+        };
+        /** DatasourceResponse */
+        DatasourceResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            type: components["schemas"]["DatasourceType"];
+            /** Base Url */
+            base_url: string;
+            /** Credential Ref */
+            credential_ref: string | null;
+        };
+        /**
+         * DatasourceType
+         * @description Supported datasource types.
+         * @enum {string}
+         */
+        DatasourceType: "s3_cloudfront" | "http_token";
+        /** DatasourceUpdate */
+        DatasourceUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Base Url */
+            base_url?: string | null;
+            /** Credential Ref */
+            credential_ref?: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -309,6 +554,191 @@ export interface operations {
             };
         };
     };
+    list_datasources_api_admin_datasources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasourceListResponse"];
+                };
+            };
+        };
+    };
+    create_datasource_api_admin_datasources_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DatasourceCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasourceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_datasource_api_admin_datasources__datasource_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                datasource_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DatasourceUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasourceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_dataset_api_admin_datasets_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DatasetCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetAdminResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_dataset_api_admin_datasets__slug__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DatasetUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetAdminResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_dataset_api_admin_datasets__slug__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     health_api_health_get: {
         parameters: {
             query?: never;
@@ -345,6 +775,90 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InfoResponse"];
+                };
+            };
+        };
+    };
+    list_datasets_api_datasets_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetListResponse"];
+                };
+            };
+        };
+    };
+    get_dataset_api_datasets__slug__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    access_dataset_api_datasets__slug__access_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/packages/highperformer/src/App.tsx
+++ b/packages/highperformer/src/App.tsx
@@ -15,12 +15,22 @@ const ENABLE_ZARR_VIEW = import.meta.env.VITE_ENABLE_ZARR_VIEW === 'true'
 function App() {
   const probeBackend = useAppStore((s) => s.probeBackend)
   const checkAuth = useAppStore((s) => s.checkAuth)
+  const fetchCatalog = useAppStore((s) => s.fetchCatalog)
+  const user = useAppStore((s) => s.user)
+
   useEffect(() => {
     probeBackend().then(() => {
       const { backendInfo } = useAppStore.getState()
+      if (backendInfo) fetchCatalog()
       if (backendInfo?.auth_enabled) checkAuth()
     })
-  }, [probeBackend, checkAuth])
+  }, [probeBackend, checkAuth, fetchCatalog])
+
+  // Re-fetch catalog when auth state changes
+  useEffect(() => {
+    const { backendInfo } = useAppStore.getState()
+    if (backendInfo) fetchCatalog()
+  }, [user, fetchCatalog])
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>

--- a/packages/highperformer/src/components/UserAvatar.tsx
+++ b/packages/highperformer/src/components/UserAvatar.tsx
@@ -1,0 +1,87 @@
+import { Button, Popover, Typography } from 'antd'
+import { LoginOutlined, LogoutOutlined } from '@ant-design/icons'
+import useAppStore from '../store/useAppStore'
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+interface UserAvatarProps {
+  /** Show the display name next to the avatar */
+  showName?: boolean
+}
+
+export default function UserAvatar({ showName = false }: UserAvatarProps) {
+  const backendInfo = useAppStore((s) => s.backendInfo)
+  const authChecked = useAppStore((s) => s.authChecked)
+  const user = useAppStore((s) => s.user)
+  const logout = useAppStore((s) => s.logout)
+
+  if (!backendInfo?.auth_enabled || !authChecked) return null
+
+  if (!user) {
+    return (
+      <Button
+        type="text"
+        size="small"
+        icon={<LoginOutlined />}
+        onClick={() => { window.location.href = '/api/auth/login' }}
+        style={{ fontSize: 12, color: '#1677ff', padding: 0 }}
+      >
+        Sign in
+      </Button>
+    )
+  }
+
+  const displayName = user.name ?? user.email ?? user.sub
+  const initials = getInitials(displayName)
+
+  const popoverContent = (
+    <div style={{ minWidth: 140 }}>
+      <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 2 }}>{displayName}</div>
+      {user.email && user.email !== displayName && (
+        <div style={{ fontSize: 11, color: '#999', marginBottom: 8 }}>{user.email}</div>
+      )}
+      <Button
+        type="text"
+        size="small"
+        icon={<LogoutOutlined />}
+        onClick={() => logout()}
+        style={{ fontSize: 12, color: '#999', padding: 0 }}
+      >
+        Sign out
+      </Button>
+    </div>
+  )
+
+  return (
+    <Popover content={popoverContent} trigger="click" placement="bottomRight">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+        <div
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: '50%',
+            background: '#1677ff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          {initials}
+        </div>
+        {showName && (
+          <Typography.Text style={{ fontSize: 12 }}>{displayName}</Typography.Text>
+        )}
+      </div>
+    </Popover>
+  )
+}

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -17,7 +17,11 @@ export async function applyConfig(config: AppConfig): Promise<void> {
   // openDataset early-returns if the URL matches the current dataset.
   // In that case, metadata may already be available — waitForStore
   // handles this by checking the predicate immediately before subscribing.
-  store.getState().openDataset(config.url)
+  if (config.dataset) {
+    await store.getState().openCatalogDataset(config.dataset)
+  } else if (config.url) {
+    store.getState().openDataset(config.url)
+  }
 
   // Phase 3: Wait for dataset metadata, then apply remaining config
   const hasPostLoadConfig =

--- a/packages/highperformer/src/config/buildConfig.ts
+++ b/packages/highperformer/src/config/buildConfig.ts
@@ -7,7 +7,9 @@ export function buildConfigFromState(): AppConfig | null {
   if (!state.datasetUrl) return null
 
   const config: Record<string, unknown> = {
-    url: state.datasetUrl,
+    ...(state.datasetSlug
+      ? { dataset: state.datasetSlug }
+      : { url: state.datasetUrl }),
     showHeader: state.showHeader,
     showLeftSidebar: state.showLeftSidebar,
     showRightSidebar: state.showRightSidebar,
@@ -49,5 +51,9 @@ export function buildConfigUrl(config: AppConfig): string {
 
 export function buildDatasetUrl(datasetUrl: string): string {
   const base = `${window.location.origin}${import.meta.env.BASE_URL}`
+  const slug = useAppStore.getState().datasetSlug
+  if (slug) {
+    return `${base}view?dataset=${encodeURIComponent(slug)}`
+  }
   return `${base}view?url=${datasetUrl}`
 }

--- a/packages/highperformer/src/config/parseConfig.test.ts
+++ b/packages/highperformer/src/config/parseConfig.test.ts
@@ -35,7 +35,7 @@ describe('parseConfig', () => {
 
   it('returns null and warns on invalid schema', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const json = JSON.stringify({ embedding: 'X_umap' }) // missing url
+    const json = JSON.stringify({ showHeader: 'not-a-boolean' }) // invalid type, no url or dataset
     const result = parseConfig(json)
     expect(result).toBeNull()
     expect(warn).toHaveBeenCalled()

--- a/packages/highperformer/src/config/schema.test.ts
+++ b/packages/highperformer/src/config/schema.test.ts
@@ -10,9 +10,18 @@ describe('AppConfigSchema', () => {
     }
   })
 
-  it('rejects config without url', () => {
+  it('rejects config without url or dataset', () => {
     const result = AppConfigSchema.safeParse({ embedding: 'X_umap' })
     expect(result.success).toBe(false)
+  })
+
+  it('validates a config with dataset slug instead of url', () => {
+    const result = AppConfigSchema.safeParse({ dataset: 'pbmc3k-private' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.dataset).toBe('pbmc3k-private')
+      expect(result.data.url).toBeUndefined()
+    }
   })
 
   it('validates a full config', () => {
@@ -134,7 +143,7 @@ describe('MessageSchema', () => {
   it('rejects message with invalid payload', () => {
     const result = MessageSchema.safeParse({
       type: 'applyConfig',
-      payload: { embedding: 'X_umap' }, // missing url
+      payload: { embedding: 'X_umap' }, // missing url and dataset
     })
     expect(result.success).toBe(false)
   })

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -6,7 +6,8 @@ const FilterSchema = z.object({
 })
 
 const RawConfigSchema = z.object({
-  url: z.string(),
+  url: z.string().optional(),
+  dataset: z.string().optional(),
   embedding: z.string().optional(),
   colorBy: z.enum(['gene', 'category']).optional(),
   gene: z.string().optional(),
@@ -19,6 +20,8 @@ const RawConfigSchema = z.object({
   showLeftSidebar: z.boolean().default(true),
   showRightSidebar: z.boolean().default(true),
   showDatasetDropdown: z.boolean().default(true),
+}).refine((data) => data.url || data.dataset, {
+  message: 'Either "url" or "dataset" must be provided',
 })
 
 export const AppConfigSchema = RawConfigSchema.transform((data) => {

--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -81,6 +81,22 @@ function CatalogTab() {
               <List.Item
                 style={{ cursor: 'pointer' }}
                 onClick={() => handleOpen(item.slug)}
+                actions={item.url ? [
+                  ...(ENABLE_ZARR_VIEW ? [
+                    <Tooltip key="inspect" title="Inspect Zarr structure">
+                      <Link to={`/zarr_view?url=${encodeURIComponent(item.url)}`} onClick={(e) => e.stopPropagation()}>
+                        <Button type="text" icon={<ApartmentOutlined />} />
+                      </Link>
+                    </Tooltip>,
+                  ] : []),
+                  <Tooltip key="copy" title="Copy zarr URL">
+                    <Button
+                      type="text"
+                      icon={<LinkOutlined />}
+                      onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(item.url!) }}
+                    />
+                  </Tooltip>,
+                ] : []}
               >
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
                   {item.url && probe ? (

--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -32,6 +32,37 @@ function CatalogTab() {
   const backendInfo = useAppStore((s) => s.backendInfo)
   const user = useAppStore((s) => s.user)
   const navigate = useNavigate()
+  const [probeResults, setProbeResults] = useState<Map<string, ProbeResult>>(new Map())
+
+  // Probe public datasets for accessibility
+  useEffect(() => {
+    const controller = new AbortController()
+    const publicUrls = catalogDatasets.filter((d) => d.url).map((d) => d.url!)
+
+    for (const url of publicUrls) {
+      setProbeResults((prev) => {
+        if (prev.has(url)) return prev
+        const next = new Map(prev)
+        next.set(url, { status: 'pending' })
+        return next
+      })
+
+      probeStore(url, controller.signal)
+        .then((result) => {
+          if (controller.signal.aborted) return
+          setProbeResults((prev) => new Map(prev).set(url, result.ok
+            ? { status: 'ok', version: result.version }
+            : { status: 'error' },
+          ))
+        })
+        .catch(() => {
+          if (controller.signal.aborted) return
+          setProbeResults((prev) => new Map(prev).set(url, { status: 'error' }))
+        })
+    }
+
+    return () => controller.abort()
+  }, [catalogDatasets])
 
   const handleOpen = async (slug: string) => {
     await openCatalogDataset(slug)
@@ -44,28 +75,46 @@ function CatalogTab() {
         <List
           bordered
           dataSource={catalogDatasets}
-          renderItem={(item) => (
-            <List.Item
-              style={{ cursor: 'pointer' }}
-              onClick={() => handleOpen(item.slug)}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
-                <div style={{ flex: 1 }}>
-                  <Typography.Text strong>{item.name}</Typography.Text>
-                  {item.description && (
-                    <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
+          renderItem={(item) => {
+            const probe = item.url ? probeResults.get(item.url) : undefined
+            return (
+              <List.Item
+                style={{ cursor: 'pointer' }}
+                onClick={() => handleOpen(item.slug)}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
+                  {item.url && probe ? (
+                    <Tooltip title={probeTooltip(probe)}>
+                      <StatusIcon status={probe.status} />
+                    </Tooltip>
+                  ) : !item.url ? (
+                    <Tooltip title="Sign in to access">
+                      <LockOutlined style={{ fontSize: 14, color: '#faad14' }} />
+                    </Tooltip>
+                  ) : null}
+                  <div style={{ flex: 1 }}>
+                    <Typography.Text strong>{item.name}</Typography.Text>
+                    {item.description && (
+                      <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
+                    )}
+                    {item.url && (
+                      <div><Typography.Text type="secondary" style={{ fontSize: 11, fontFamily: 'monospace' }}>{item.url}</Typography.Text></div>
+                    )}
+                  </div>
+                  <Tag
+                    color={item.is_public ? 'green' : 'orange'}
+                    icon={item.is_public ? <GlobalOutlined /> : <LockOutlined />}
+                    style={{ fontSize: 11, margin: 0 }}
+                  >
+                    {item.is_public ? 'public' : 'private'}
+                  </Tag>
+                  {probe?.status === 'ok' && probe.version && (
+                    <Tag color="default" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>v{probe.version}</Tag>
                   )}
                 </div>
-                <Tag
-                  color={item.is_public ? 'green' : 'orange'}
-                  icon={item.is_public ? <GlobalOutlined /> : <LockOutlined />}
-                  style={{ fontSize: 11, margin: 0 }}
-                >
-                  {item.is_public ? 'public' : 'private'}
-                </Tag>
-              </div>
-            </List.Item>
-          )}
+              </List.Item>
+            )
+          }}
         />
       ) : (
         <Typography.Text type="secondary">

--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { Input, Button, List, Tag, Tooltip, Typography, Tabs } from 'antd'
-import { ApartmentOutlined, CheckCircleOutlined, CopyOutlined, DeleteOutlined, ExclamationCircleOutlined, LinkOutlined, LoadingOutlined, LockOutlined, GlobalOutlined } from '@ant-design/icons'
+import { Input, Button, List, Tooltip, Typography, Tabs } from 'antd'
+import { ApartmentOutlined, CopyOutlined, DeleteOutlined, LinkOutlined } from '@ant-design/icons'
 import { loadDatasets, saveDatasets } from '../utils/datasets'
 import { probeStore } from '../utils/datasetProbe'
 import useAppStore from '../store/useAppStore'
@@ -14,16 +14,42 @@ interface ProbeResult {
   version?: number
 }
 
-const StatusIcon = ({ status }: { status: ProbeResult['status'] }) => {
-  if (status === 'pending') return <LoadingOutlined style={{ fontSize: 14, color: '#d9d9d9' }} />
-  if (status === 'ok') return <CheckCircleOutlined style={{ fontSize: 14, color: '#52c41a' }} />
-  return <ExclamationCircleOutlined style={{ fontSize: 14, color: '#ff4d4f' }} />
+function StatusLine({ probe, isPublic }: { probe?: ProbeResult; isPublic: boolean }) {
+  const accessLabel = isPublic ? 'Public' : 'Private'
+  const accessColor = isPublic ? '#52c41a' : '#faad14'
+
+  let reachLabel: string
+  let reachColor: string
+  if (!probe) {
+    reachLabel = isPublic ? '' : 'Requires authentication'
+    reachColor = '#999'
+  } else if (probe.status === 'pending') {
+    reachLabel = 'Checking...'
+    reachColor = '#999'
+  } else if (probe.status === 'ok') {
+    reachLabel = probe.version ? `Reachable (v${probe.version})` : 'Reachable'
+    reachColor = '#52c41a'
+  } else {
+    reachLabel = 'Unreachable'
+    reachColor = '#ff4d4f'
+  }
+
+  return (
+    <div style={{ fontSize: 11, marginTop: 4 }}>
+      <span style={{ color: accessColor }}>● {accessLabel}</span>
+      {reachLabel && (
+        <>
+          <span style={{ color: '#ccc', margin: '0 6px' }}>·</span>
+          <span style={{ color: reachColor }}>{reachLabel}</span>
+        </>
+      )}
+    </div>
+  )
 }
 
-function probeTooltip(result: ProbeResult): string {
-  if (result.status === 'pending') return 'Checking...'
-  if (result.status === 'error') return 'Unreachable — check CORS, URL, or permissions'
-  return `Accessible (Zarr v${result.version})`
+interface ResolvedAccess {
+  url: string
+  token?: string
 }
 
 function CatalogTab() {
@@ -33,40 +59,89 @@ function CatalogTab() {
   const user = useAppStore((s) => s.user)
   const navigate = useNavigate()
   const [probeResults, setProbeResults] = useState<Map<string, ProbeResult>>(new Map())
+  const [resolvedAccess, setResolvedAccess] = useState<Map<string, ResolvedAccess>>(new Map())
 
-  // Probe public datasets for accessibility
+  // Resolve access for private datasets, then probe all datasets
   useEffect(() => {
     const controller = new AbortController()
-    const publicUrls = catalogDatasets.filter((d) => d.url).map((d) => d.url!)
 
-    for (const url of publicUrls) {
-      setProbeResults((prev) => {
-        if (prev.has(url)) return prev
-        const next = new Map(prev)
-        next.set(url, { status: 'pending' })
-        return next
-      })
+    // Probe public datasets directly
+    for (const ds of catalogDatasets) {
+      if (ds.url) {
+        const url = ds.url
+        setProbeResults((prev) => {
+          if (prev.has(ds.slug)) return prev
+          return new Map(prev).set(ds.slug, { status: 'pending' })
+        })
+        setResolvedAccess((prev) => new Map(prev).set(ds.slug, { url }))
 
-      probeStore(url, controller.signal)
-        .then((result) => {
-          if (controller.signal.aborted) return
-          setProbeResults((prev) => new Map(prev).set(url, result.ok
-            ? { status: 'ok', version: result.version }
-            : { status: 'error' },
-          ))
-        })
-        .catch(() => {
-          if (controller.signal.aborted) return
-          setProbeResults((prev) => new Map(prev).set(url, { status: 'error' }))
-        })
+        probeStore(url, controller.signal)
+          .then((result) => {
+            if (controller.signal.aborted) return
+            setProbeResults((prev) => new Map(prev).set(ds.slug, result.ok
+              ? { status: 'ok', version: result.version }
+              : { status: 'error' },
+            ))
+          })
+          .catch(() => {
+            if (controller.signal.aborted) return
+            setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
+          })
+      }
     }
 
+    // Resolve private datasets via /access, then probe with token
+    const resolvePrivate = async () => {
+      const { api } = await import('../api')
+      for (const ds of catalogDatasets) {
+        if (ds.url || controller.signal.aborted) continue
+
+        setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'pending' }))
+
+        try {
+          const { data } = await api.POST('/api/datasets/{slug}/access', {
+            params: { path: { slug: ds.slug } },
+          })
+          if (controller.signal.aborted || !data) continue
+
+          const access: ResolvedAccess = { url: data.url }
+          if (data.credential_type === 'bearer_token' && data.token) {
+            access.token = data.token
+          }
+          setResolvedAccess((prev) => new Map(prev).set(ds.slug, access))
+
+          // Probe with auth headers if needed
+          const headers: Record<string, string> = {}
+          if (access.token) {
+            headers['Authorization'] = `Bearer ${access.token}`
+          }
+
+          try {
+            const result = await probeStore(data.url, controller.signal, Object.keys(headers).length > 0 ? headers : undefined)
+            if (controller.signal.aborted) continue
+            setProbeResults((prev) => new Map(prev).set(ds.slug, result.ok
+              ? { status: 'ok', version: result.version }
+              : { status: 'error' },
+            ))
+          } catch {
+            if (!controller.signal.aborted) {
+              setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
+            }
+          }
+        } catch {
+          if (!controller.signal.aborted) {
+            setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
+          }
+        }
+      }
+    }
+
+    resolvePrivate()
     return () => controller.abort()
   }, [catalogDatasets])
 
-  const handleOpen = async (slug: string) => {
-    await openCatalogDataset(slug)
-    navigate('/view')
+  const handleOpen = (slug: string) => {
+    navigate(`/view?dataset=${encodeURIComponent(slug)}`)
   }
 
   return (
@@ -76,15 +151,17 @@ function CatalogTab() {
           bordered
           dataSource={catalogDatasets}
           renderItem={(item) => {
-            const probe = item.url ? probeResults.get(item.url) : undefined
+            const probe = probeResults.get(item.slug)
+            const access = resolvedAccess.get(item.slug)
+            const displayUrl = item.url ?? access?.url
             return (
               <List.Item
                 style={{ cursor: 'pointer' }}
                 onClick={() => handleOpen(item.slug)}
-                actions={item.url ? [
+                actions={displayUrl ? [
                   ...(ENABLE_ZARR_VIEW ? [
                     <Tooltip key="inspect" title="Inspect Zarr structure">
-                      <Link to={`/zarr_view?url=${encodeURIComponent(item.url)}`} onClick={(e) => e.stopPropagation()}>
+                      <Link to={`/zarr_view?url=${encodeURIComponent(displayUrl)}`} onClick={(e) => e.stopPropagation()}>
                         <Button type="text" icon={<ApartmentOutlined />} />
                       </Link>
                     </Tooltip>,
@@ -93,40 +170,20 @@ function CatalogTab() {
                     <Button
                       type="text"
                       icon={<LinkOutlined />}
-                      onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(item.url!) }}
+                      onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(displayUrl) }}
                     />
                   </Tooltip>,
                 ] : []}
               >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
-                  {item.url && probe ? (
-                    <Tooltip title={probeTooltip(probe)}>
-                      <StatusIcon status={probe.status} />
-                    </Tooltip>
-                  ) : !item.url ? (
-                    <Tooltip title="Sign in to access">
-                      <LockOutlined style={{ fontSize: 14, color: '#faad14' }} />
-                    </Tooltip>
-                  ) : null}
-                  <div style={{ flex: 1 }}>
-                    <Typography.Text strong>{item.name}</Typography.Text>
-                    {item.description && (
-                      <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
-                    )}
-                    {item.url && (
-                      <div><Typography.Text type="secondary" style={{ fontSize: 11, fontFamily: 'monospace' }}>{item.url}</Typography.Text></div>
-                    )}
-                  </div>
-                  <Tag
-                    color={item.is_public ? 'green' : 'orange'}
-                    icon={item.is_public ? <GlobalOutlined /> : <LockOutlined />}
-                    style={{ fontSize: 11, margin: 0 }}
-                  >
-                    {item.is_public ? 'public' : 'private'}
-                  </Tag>
-                  {probe?.status === 'ok' && probe.version && (
-                    <Tag color="default" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>v{probe.version}</Tag>
+                <div style={{ flex: 1 }}>
+                  <Typography.Text strong>{item.name}</Typography.Text>
+                  {item.description && (
+                    <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
                   )}
+                  {displayUrl && (
+                    <div><Typography.Text type="secondary" style={{ fontSize: 11, fontFamily: 'monospace' }}>{displayUrl}</Typography.Text></div>
+                  )}
+                  <StatusLine probe={probe} isPublic={item.is_public} />
                 </div>
               </List.Item>
             )
@@ -251,19 +308,11 @@ function MyUrlsTab() {
                   />,
                 ]}
               >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                  <Tooltip title={probeTooltip(result)}>
-                    <StatusIcon status={result.status} />
-                  </Tooltip>
+                <div style={{ flex: 1 }}>
                   <Link to={`/view?url=${encodeURIComponent(item)}`}>
                     <Typography.Text>{item}</Typography.Text>
                   </Link>
-                  {result.status === 'ok' && result.version && (
-                    <Tag color="default" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>v{result.version}</Tag>
-                  )}
-                  {result.status === 'error' && (
-                    <Tag color="error" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>unreachable</Tag>
-                  )}
+                  <StatusLine probe={result} isPublic={true} />
                 </div>
               </List.Item>
             )
@@ -278,6 +327,32 @@ function MyUrlsTab() {
 
 function Home() {
   const backendInfo = useAppStore((s) => s.backendInfo)
+  const [activeTab, setActiveTab] = useState('catalog')
+  const [backendProbed, setBackendProbed] = useState(false)
+
+  useEffect(() => {
+    // Wait for probeBackend to finish before rendering layout
+    const check = () => {
+      const { backendInfo } = useAppStore.getState()
+      // backendInfo is set (backend found) or authChecked is true (probe finished, no backend)
+      if (backendInfo !== null || useAppStore.getState().authChecked) {
+        setBackendProbed(true)
+      }
+    }
+    check()
+    const unsub = useAppStore.subscribe(check)
+    return unsub
+  }, [])
+
+  if (!backendProbed) {
+    return (
+      <div style={{ maxWidth: 960 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+          <h2 style={{ margin: 0 }}>Datasets</h2>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div style={{ maxWidth: 960 }}>
@@ -288,7 +363,8 @@ function Home() {
 
       {backendInfo ? (
         <Tabs
-          defaultActiveKey="catalog"
+          activeKey={activeTab}
+          onChange={setActiveTab}
           items={[
             { key: 'catalog', label: 'Catalog', children: <CatalogTab /> },
             { key: 'urls', label: 'My URLs', children: <MyUrlsTab /> },

--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
-import { Input, Button, List, Tag, Tooltip, Typography } from 'antd'
-import { ApartmentOutlined, CheckCircleOutlined, CopyOutlined, DeleteOutlined, ExclamationCircleOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons'
+import { Link, useNavigate } from 'react-router-dom'
+import { Input, Button, List, Tag, Tooltip, Typography, Tabs } from 'antd'
+import { ApartmentOutlined, CheckCircleOutlined, CopyOutlined, DeleteOutlined, ExclamationCircleOutlined, LinkOutlined, LoadingOutlined, LockOutlined, GlobalOutlined } from '@ant-design/icons'
 import { loadDatasets, saveDatasets } from '../utils/datasets'
-import { probeStore, isLocalUrl } from '../utils/datasetProbe'
+import { probeStore } from '../utils/datasetProbe'
+import useAppStore from '../store/useAppStore'
+import UserAvatar from '../components/UserAvatar'
 
 const ENABLE_ZARR_VIEW = import.meta.env.VITE_ENABLE_ZARR_VIEW === 'true'
 
@@ -24,83 +26,59 @@ function probeTooltip(result: ProbeResult): string {
   return `Accessible (Zarr v${result.version})`
 }
 
-interface DatasetListProps {
-  title: string
-  datasets: string[]
-  probeResults: Map<string, ProbeResult>
-  onRemove: (url: string) => void
-}
+function CatalogTab() {
+  const catalogDatasets = useAppStore((s) => s.catalogDatasets)
+  const openCatalogDataset = useAppStore((s) => s.openCatalogDataset)
+  const backendInfo = useAppStore((s) => s.backendInfo)
+  const user = useAppStore((s) => s.user)
+  const navigate = useNavigate()
 
-function DatasetList({ title, datasets, probeResults, onRemove }: DatasetListProps) {
-  if (datasets.length === 0) return null
+  const handleOpen = async (slug: string) => {
+    await openCatalogDataset(slug)
+    navigate('/view')
+  }
 
   return (
-    <div style={{ marginBottom: 24 }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-        <Typography.Text strong>{title}</Typography.Text>
-        <Tooltip title="Copy all URLs">
-          <Button
-            type="text"
-            size="small"
-            icon={<CopyOutlined />}
-            onClick={() => navigator.clipboard.writeText(datasets.join('\n'))}
-          />
-        </Tooltip>
-      </div>
-      <List
-        bordered
-        dataSource={datasets}
-        renderItem={(item) => {
-          const result = probeResults.get(item) ?? { status: 'pending' as const }
-          return (
+    <div>
+      {catalogDatasets.length > 0 ? (
+        <List
+          bordered
+          dataSource={catalogDatasets}
+          renderItem={(item) => (
             <List.Item
-              actions={[
-                ...(ENABLE_ZARR_VIEW ? [
-                  <Tooltip key="inspect" title="Inspect Zarr structure">
-                    <Link to={`/zarr_view?url=${encodeURIComponent(item)}`}>
-                      <Button type="text" icon={<ApartmentOutlined />} />
-                    </Link>
-                  </Tooltip>,
-                ] : []),
-                <Tooltip key="copy" title="Copy zarr URL">
-                  <Button
-                    type="text"
-                    icon={<LinkOutlined />}
-                    onClick={() => navigator.clipboard.writeText(item)}
-                  />
-                </Tooltip>,
-                <Button
-                  key="delete"
-                  type="text"
-                  danger
-                  icon={<DeleteOutlined />}
-                  onClick={() => onRemove(item)}
-                />,
-              ]}
+              style={{ cursor: 'pointer' }}
+              onClick={() => handleOpen(item.slug)}
             >
-              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                <Tooltip title={probeTooltip(result)}>
-                  <StatusIcon status={result.status} />
-                </Tooltip>
-                <Link to={`/view?url=${encodeURIComponent(item)}`}>
-                  <Typography.Text>{item}</Typography.Text>
-                </Link>
-                {result.status === 'ok' && result.version && (
-                  <Tag color="default" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>v{result.version}</Tag>
-                )}
-                {result.status === 'error' && (
-                  <Tag color="error" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>unreachable</Tag>
-                )}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
+                <div style={{ flex: 1 }}>
+                  <Typography.Text strong>{item.name}</Typography.Text>
+                  {item.description && (
+                    <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
+                  )}
+                </div>
+                <Tag
+                  color={item.is_public ? 'green' : 'orange'}
+                  icon={item.is_public ? <GlobalOutlined /> : <LockOutlined />}
+                  style={{ fontSize: 11, margin: 0 }}
+                >
+                  {item.is_public ? 'public' : 'private'}
+                </Tag>
               </div>
             </List.Item>
-          )
-        }}
-      />
+          )}
+        />
+      ) : (
+        <Typography.Text type="secondary">
+          {!user && backendInfo?.auth_enabled
+            ? 'Sign in to see more datasets'
+            : 'No datasets available'}
+        </Typography.Text>
+      )}
     </div>
   )
 }
 
-function Home() {
+function MyUrlsTab() {
   const [url, setUrl] = useState('')
   const [datasets, setDatasets] = useState<string[]>(loadDatasets)
   const [probeResults, setProbeResults] = useState<Map<string, ProbeResult>>(new Map())
@@ -109,7 +87,6 @@ function Home() {
     saveDatasets(datasets)
   }, [datasets])
 
-  // Probe all datasets on mount and when list changes
   useEffect(() => {
     const controller = new AbortController()
 
@@ -135,7 +112,6 @@ function Home() {
         })
     }
 
-    // Clean up probes for removed datasets
     setProbeResults((prev) => {
       const dsSet = new Set(datasets)
       let changed = false
@@ -148,9 +124,6 @@ function Home() {
 
     return () => controller.abort()
   }, [datasets])
-
-  const localDatasets = useMemo(() => datasets.filter(isLocalUrl), [datasets])
-  const remoteDatasets = useMemo(() => datasets.filter((d) => !isLocalUrl(d)), [datasets])
 
   const handleAdd = () => {
     const urls = url.split(/[\n,]+/).map((u) => u.trim()).filter(Boolean)
@@ -166,9 +139,8 @@ function Home() {
   }
 
   return (
-    <div style={{ maxWidth: 960 }}>
-      <h2>Datasets</h2>
-      <div style={{ display: 'flex', gap: 8, marginBottom: 24 }}>
+    <div>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
         <Input.TextArea
           placeholder="Paste one or more .zarr URLs (one per line or comma-separated)"
           value={url}
@@ -182,21 +154,83 @@ function Home() {
         </Button>
       </div>
 
-      <DatasetList
-        title="Remote"
-        datasets={remoteDatasets}
-        probeResults={probeResults}
-        onRemove={handleRemove}
-      />
-      <DatasetList
-        title="Local"
-        datasets={localDatasets}
-        probeResults={probeResults}
-        onRemove={handleRemove}
-      />
+      {datasets.length > 0 ? (
+        <List
+          bordered
+          dataSource={datasets}
+          renderItem={(item) => {
+            const result = probeResults.get(item) ?? { status: 'pending' as const }
+            return (
+              <List.Item
+                actions={[
+                  ...(ENABLE_ZARR_VIEW ? [
+                    <Tooltip key="inspect" title="Inspect Zarr structure">
+                      <Link to={`/zarr_view?url=${encodeURIComponent(item)}`}>
+                        <Button type="text" icon={<ApartmentOutlined />} />
+                      </Link>
+                    </Tooltip>,
+                  ] : []),
+                  <Tooltip key="copy" title="Copy zarr URL">
+                    <Button
+                      type="text"
+                      icon={<LinkOutlined />}
+                      onClick={() => navigator.clipboard.writeText(item)}
+                    />
+                  </Tooltip>,
+                  <Button
+                    key="delete"
+                    type="text"
+                    danger
+                    icon={<DeleteOutlined />}
+                    onClick={() => handleRemove(item)}
+                  />,
+                ]}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <Tooltip title={probeTooltip(result)}>
+                    <StatusIcon status={result.status} />
+                  </Tooltip>
+                  <Link to={`/view?url=${encodeURIComponent(item)}`}>
+                    <Typography.Text>{item}</Typography.Text>
+                  </Link>
+                  {result.status === 'ok' && result.version && (
+                    <Tag color="default" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>v{result.version}</Tag>
+                  )}
+                  {result.status === 'error' && (
+                    <Tag color="error" style={{ fontSize: 11, lineHeight: '18px', margin: 0 }}>unreachable</Tag>
+                  )}
+                </div>
+              </List.Item>
+            )
+          }}
+        />
+      ) : (
+        <Typography.Text type="secondary">No URLs added yet</Typography.Text>
+      )}
+    </div>
+  )
+}
 
-      {datasets.length === 0 && (
-        <Typography.Text type="secondary">No datasets added yet</Typography.Text>
+function Home() {
+  const backendInfo = useAppStore((s) => s.backendInfo)
+
+  return (
+    <div style={{ maxWidth: 960 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+        <h2 style={{ margin: 0 }}>Datasets</h2>
+        <UserAvatar />
+      </div>
+
+      {backendInfo ? (
+        <Tabs
+          defaultActiveKey="catalog"
+          items={[
+            { key: 'catalog', label: 'Catalog', children: <CatalogTab /> },
+            { key: 'urls', label: 'My URLs', children: <MyUrlsTab /> },
+          ]}
+        />
+      ) : (
+        <MyUrlsTab />
       )}
     </div>
   )

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useNavigate, Link } from 'react-router-dom'
 import { Button, Collapse, InputNumber, Layout, Popover, Switch, Typography, Select, Spin, message } from 'antd'
-import { BgColorsOutlined, DatabaseOutlined, DotChartOutlined, HolderOutlined, InfoCircleOutlined, LeftOutlined, LinkOutlined, LoginOutlined, LogoutOutlined, RightOutlined, SettingOutlined, UserOutlined } from '@ant-design/icons'
+import { BgColorsOutlined, DatabaseOutlined, DotChartOutlined, HolderOutlined, InfoCircleOutlined, LeftOutlined, LinkOutlined, RightOutlined, SettingOutlined } from '@ant-design/icons'
 import { DeckGL } from '@deck.gl/react'
 import { OrthographicView } from '@deck.gl/core'
 import { PolygonLayer, ScatterplotLayer } from '@deck.gl/layers'
@@ -15,6 +15,7 @@ import { usePostMessage } from '../config/usePostMessage'
 import { parseConfig } from '../config/parseConfig'
 import { applyConfig } from '../config/applyConfig'
 import { DatasetError } from '../components/DatasetError'
+import UserAvatar from '../components/UserAvatar'
 import ColorBySection from '../components/ColorBySection'
 import SelectionOverlay from '../components/SelectionOverlay'
 import SelectionToolbar from '../components/SelectionToolbar'
@@ -160,15 +161,9 @@ const collapsedIconStyle: React.CSSProperties = {
 }
 
 function CollapsedAuthIcon() {
-  const backendInfo = useAppStore((s) => s.backendInfo)
-  const authChecked = useAppStore((s) => s.authChecked)
-  const user = useAppStore((s) => s.user)
-
-  if (!backendInfo?.auth_enabled || !authChecked) return null
-
   return (
     <div style={{ ...collapsedIconStyle, paddingBottom: 12 }}>
-      {user ? <UserOutlined /> : <LoginOutlined />}
+      <UserAvatar />
     </div>
   )
 }
@@ -227,45 +222,9 @@ function InfoPopoverContent() {
 }
 
 function AuthSection() {
-  const backendInfo = useAppStore((s) => s.backendInfo)
-  const authChecked = useAppStore((s) => s.authChecked)
-  const user = useAppStore((s) => s.user)
-  const logout = useAppStore((s) => s.logout)
-
-  if (!backendInfo?.auth_enabled || !authChecked) return null
-
-  if (!user) {
-    return (
-      <div style={{ padding: '8px 16px', borderTop: '1px solid #f0f0f0' }}>
-        <Button
-          type="text"
-          size="small"
-          icon={<LoginOutlined />}
-          onClick={() => { window.location.href = '/api/auth/login' }}
-          style={{ fontSize: 12, color: '#1677ff', padding: 0 }}
-        >
-          Sign in
-        </Button>
-      </div>
-    )
-  }
-
-  const displayName = user.name ?? user.email ?? user.sub
-
   return (
-    <div style={{ padding: '8px 16px', borderTop: '1px solid #f0f0f0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-      <span style={{ fontSize: 12, color: '#666', display: 'flex', alignItems: 'center', gap: 6 }}>
-        <UserOutlined /> {displayName}
-      </span>
-      <Button
-        type="text"
-        size="small"
-        icon={<LogoutOutlined />}
-        onClick={() => { logout() }}
-        style={{ fontSize: 11, color: '#999', padding: 0 }}
-      >
-        Sign out
-      </Button>
+    <div style={{ padding: '8px 16px', borderTop: '1px solid #f0f0f0' }}>
+      <UserAvatar showName />
     </div>
   )
 }

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -741,7 +741,9 @@ function View() {
   const [searchParams] = useSearchParams()
   const configParam = searchParams.get('config')
   const urlParam = searchParams.get('url')
+  const datasetParam = searchParams.get('dataset')
   const openDataset = useAppStore((s) => s.openDataset)
+  const openCatalogDataset = useAppStore((s) => s.openCatalogDataset)
   const loadingError = useAppStore((s) => s.loadingError)
   const datasetUrl = useAppStore((s) => s.datasetUrl)
   const [leftCollapsed, setLeftCollapsed] = useState(false)
@@ -770,12 +772,13 @@ function View() {
     }
   }, [configParam])
 
-  // Handle ?url= param — loads dataset on initial visit and when switching via dropdown
+  // Handle ?url= or ?dataset= param — loads dataset on initial visit
   // Skipped when ?config= was used (applyConfig handles dataset loading)
   useEffect(() => {
     if (configParam) return
-    if (urlParam) openDataset(urlParam)
-  }, [urlParam, configParam, openDataset])
+    if (datasetParam) openCatalogDataset(datasetParam)
+    else if (urlParam) openDataset(urlParam)
+  }, [urlParam, datasetParam, configParam, openDataset, openCatalogDataset])
 
   if (loadingError) {
     const isEmbedded = window.self !== window.top

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1148,5 +1148,65 @@ describe('useAppStore', () => {
       await useAppStore.getState().fetchCatalog()
       expect(useAppStore.getState().catalogDatasets).toEqual([])
     })
+
+    it('openCatalogDataset opens a public dataset directly', async () => {
+      useAppStore.setState({
+        catalogDatasets: [
+          { slug: 'public-ds', name: 'Public', description: null, is_public: true, url: 'https://cdn.example.com/test.zarr' },
+        ],
+      })
+
+      const { AnnDataStore } = await import('@cbioportal-cell-explorer/zarrstore')
+      const mockOpen = vi.spyOn(AnnDataStore, 'open').mockResolvedValueOnce({
+        nObs: 100, nVar: 50, obsmKeys: () => ['X_umap'],
+      } as any)
+
+      await useAppStore.getState().openCatalogDataset('public-ds')
+      expect(mockOpen).toHaveBeenCalledWith('https://cdn.example.com/test.zarr', undefined)
+      mockOpen.mockRestore()
+    })
+
+    it('openCatalogDataset calls /access for private datasets', async () => {
+      useAppStore.setState({
+        catalogDatasets: [
+          { slug: 'private-ds', name: 'Private', description: null, is_public: false, url: null },
+        ],
+      })
+
+      mockPOST.mockResolvedValueOnce({
+        data: {
+          url: 'https://lab.example.com/private.zarr',
+          credential_type: 'bearer_token',
+          token: 'test-jwt-token',
+          expires_at: '2026-04-14T12:00:00Z',
+        },
+      })
+
+      const { AnnDataStore } = await import('@cbioportal-cell-explorer/zarrstore')
+      const mockOpen = vi.spyOn(AnnDataStore, 'open').mockResolvedValueOnce({
+        nObs: 100, nVar: 50, obsmKeys: () => ['X_umap'],
+      } as any)
+
+      await useAppStore.getState().openCatalogDataset('private-ds')
+      expect(mockPOST).toHaveBeenCalledWith('/api/datasets/{slug}/access', { params: { path: { slug: 'private-ds' } } })
+      expect(mockOpen).toHaveBeenCalledWith(
+        'https://lab.example.com/private.zarr',
+        { headers: { Authorization: 'Bearer test-jwt-token' } },
+      )
+      mockOpen.mockRestore()
+    })
+
+    it('openCatalogDataset sets error on 503', async () => {
+      useAppStore.setState({
+        catalogDatasets: [
+          { slug: 'broken-ds', name: 'Broken', description: null, is_public: false, url: null },
+        ],
+      })
+
+      mockPOST.mockResolvedValueOnce({ data: undefined, error: { detail: 'not configured' }, response: { status: 503 } })
+
+      await useAppStore.getState().openCatalogDataset('broken-ds')
+      expect(useAppStore.getState().loadingError).toContain('temporarily unavailable')
+    })
   })
 })

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1125,4 +1125,28 @@ describe('useAppStore', () => {
       expect(useAppStore.getState().user).toBeNull()
     })
   })
+
+  describe('catalog', () => {
+    it('has empty catalogDatasets initially', () => {
+      expect(useAppStore.getState().catalogDatasets).toEqual([])
+    })
+
+    it('fetchCatalog stores datasets from API', async () => {
+      const mockDatasets = [
+        { slug: 'brca-demo', name: 'BRCA Demo', description: 'Test', is_public: true, url: 'https://cdn.example.com/brca.zarr' },
+        { slug: 'private-study', name: 'Private Study', description: null, is_public: false, url: null },
+      ]
+      mockGET.mockResolvedValueOnce({ data: { datasets: mockDatasets } })
+
+      await useAppStore.getState().fetchCatalog()
+      expect(mockGET).toHaveBeenCalledWith('/api/datasets')
+      expect(useAppStore.getState().catalogDatasets).toEqual(mockDatasets)
+    })
+
+    it('fetchCatalog handles API failure gracefully', async () => {
+      mockGET.mockRejectedValueOnce(new Error('Network error'))
+      await useAppStore.getState().fetchCatalog()
+      expect(useAppStore.getState().catalogDatasets).toEqual([])
+    })
+  })
 })

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -55,6 +55,7 @@ export type SelectionGroup = SpatialSelectionGroup | CustomSelectionGroup
 export interface AppState {
   // Dataset
   datasetUrl: string | null
+  datasetSlug: string | null
   adata: AnnDataStore | null
   loading: boolean
 
@@ -273,6 +274,7 @@ const DEBOUNCE_MS = 150
 const useAppStore = create<AppState>((set, get) => ({
   // Dataset
   datasetUrl: null,
+  datasetSlug: null,
   adata: null,
   loading: false,
 
@@ -414,12 +416,33 @@ const useAppStore = create<AppState>((set, get) => ({
   },
 
   openCatalogDataset: async (slug) => {
-    const dataset = get().catalogDatasets.find((d) => d.slug === slug)
-    if (!dataset) return
+    let dataset = get().catalogDatasets.find((d) => d.slug === slug)
+
+    // If not in local catalog yet (e.g., cold start from a shared link),
+    // fetch the dataset directly from the API
+    if (!dataset) {
+      try {
+        const { api } = await import('../api')
+        const { data } = await api.GET('/api/datasets/{slug}', {
+          params: { path: { slug } },
+        })
+        if (data) {
+          dataset = data
+        } else {
+          set({ loadingError: 'Dataset not found' })
+          return
+        }
+      } catch {
+        set({ loadingError: 'Failed to load dataset' })
+        return
+      }
+    }
 
     // Public dataset — open directly
     if (dataset.url) {
-      return get().openDataset(dataset.url)
+      await get().openDataset(dataset.url)
+      set({ datasetSlug: slug })
+      return
     }
 
     // Private dataset — get access credentials
@@ -440,13 +463,16 @@ const useAppStore = create<AppState>((set, get) => ({
       }
 
       if (data.credential_type === 'bearer_token' && data.token) {
-        return get().openDataset(data.url, {
+        await get().openDataset(data.url, {
           headers: { Authorization: `Bearer ${data.token}` },
         })
+        set({ datasetSlug: slug })
+        return
       }
 
       // signed_cookies or public — no overrides needed
-      return get().openDataset(data.url)
+      await get().openDataset(data.url)
+      set({ datasetSlug: slug })
     } catch {
       set({ loadingError: 'Failed to access dataset' })
     }
@@ -930,7 +956,7 @@ const useAppStore = create<AppState>((set, get) => ({
   openDataset: async (url, overrides) => {
     if (url === get().datasetUrl && get().adata) return
     set({
-      datasetUrl: url, loading: true, loadingError: null, adata: null, nObs: null, nVar: null, obsmKeys: [],
+      datasetUrl: url, datasetSlug: null, loading: true, loadingError: null, adata: null, nObs: null, nVar: null, obsmKeys: [],
       selectedEmbedding: null, embeddingData: null, colorBuffer: null,
       colorMode: 'category', selectedObsColumn: null, selectedGene: null,
       obsColumnNames: [], varNames: [], categoryMap: [], expressionRange: null,

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -179,6 +179,16 @@ export interface AppState {
   checkAuth: () => Promise<void>
   logout: () => Promise<void>
 
+  // Dataset catalog
+  catalogDatasets: Array<{
+    slug: string
+    name: string
+    description: string | null
+    is_public: boolean
+    url: string | null
+  }>
+  fetchCatalog: () => Promise<void>
+
   // UI visibility toggles (for embedded mode)
   showHeader: boolean
   showLeftSidebar: boolean
@@ -389,6 +399,17 @@ const useAppStore = create<AppState>((set, get) => ({
       // Clear local state regardless
     }
     set({ user: null })
+  },
+
+  catalogDatasets: [],
+  fetchCatalog: async () => {
+    try {
+      const { api } = await import('../api')
+      const { data } = await api.GET('/api/datasets')
+      if (data?.datasets) set({ catalogDatasets: data.datasets })
+    } catch {
+      // Backend unavailable or request failed — keep existing catalog
+    }
   },
 
   showHeader: true,

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -199,7 +199,7 @@ export interface AppState {
   loadingError: string | null
 
   // Actions
-  openDataset: (url: string) => Promise<void>
+  openDataset: (url: string, overrides?: RequestInit) => Promise<void>
   setSelectedEmbedding: (key: string) => void
   fetchEmbedding: (key: string) => Promise<void>
   rebuildColorBuffer: () => void
@@ -887,7 +887,7 @@ const useAppStore = create<AppState>((set, get) => ({
   reorderSummaryGenes: (reordered) => set({ summaryGenes: reordered }),
 
   // Actions
-  openDataset: async (url) => {
+  openDataset: async (url, overrides) => {
     if (url === get().datasetUrl && get().adata) return
     set({
       datasetUrl: url, loading: true, loadingError: null, adata: null, nObs: null, nVar: null, obsmKeys: [],
@@ -905,7 +905,7 @@ const useAppStore = create<AppState>((set, get) => ({
       summaryCache: new Map(),
     })
     try {
-      const adata = await AnnDataStore.open(url)
+      const adata = await AnnDataStore.open(url, overrides)
       const obsmKeys = adata.obsmKeys()
       const umap = obsmKeys.find((k) => /umap/i.test(k))
       const defaultKey = umap ?? obsmKeys[0] ?? null

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -188,6 +188,7 @@ export interface AppState {
     url: string | null
   }>
   fetchCatalog: () => Promise<void>
+  openCatalogDataset: (slug: string) => Promise<void>
 
   // UI visibility toggles (for embedded mode)
   showHeader: boolean
@@ -409,6 +410,45 @@ const useAppStore = create<AppState>((set, get) => ({
       if (data?.datasets) set({ catalogDatasets: data.datasets })
     } catch {
       // Backend unavailable or request failed — keep existing catalog
+    }
+  },
+
+  openCatalogDataset: async (slug) => {
+    const dataset = get().catalogDatasets.find((d) => d.slug === slug)
+    if (!dataset) return
+
+    // Public dataset — open directly
+    if (dataset.url) {
+      return get().openDataset(dataset.url)
+    }
+
+    // Private dataset — get access credentials
+    try {
+      const { api } = await import('../api')
+      const { data, error, response } = await api.POST('/api/datasets/{slug}/access', {
+        params: { path: { slug } },
+      })
+
+      if (!data) {
+        const status = response?.status
+        if (status === 503) {
+          set({ loadingError: 'Dataset temporarily unavailable' })
+        } else {
+          set({ loadingError: error?.detail ?? 'Failed to access dataset' })
+        }
+        return
+      }
+
+      if (data.credential_type === 'bearer_token' && data.token) {
+        return get().openDataset(data.url, {
+          headers: { Authorization: `Bearer ${data.token}` },
+        })
+      }
+
+      // signed_cookies or public — no overrides needed
+      return get().openDataset(data.url)
+    } catch {
+      set({ loadingError: 'Failed to access dataset' })
     }
   },
 

--- a/packages/highperformer/src/utils/datasetProbe.ts
+++ b/packages/highperformer/src/utils/datasetProbe.ts
@@ -1,11 +1,13 @@
-export async function probeStore(url: string, signal: AbortSignal): Promise<{ ok: boolean; version?: number }> {
+export async function probeStore(url: string, signal: AbortSignal, headers?: Record<string, string>): Promise<{ ok: boolean; version?: number }> {
   const base = url.endsWith('/') ? url : url + '/'
+  const opts: RequestInit = { method: 'GET', signal }
+  if (headers) opts.headers = headers
 
   // Try zarr.json (v3), then .zmetadata (v2) — simple GET, no preflight
-  const v3 = await fetch(base + 'zarr.json', { method: 'GET', signal })
+  const v3 = await fetch(base + 'zarr.json', opts)
   if (v3.ok) return { ok: true, version: 3 }
 
-  const v2 = await fetch(base + '.zmetadata', { method: 'GET', signal })
+  const v2 = await fetch(base + '.zmetadata', opts)
   if (v2.ok) return { ok: true, version: 2 }
 
   return { ok: false }

--- a/packages/zarrstore/src/AnnDataStore.test.ts
+++ b/packages/zarrstore/src/AnnDataStore.test.ts
@@ -331,3 +331,12 @@ describe("AnnDataStore", () => {
     });
   });
 });
+
+describe('AnnDataStore.open overrides', () => {
+  it('accepts an optional overrides parameter', async () => {
+    const url = `${globalThis.__TEST_BASE_URL__}/pbmc3k.zarr`
+    const store = await AnnDataStore.open(url, { headers: { 'X-Test': 'value' } })
+    expect(store).toBeDefined()
+    expect(store.nObs).toBeGreaterThan(0)
+  })
+})

--- a/packages/zarrstore/src/AnnDataStore.ts
+++ b/packages/zarrstore/src/AnnDataStore.ts
@@ -210,8 +210,8 @@ export class AnnDataStore {
     this.#labelCache.clear();
   }
 
-  static async open(url: string): Promise<AnnDataStore> {
-    const zarrStore = await ZarrStore.open(url);
+  static async open(url: string, overrides?: RequestInit): Promise<AnnDataStore> {
+    const zarrStore = await ZarrStore.open(url, overrides);
     const attrs = zarrStore.attrs;
 
     if (attrs["encoding-type"] !== "anndata") {

--- a/packages/zarrstore/src/ZarrStore.test.ts
+++ b/packages/zarrstore/src/ZarrStore.test.ts
@@ -50,3 +50,18 @@ describe("ZarrStore", () => {
     expect(stats.cacheHits).toBeGreaterThan(0);
   });
 });
+
+describe('ZarrStore.open overrides', () => {
+  it('accepts an optional overrides parameter', async () => {
+    const url = `${globalThis.__TEST_BASE_URL__}/pbmc3k.zarr`
+    const store = await ZarrStore.open(url, { headers: { 'X-Test': 'value' } })
+    expect(store).toBeDefined()
+    expect(store.root).toBeDefined()
+  })
+
+  it('works without overrides (backward compatible)', async () => {
+    const url = `${globalThis.__TEST_BASE_URL__}/pbmc3k.zarr`
+    const store = await ZarrStore.open(url)
+    expect(store).toBeDefined()
+  })
+})

--- a/packages/zarrstore/src/ZarrStore.ts
+++ b/packages/zarrstore/src/ZarrStore.ts
@@ -31,14 +31,14 @@ export class ZarrStore {
     this.#effectiveStore = effectiveStore ?? store;
   }
 
-  static async open(url: string): Promise<ZarrStore> {
+  static async open(url: string, overrides?: RequestInit): Promise<ZarrStore> {
     // useSuffixRequest: false — uses HEAD+GET instead of Range suffix requests.
     // Range headers trigger CORS preflights (OPTIONS), which fail on CloudFront
     // distributions that don't allow OPTIONS method. HEAD+GET adds one extra
     // request per shard but avoids preflight entirely. To re-enable, CloudFront
     // needs: OPTIONS in allowed methods, CORS-S3Origin request policy, and
     // Origin in the cache key. See: https://github.com/cBioPortal/cbioportal-cell-explorer/issues/162
-    const fetchStore = new zarr.FetchStore(url, { useSuffixRequest: false });
+    const fetchStore = new zarr.FetchStore(url, { useSuffixRequest: false, overrides });
     const instrumented = new InstrumentedStore(fetchStore);
 
     let effectiveStore: ConsolidatedStore | undefined;


### PR DESCRIPTION
## Summary

- Add `overrides` parameter to `ZarrStore.open()` and `AnnDataStore.open()` for bearer token injection
- Regenerate api-client types with dataset catalog endpoints
- Add catalog state, `fetchCatalog`, and `openCatalogDataset` to app store with credential minting support
- Home page: tabbed Catalog/My URLs layout with status lines, probing (including private datasets via /access), copy link, and zarr inspector
- UserAvatar component with popover sign-out, used on both Home and View pages
- Support `?dataset=slug` URL param and config serialization for shareable links
- Config schema accepts either `url` or `dataset` for backward compatibility

## Test plan

- [ ] `pnpm --filter zarrstore test` — 50 tests pass
- [ ] `pnpm --filter highperformer test` — 254 tests pass
- [ ] Home page: Catalog tab shows public datasets, probes them
- [ ] Sign in: private datasets appear, probed via /access with token
- [ ] Click catalog dataset: opens in View page via `?dataset=slug`
- [ ] Share view link: config contains `dataset` slug, resolves on paste
- [ ] No backend: Home page shows My URLs only, no tabs
- [ ] UserAvatar: shows initials + popover on both Home and View pages