### PR TITLE
fix: show My URLs in frontend-only mode

### DIFF
--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -327,22 +327,8 @@ function MyUrlsTab() {
 
 function Home() {
   const backendInfo = useAppStore((s) => s.backendInfo)
+  const backendProbed = useAppStore((s) => s.backendProbed)
   const [activeTab, setActiveTab] = useState('catalog')
-  const [backendProbed, setBackendProbed] = useState(false)
-
-  useEffect(() => {
-    // Wait for probeBackend to finish before rendering layout
-    const check = () => {
-      const { backendInfo } = useAppStore.getState()
-      // backendInfo is set (backend found) or authChecked is true (probe finished, no backend)
-      if (backendInfo !== null || useAppStore.getState().authChecked) {
-        setBackendProbed(true)
-      }
-    }
-    check()
-    const unsub = useAppStore.subscribe(check)
-    return unsub
-  }, [])
 
   if (!backendProbed) {
     return (

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1047,30 +1047,34 @@ describe('useAppStore', () => {
   })
 
   describe('probeBackend', () => {
-    it('sets backendInfo on success', async () => {
+    it('sets backendInfo and backendProbed on success', async () => {
       const info = { version: '0.1.0', environment: 'development', git_sha: 'abc1234', auth_enabled: true }
       mockGET.mockResolvedValue({ data: info })
 
+      expect(useAppStore.getState().backendProbed).toBe(false)
       await useAppStore.getState().probeBackend()
 
       expect(mockGET).toHaveBeenCalledWith('/api/info')
       expect(useAppStore.getState().backendInfo).toEqual(info)
+      expect(useAppStore.getState().backendProbed).toBe(true)
     })
 
-    it('leaves backendInfo null when data is undefined', async () => {
+    it('sets backendProbed when data is undefined', async () => {
       mockGET.mockResolvedValue({ data: undefined, error: { detail: 'Not found' } })
 
       await useAppStore.getState().probeBackend()
 
       expect(useAppStore.getState().backendInfo).toBeNull()
+      expect(useAppStore.getState().backendProbed).toBe(true)
     })
 
-    it('leaves backendInfo null on network error', async () => {
+    it('sets backendProbed on network error (frontend-only mode)', async () => {
       mockGET.mockRejectedValue(new Error('Network error'))
 
       await useAppStore.getState().probeBackend()
 
       expect(useAppStore.getState().backendInfo).toBeNull()
+      expect(useAppStore.getState().backendProbed).toBe(true)
     })
   })
 

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -172,6 +172,7 @@ export interface AppState {
 
   // Backend info (null = no backend detected)
   backendInfo: BackendInfo | null
+  backendProbed: boolean
   probeBackend: () => Promise<void>
 
   // Auth
@@ -373,6 +374,7 @@ const useAppStore = create<AppState>((set, get) => ({
 
   // UI toggles
   backendInfo: null,
+  backendProbed: false,
   probeBackend: async () => {
     try {
       const { api } = await import('../api')
@@ -381,6 +383,7 @@ const useAppStore = create<AppState>((set, get) => ({
     } catch {
       // No backend available — frontend-only mode
     }
+    set({ backendProbed: true })
   },
 
   user: null,


### PR DESCRIPTION
## Summary

- Add `backendProbed` flag to store, set after `probeBackend` completes (success or failure)
- Home page waits for probe to finish, then renders My URLs when no backend is detected
- Previously, the Home page showed nothing in frontend-only mode because the probe completion check relied on `authChecked` which is never set without a backend

## Test plan

- [ ] Stop backend, load Home page — My URLs tab shows with localStorage datasets
- [ ] Start backend, refresh — Catalog/My URLs tabs appear