### PR TITLE
feat(chat): chat panel for the highperformer SPA (Plan 3)

### DIFF
--- a/.changeset/chat-panel.md
+++ b/.changeset/chat-panel.md
@@ -1,0 +1,6 @@
+---
+"@cbioportal-cell-explorer/api-client": minor
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add chat panel to the right sidebar. Wraps the existing Summary panel in antd Tabs so users can switch between `Summary` and `Chat`. The chat panel streams answers from the new `/api/chat/{slug}` backend (cell-explorer-py PR #64), renders markdown including GFM tables, supports stop / retry / auto-scroll, and dispatches agent `ui_action` events into `applyConfig` so the agent can update the view (color, embedding, etc.). The Chat tab is hidden unless the backend reports `chat_enabled: true` (set when `ANTHROPIC_API_KEY` is configured).

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -24,6 +24,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/cli-login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cli Login
+         * @description Browser OAuth flow for the CLI.
+         *
+         *     The CLI passes its localhost callback URL. We validate it, sign it into a
+         *     state JWT, and redirect to Keycloak. The existing /callback endpoint will
+         *     detect the CLI flow on the way back.
+         */
+        get: operations["cli_login_api_auth_cli_login_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/callback": {
         parameters: {
             query?: never;
@@ -146,7 +170,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List Datasets Admin */
+        get: operations["list_datasets_admin_api_admin_datasets_get"];
         put?: never;
         /** Create Dataset */
         post: operations["create_dataset_api_admin_datasets_post"];
@@ -268,10 +293,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/{slug}/context": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Chat Context */
+        get: operations["get_chat_context_api_chat__slug__context_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/{slug}/turns": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post Chat Turn */
+        post: operations["post_chat_turn_api_chat__slug__turns_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** ChatMessage */
+        ChatMessage: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "user" | "assistant";
+            /** Content */
+            content: string;
+        };
+        /** ContextResponse */
+        ContextResponse: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            /** N Obs */
+            n_obs: number;
+            /** N Var */
+            n_var: number;
+            /** Obs Columns */
+            obs_columns: components["schemas"]["ObsColumnInfo"][];
+            /** Embedding Keys */
+            embedding_keys: string[];
+            /** Available Tools */
+            available_tools: string[];
+        };
+        /** DatasetAdminListResponse */
+        DatasetAdminListResponse: {
+            /** Datasets */
+            datasets: components["schemas"]["DatasetAdminResponse"][];
+        };
         /** DatasetAdminResponse */
         DatasetAdminResponse: {
             /** Id */
@@ -402,6 +495,27 @@ export interface components {
             git_sha: string | null;
             /** Auth Enabled */
             auth_enabled: boolean;
+            /** Chat Enabled */
+            chat_enabled: boolean;
+        };
+        /** ObsColumnInfo */
+        ObsColumnInfo: {
+            /** Name */
+            name: string;
+            /**
+             * Dtype
+             * @enum {string}
+             */
+            dtype: "categorical" | "numeric" | "string";
+            /** Cardinality */
+            cardinality?: number | null;
+            /** Values */
+            values?: string[] | null;
+        };
+        /** TurnRequest */
+        TurnRequest: {
+            /** Messages */
+            messages: components["schemas"]["ChatMessage"][];
         };
         /**
          * User
@@ -458,6 +572,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    cli_login_api_auth_cli_login_get: {
+        parameters: {
+            query: {
+                redirect_uri: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -638,6 +783,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_datasets_admin_api_admin_datasets_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetAdminListResponse"];
                 };
             };
         };
@@ -850,6 +1015,72 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_context_api_chat__slug__context_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContextResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_chat_turn_api_chat__slug__turns_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TurnRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/packages/highperformer/package.json
+++ b/packages/highperformer/package.json
@@ -28,7 +28,9 @@
     "deck.gl": "^9.2.10",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
+    "remark-gfm": "^4.0.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/packages/highperformer/src/api.ts
+++ b/packages/highperformer/src/api.ts
@@ -31,3 +31,39 @@ const authMiddleware: Middleware = {
 
 export const api = createApiClient()
 api.use(authMiddleware)
+
+import { parseNdjson } from "./chat/ndjsonParser";
+import {
+  HttpError,
+  type ChatEvent,
+  type ContextResponse,
+  type WireMessage,
+} from "./chat/types";
+
+export const chat = {
+  async getContext(slug: string, signal?: AbortSignal): Promise<ContextResponse> {
+    const res = await fetch(`/api/chat/${encodeURIComponent(slug)}/context`, {
+      credentials: "include",
+      signal,
+    });
+    if (!res.ok) throw new HttpError(res.status, await res.text());
+    return (await res.json()) as ContextResponse;
+  },
+
+  async *streamTurn(
+    slug: string,
+    messages: WireMessage[],
+    signal: AbortSignal,
+  ): AsyncIterable<ChatEvent> {
+    const res = await fetch(`/api/chat/${encodeURIComponent(slug)}/turns`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages }),
+      signal,
+    });
+    if (!res.ok) throw new HttpError(res.status, await res.text());
+    if (!res.body) throw new Error("empty response body");
+    yield* parseNdjson<ChatEvent>(res.body);
+  },
+};

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatPanel } from "./ChatPanel";
+import * as useChatContextModule from "./useChatContext";
+import * as useChatTurnModule from "./useChatTurn";
+import type { ChatEvent, ContextResponse } from "./types";
+
+vi.mock("../store/useAppStore", () => ({
+  useAppStore: Object.assign(
+    (selector: (s: unknown) => unknown) => selector({ applyConfig: vi.fn() }),
+    { getState: () => ({ applyConfig: vi.fn() }) },
+  ),
+}));
+
+const sampleCtx: ContextResponse = {
+  slug: "spectrum",
+  name: "Spectrum",
+  description: "test",
+  n_obs: 100,
+  n_var: 10,
+  obs_columns: [
+    { name: "cell_type", dtype: "categorical", cardinality: 3, values: ["T", "B", "M"] },
+  ],
+  embedding_keys: ["X_umap"],
+  available_tools: ["top_expressed_genes"],
+};
+
+const startMock = vi.fn();
+const stopMock = vi.fn();
+
+beforeEach(() => {
+  vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+    data: sampleCtx,
+    error: undefined,
+    loading: false,
+  });
+  vi.spyOn(useChatTurnModule, "useChatTurn").mockReturnValue({
+    streaming: false,
+    start: startMock,
+    stop: stopMock,
+  });
+  startMock.mockReset();
+  stopMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ChatPanel", () => {
+  it("renders empty state with chips when history is empty", () => {
+    render(<ChatPanel slug="spectrum" />);
+    expect(screen.getByText(/Spectrum/)).toBeDefined();
+    expect(screen.getByText(/Top genes in T/)).toBeDefined();
+    expect(screen.getByPlaceholderText(/Ask anything/i)).toBeDefined();
+  });
+
+  it("clicking a chip fills the input", () => {
+    render(<ChatPanel slug="spectrum" />);
+    const chip = screen.getByText(/Top genes in T/);
+    fireEvent.click(chip);
+    const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
+    expect(input.value).toMatch(/Top genes in T/i);
+  });
+
+  it("submitting calls useChatTurn.start with the user message appended", async () => {
+    render(<ChatPanel slug="spectrum" />);
+    const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "hello" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+    const [slug, messages] = startMock.mock.calls[0];
+    expect(slug).toBe("spectrum");
+    expect(messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("renders an error bubble with Retry when an error event is dispatched", async () => {
+    let dispatch: ((e: ChatEvent) => void) | null = null;
+    startMock.mockImplementation(async (_s, _m, onEvent) => {
+      dispatch = onEvent;
+    });
+    render(<ChatPanel slug="spectrum" />);
+    const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(startMock).toHaveBeenCalled());
+    dispatch!({ type: "text_delta", text: "partial " });
+    dispatch!({ type: "error", message: "boom", retryable: false });
+    await waitFor(() => expect(screen.getByText(/boom/)).toBeDefined());
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    await waitFor(() => expect(startMock).toHaveBeenCalledTimes(2));
+    const [, messages] = startMock.mock.calls[1];
+    expect(messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+});

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Input, Spin, Tag } from "antd";
-import { useCallback, useReducer, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useReducer, useRef, useState } from "react";
 import { applyConfig as applyConfigFn } from "../config/applyConfig";
 import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
@@ -59,6 +59,23 @@ export function ChatPanel({ slug }: { slug: string }) {
   const ctxQuery = useChatContext(slug);
   const { streaming, start, stop } = useChatTurn();
 
+  // Auto-scroll-to-bottom: stick to the bottom of the message list as content
+  // streams in, but preserve the user's scroll position if they've manually
+  // scrolled up to read earlier output.
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+  const handleScroll = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 24;
+  }, []);
+  useLayoutEffect(() => {
+    if (!stickToBottomRef.current) return;
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [state]);
+
   const submit = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
@@ -116,7 +133,11 @@ export function ChatPanel({ slug }: { slug: string }) {
           showIcon
         />
       )}
-      <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+      >
         {ctxQuery.data && isEmpty && (
           <div>
             <p>

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Input, Spin, Tag } from "antd";
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { useAppStore } from "../store/useAppStore";
+import { useCallback, useReducer, useRef, useState } from "react";
+import { applyConfig as applyConfigFn } from "../config/applyConfig";
 import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
 import type { ChatEvent, ChatMessage, MessagePart, WireMessage } from "./types";
@@ -48,13 +48,9 @@ function MessagePartView({ part }: { part: MessagePart }) {
 }
 
 export function ChatPanel({ slug }: { slug: string }) {
-  const applyConfig = useAppStore(
-    (s) => (s as { applyConfig: (cfg: Record<string, unknown>) => void }).applyConfig,
-  );
-  const applyConfigRef = useRef(applyConfig);
-  useEffect(() => { applyConfigRef.current = applyConfig; }, [applyConfig]);
   const reducerFn = useRef(
-    (state: State, action: Action) => makeReducer(applyConfigRef.current)(state, action),
+    (state: State, action: Action) =>
+      makeReducer((cfg) => void applyConfigFn(cfg as Parameters<typeof applyConfigFn>[0]))(state, action),
   ).current;
   const [state, dispatch] = useReducer(reducerFn, undefined, initialState);
   const [input, setInput] = useState("");

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -1,0 +1,190 @@
+import { Alert, Button, Input, Spin, Tag } from "antd";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useAppStore } from "../store/useAppStore";
+import { initialState, reduce, type State } from "./eventReducer";
+import { deriveSuggestionChips } from "./suggestionChips";
+import type { ChatEvent, ChatMessage, MessagePart, WireMessage } from "./types";
+import { useChatContext } from "./useChatContext";
+import { useChatTurn } from "./useChatTurn";
+
+type Action = { type: "AGENT_EVENT"; event: ChatEvent } | { type: "USER_SUBMIT"; content: string };
+
+function makeReducer(applyConfig: (cfg: Record<string, unknown>) => void) {
+  return (state: State, action: Action): State => {
+    if (action.type === "USER_SUBMIT") {
+      const userMsg: ChatMessage = {
+        role: "user",
+        parts: [{ kind: "text", text: action.content }],
+      };
+      return { ...state, history: [...state.history, userMsg] };
+    }
+    return reduce(state, action.event, applyConfig);
+  };
+}
+
+function toWireMessages(history: ChatMessage[]): WireMessage[] {
+  return history.map((m) => ({
+    role: m.role,
+    content: m.parts
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text")
+      .map((p) => p.text)
+      .join(""),
+  }));
+}
+
+function MessagePartView({ part }: { part: MessagePart }) {
+  if (part.kind === "text") return <span>{part.text}</span>;
+  if (part.kind === "tool") {
+    const sym = part.status === "started" ? "▶" : part.status === "ok" ? "✓" : "✗";
+    const color = part.status === "error" ? "red" : part.status === "ok" ? "green" : "blue";
+    return (
+      <Tag color={color}>
+        {sym} {part.tool}
+        {part.summary ? ` — ${part.summary}` : part.status === "started" ? "…" : ""}
+      </Tag>
+    );
+  }
+  return <Alert type="error" message={part.message} showIcon style={{ marginTop: 8 }} />;
+}
+
+export function ChatPanel({ slug }: { slug: string }) {
+  const applyConfig = useAppStore(
+    (s) => (s as { applyConfig: (cfg: Record<string, unknown>) => void }).applyConfig,
+  );
+  const applyConfigRef = useRef(applyConfig);
+  useEffect(() => { applyConfigRef.current = applyConfig; }, [applyConfig]);
+  const reducerFn = useRef(
+    (state: State, action: Action) => makeReducer(applyConfigRef.current)(state, action),
+  ).current;
+  const [state, dispatch] = useReducer(reducerFn, undefined, initialState);
+  const [input, setInput] = useState("");
+  const [lastSubmittedMessages, setLastSubmittedMessages] = useState<WireMessage[] | null>(null);
+
+  const ctxQuery = useChatContext(slug);
+  const { streaming, start, stop } = useChatTurn();
+
+  const submit = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || streaming) return;
+      dispatch({ type: "USER_SUBMIT", content: trimmed });
+      const wireMessages: WireMessage[] = [
+        ...toWireMessages(state.history),
+        { role: "user", content: trimmed },
+      ];
+      setLastSubmittedMessages(wireMessages);
+      setInput("");
+      try {
+        await start(slug, wireMessages, (e) => dispatch({ type: "AGENT_EVENT", event: e }));
+      } catch (e) {
+        const msg = (e as Error).message ?? "request failed";
+        dispatch({
+          type: "AGENT_EVENT",
+          event: { type: "error", message: msg, retryable: false },
+        });
+      }
+    },
+    [start, slug, state.history, streaming],
+  );
+
+  const retry = useCallback(async () => {
+    if (!lastSubmittedMessages) return;
+    try {
+      await start(slug, lastSubmittedMessages, (e) =>
+        dispatch({ type: "AGENT_EVENT", event: e }),
+      );
+    } catch (e) {
+      const msg = (e as Error).message ?? "request failed";
+      dispatch({
+        type: "AGENT_EVENT",
+        event: { type: "error", message: msg, retryable: false },
+      });
+    }
+  }, [start, slug, lastSubmittedMessages]);
+
+  const isEmpty = state.history.length === 0 && state.current === null && !streaming;
+  const hasError = state.status === "error";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
+      {ctxQuery.loading && <Spin />}
+      {ctxQuery.error && (
+        <Alert
+          type="error"
+          message={`Couldn't load chat context: ${(ctxQuery.error as Error).message}`}
+          showIcon
+        />
+      )}
+      {ctxQuery.data && isEmpty && (
+        <div>
+          <p>
+            Ask about {ctxQuery.data.name} — {ctxQuery.data.n_obs.toLocaleString()} cells ×{" "}
+            {ctxQuery.data.n_var.toLocaleString()} genes.
+          </p>
+          {deriveSuggestionChips(ctxQuery.data).map((chip) => (
+            <Button
+              key={chip.label}
+              size="small"
+              style={{ margin: "4px 4px 4px 0" }}
+              onClick={() => setInput(chip.prompt)}
+            >
+              {chip.label}
+            </Button>
+          ))}
+        </div>
+      )}
+      {!isEmpty && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            marginTop: 12,
+            flex: 1,
+            overflowY: "auto",
+          }}
+        >
+          {state.history.map((m, i) => (
+            <div key={i}>
+              <strong>{m.role === "user" ? "You: " : "Assistant: "}</strong>
+              {m.parts.map((p, j) => (
+                <MessagePartView key={j} part={p} />
+              ))}
+            </div>
+          ))}
+          {state.current && (
+            <div>
+              <strong>Assistant: </strong>
+              {state.current.parts.map((p, j) => (
+                <MessagePartView key={j} part={p} />
+              ))}
+            </div>
+          )}
+          {hasError && (
+            <Button onClick={retry} type="primary" size="small">
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
+      <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+        <Input
+          placeholder="Ask anything…"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !streaming) submit(input);
+          }}
+          disabled={streaming}
+        />
+        {streaming ? (
+          <Button onClick={stop}>Stop</Button>
+        ) : (
+          <Button type="primary" onClick={() => submit(input)}>
+            Send
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -103,7 +103,12 @@ export function ChatPanel({ slug }: { slug: string }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
-      {ctxQuery.loading && <Spin />}
+      {ctxQuery.loading && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: 8 }}>
+          <Spin size="small" />
+          <span>Fetching metadata…</span>
+        </div>
+      )}
       {ctxQuery.error && (
         <Alert
           type="error"

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -169,7 +169,6 @@ export function ChatPanel({ slug }: { slug: string }) {
           onKeyDown={(e) => {
             if (e.key === "Enter" && !streaming) submit(input);
           }}
-          disabled={streaming}
         />
         {streaming ? (
           <Button onClick={stop}>Stop</Button>

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -1,5 +1,7 @@
 import { Alert, Button, Input, Spin, Tag } from "antd";
 import { useCallback, useLayoutEffect, useReducer, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { applyConfig as applyConfigFn } from "../config/applyConfig";
 import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
@@ -32,8 +34,42 @@ function toWireMessages(history: ChatMessage[]): WireMessage[] {
   }));
 }
 
+// Components passed to ReactMarkdown — keep tables readable in a narrow sidebar
+// and tighten paragraph margins for chat-density layout.
+const markdownComponents = {
+  table: (props: React.HTMLAttributes<HTMLTableElement>) => (
+    <div style={{ overflowX: "auto", margin: "8px 0" }}>
+      <table {...props} style={{ borderCollapse: "collapse", fontSize: 12 }} />
+    </div>
+  ),
+  th: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
+    <th
+      {...props}
+      style={{ border: "1px solid #ddd", padding: "4px 8px", textAlign: "left", background: "#fafafa" }}
+    />
+  ),
+  td: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
+    <td {...props} style={{ border: "1px solid #ddd", padding: "4px 8px" }} />
+  ),
+  p: (props: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props} style={{ margin: "4px 0" }} />
+  ),
+  code: (props: React.HTMLAttributes<HTMLElement>) => (
+    <code
+      {...props}
+      style={{ background: "#f6f8fa", padding: "1px 4px", borderRadius: 3, fontSize: "0.9em" }}
+    />
+  ),
+};
+
 function MessagePartView({ part }: { part: MessagePart }) {
-  if (part.kind === "text") return <span>{part.text}</span>;
+  if (part.kind === "text") {
+    return (
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {part.text}
+      </ReactMarkdown>
+    );
+  }
   if (part.kind === "tool") {
     const sym = part.status === "started" ? "▶" : part.status === "ok" ? "✓" : "✗";
     const color = part.status === "error" ? "red" : part.status === "ok" ? "green" : "blue";

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -111,59 +111,52 @@ export function ChatPanel({ slug }: { slug: string }) {
           showIcon
         />
       )}
-      {ctxQuery.data && isEmpty && (
-        <div>
-          <p>
-            Ask about {ctxQuery.data.name} — {ctxQuery.data.n_obs.toLocaleString()} cells ×{" "}
-            {ctxQuery.data.n_var.toLocaleString()} genes.
-          </p>
-          {deriveSuggestionChips(ctxQuery.data).map((chip) => (
-            <Button
-              key={chip.label}
-              size="small"
-              style={{ margin: "4px 4px 4px 0" }}
-              onClick={() => setInput(chip.prompt)}
-            >
-              {chip.label}
-            </Button>
-          ))}
-        </div>
-      )}
-      {!isEmpty && (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 12,
-            marginTop: 12,
-            flex: 1,
-            overflowY: "auto",
-          }}
-        >
-          {state.history.map((m, i) => (
-            <div key={i}>
-              <strong>{m.role === "user" ? "You: " : "Assistant: "}</strong>
-              {m.parts.map((p, j) => (
-                <MessagePartView key={j} part={p} />
-              ))}
-            </div>
-          ))}
-          {state.current && (
-            <div>
-              <strong>Assistant: </strong>
-              {state.current.parts.map((p, j) => (
-                <MessagePartView key={j} part={p} />
-              ))}
-            </div>
-          )}
-          {hasError && (
-            <Button onClick={retry} type="primary" size="small">
-              Retry
-            </Button>
-          )}
-        </div>
-      )}
-      <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+      <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+        {ctxQuery.data && isEmpty && (
+          <div>
+            <p>
+              Ask about {ctxQuery.data.name} — {ctxQuery.data.n_obs.toLocaleString()} cells ×{" "}
+              {ctxQuery.data.n_var.toLocaleString()} genes.
+            </p>
+            {deriveSuggestionChips(ctxQuery.data).map((chip) => (
+              <Button
+                key={chip.label}
+                size="small"
+                style={{ margin: "4px 4px 4px 0" }}
+                onClick={() => setInput(chip.prompt)}
+              >
+                {chip.label}
+              </Button>
+            ))}
+          </div>
+        )}
+        {!isEmpty && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {state.history.map((m, i) => (
+              <div key={i}>
+                <strong>{m.role === "user" ? "You: " : "Assistant: "}</strong>
+                {m.parts.map((p, j) => (
+                  <MessagePartView key={j} part={p} />
+                ))}
+              </div>
+            ))}
+            {state.current && (
+              <div>
+                <strong>Assistant: </strong>
+                {state.current.parts.map((p, j) => (
+                  <MessagePartView key={j} part={p} />
+                ))}
+              </div>
+            )}
+            {hasError && (
+              <Button onClick={retry} type="primary" size="small">
+                Retry
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+      <div style={{ marginTop: 12, display: "flex", gap: 8, flexShrink: 0 }}>
         <Input
           placeholder="Ask anything…"
           value={input}

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { initialState, reduce } from "./eventReducer";
+import type { ChatEvent } from "./types";
+
+const noopApply = vi.fn();
+
+describe("eventReducer.reduce", () => {
+  it("merges consecutive text_delta events into one TextPart", () => {
+    let s = initialState();
+    s = reduce(s, { type: "text_delta", text: "Hello " }, noopApply);
+    s = reduce(s, { type: "text_delta", text: "world" }, noopApply);
+    expect(s.current).not.toBeNull();
+    expect(s.current!.parts).toEqual([{ kind: "text", text: "Hello world" }]);
+    expect(s.status).toBe("streaming");
+  });
+
+  it("tool_progress started -> ok updates the same ToolPart by tool name", () => {
+    let s = initialState();
+    s = reduce(s, { type: "tool_progress", tool: "top_genes", status: "started" }, noopApply);
+    s = reduce(s, { type: "tool_progress", tool: "top_genes", status: "ok", summary: "32k scanned" }, noopApply);
+    const tools = s.current!.parts.filter((p) => p.kind === "tool");
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ tool: "top_genes", status: "ok", summary: "32k scanned" });
+  });
+
+  it("tool_progress for two different tools yields two pills", () => {
+    let s = initialState();
+    s = reduce(s, { type: "tool_progress", tool: "a", status: "started" }, noopApply);
+    s = reduce(s, { type: "tool_progress", tool: "b", status: "started" }, noopApply);
+    const tools = s.current!.parts.filter((p) => p.kind === "tool");
+    expect(tools.map((t) => (t as { tool: string }).tool)).toEqual(["a", "b"]);
+  });
+
+  it("ui_action calls applyConfig once with the payload, doesn't mutate state", () => {
+    const apply = vi.fn();
+    const before = initialState();
+    const after = reduce(
+      before,
+      { type: "ui_action", payload: { colorBy: "category", category: "T cells" } },
+      apply,
+    );
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith({ colorBy: "category", category: "T cells" });
+    expect(after).toBe(before); // no state mutation
+  });
+
+  it("error event appends ErrorPart and sets status to error, keeps preceding text", () => {
+    let s = initialState();
+    s = reduce(s, { type: "text_delta", text: "partial " }, noopApply);
+    s = reduce(s, { type: "error", message: "boom", retryable: false }, noopApply);
+    expect(s.status).toBe("error");
+    expect(s.current!.parts).toEqual([
+      { kind: "text", text: "partial " },
+      { kind: "error", message: "boom" },
+    ]);
+  });
+
+  it("done finalizes current onto history and clears current", () => {
+    let s = initialState();
+    s = reduce(s, { type: "text_delta", text: "hi" }, noopApply);
+    s = reduce(s, { type: "done", usage: { input_tokens: 1, output_tokens: 2 } }, noopApply);
+    expect(s.current).toBeNull();
+    expect(s.history).toHaveLength(1);
+    expect(s.history[0].parts).toEqual([{ kind: "text", text: "hi" }]);
+    expect(s.status).toBe("idle");
+  });
+
+  it("mid-stream error between text_delta events keeps partial text visible", () => {
+    let s = initialState();
+    s = reduce(s, { type: "text_delta", text: "before " }, noopApply);
+    s = reduce(s, { type: "error", message: "x", retryable: false }, noopApply);
+    expect(s.current!.parts.find((p) => p.kind === "text")).toEqual({
+      kind: "text",
+      text: "before ",
+    });
+  });
+
+  it("unknown event type appends a synthetic error part instead of throwing", () => {
+    const s = reduce(
+      initialState(),
+      { type: "garbage" } as unknown as ChatEvent,
+      noopApply,
+    );
+    expect(s.status).toBe("error");
+    expect(s.current!.parts.some((p) => p.kind === "error")).toBe(true);
+  });
+});

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -1,0 +1,117 @@
+import type {
+  ChatEvent,
+  ChatMessage,
+  MessagePart,
+  TextPart,
+  ToolPart,
+  ErrorPart,
+} from "./types";
+
+export type State = {
+  history: ChatMessage[];
+  current: ChatMessage | null;
+  status: "idle" | "streaming" | "error";
+};
+
+export function initialState(): State {
+  return { history: [], current: null, status: "idle" };
+}
+
+function ensureCurrent(state: State): ChatMessage {
+  return state.current ?? { role: "assistant", parts: [] };
+}
+
+function mergeTextDelta(parts: MessagePart[], text: string): MessagePart[] {
+  const last = parts.at(-1);
+  if (last && last.kind === "text") {
+    const merged: TextPart = { kind: "text", text: last.text + text };
+    return [...parts.slice(0, -1), merged];
+  }
+  return [...parts, { kind: "text", text }];
+}
+
+function upsertToolPart(
+  parts: MessagePart[],
+  ev: { tool: string; status: ToolPart["status"]; summary?: string },
+): MessagePart[] {
+  const idx = parts.findIndex(
+    (p) => p.kind === "tool" && (p as ToolPart).tool === ev.tool,
+  );
+  const updated: ToolPart = {
+    kind: "tool",
+    tool: ev.tool,
+    status: ev.status,
+    summary: ev.summary,
+  };
+  if (idx === -1) return [...parts, updated];
+  const next = parts.slice();
+  next[idx] = updated;
+  return next;
+}
+
+function appendErrorPart(parts: MessagePart[], message: string): MessagePart[] {
+  const err: ErrorPart = { kind: "error", message };
+  return [...parts, err];
+}
+
+export function reduce(
+  state: State,
+  ev: ChatEvent,
+  applyConfig: (cfg: Record<string, unknown>) => void,
+): State {
+  switch (ev.type) {
+    case "text_delta": {
+      const cur = ensureCurrent(state);
+      return {
+        ...state,
+        current: { ...cur, parts: mergeTextDelta(cur.parts, ev.text) },
+        status: "streaming",
+      };
+    }
+    case "tool_progress": {
+      const cur = ensureCurrent(state);
+      return {
+        ...state,
+        current: {
+          ...cur,
+          parts: upsertToolPart(cur.parts, {
+            tool: ev.tool,
+            status: ev.status,
+            summary: ev.summary,
+          }),
+        },
+        status: "streaming",
+      };
+    }
+    case "ui_action": {
+      applyConfig(ev.payload);
+      return state;
+    }
+    case "error": {
+      const cur = ensureCurrent(state);
+      return {
+        ...state,
+        current: { ...cur, parts: appendErrorPart(cur.parts, ev.message) },
+        status: "error",
+      };
+    }
+    case "done": {
+      const cur = state.current;
+      return {
+        history: cur ? [...state.history, cur] : state.history,
+        current: null,
+        status: "idle",
+      };
+    }
+    default: {
+      // Unknown event type — defensive; surface as error part.
+      const cur = ensureCurrent(state);
+      const message = `unknown event type: ${(ev as { type?: string }).type ?? "<missing>"}`;
+      return {
+        ...state,
+        current: { ...cur, parts: appendErrorPart(cur.parts, message) },
+        status: "error",
+      };
+    }
+  }
+}

--- a/packages/highperformer/src/chat/ndjsonParser.test.ts
+++ b/packages/highperformer/src/chat/ndjsonParser.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { parseNdjson } from "./ndjsonParser";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const v of iter) out.push(v);
+  return out;
+}
+
+describe("parseNdjson", () => {
+  it("splits on newlines and parses each line as JSON", async () => {
+    const stream = streamFromChunks([
+      '{"a":1}\n{"b":2}\n{"c":3}\n',
+    ]);
+    const events = await collect<unknown>(parseNdjson(stream));
+    expect(events).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it("emits events incrementally across chunk boundaries", async () => {
+    const stream = streamFromChunks([
+      '{"a":1}\n{"b":',
+      '2}\n',
+    ]);
+    const events = await collect<unknown>(parseNdjson(stream));
+    expect(events).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it("handles empty trailing newline", async () => {
+    const stream = streamFromChunks(['{"a":1}\n']);
+    const events = await collect<unknown>(parseNdjson(stream));
+    expect(events).toEqual([{ a: 1 }]);
+  });
+
+  it("handles a non-empty final line without trailing newline", async () => {
+    const stream = streamFromChunks(['{"a":1}\n{"b":2}']);
+    const events = await collect<unknown>(parseNdjson(stream));
+    expect(events).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it("propagates AbortError from the underlying stream", async () => {
+    const stream = new ReadableStream({
+      pull(controller) {
+        controller.error(new DOMException("aborted", "AbortError"));
+      },
+    });
+    await expect(collect(parseNdjson(stream))).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+});

--- a/packages/highperformer/src/chat/ndjsonParser.ts
+++ b/packages/highperformer/src/chat/ndjsonParser.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse a binary stream of `\n`-terminated UTF-8 JSON lines into objects.
+ *
+ * Buffers a partial trailing line until the next chunk arrives. Closes
+ * cleanly on stream end (parses any non-empty final buffer). Underlying
+ * stream errors (including AbortError) propagate through the iterator.
+ */
+export async function* parseNdjson<T = unknown>(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<T> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (line.length > 0) yield JSON.parse(line) as T;
+      }
+    }
+    // Flush any remaining decoder state and a final unterminated line.
+    buffer += decoder.decode();
+    if (buffer.length > 0) yield JSON.parse(buffer) as T;
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/highperformer/src/chat/suggestionChips.test.ts
+++ b/packages/highperformer/src/chat/suggestionChips.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { deriveSuggestionChips } from "./suggestionChips";
+import type { ContextResponse } from "./types";
+
+const baseCtx: ContextResponse = {
+  slug: "spectrum",
+  name: "Spectrum",
+  description: "test",
+  n_obs: 100,
+  n_var: 10,
+  obs_columns: [],
+  embedding_keys: ["X_umap"],
+  available_tools: [],
+};
+
+describe("deriveSuggestionChips", () => {
+  it("returns all 4 chips for a categorical fixture with values populated", () => {
+    const ctx: ContextResponse = {
+      ...baseCtx,
+      obs_columns: [
+        {
+          name: "cell_type",
+          dtype: "categorical",
+          cardinality: 3,
+          values: ["T cells", "B cells", "Myeloid"],
+        },
+      ],
+    };
+    const chips = deriveSuggestionChips(ctx);
+    expect(chips).toHaveLength(4);
+    expect(chips[0].prompt).toMatch(/cell types/i);
+    expect(chips[1].prompt).toMatch(/T cells/);
+    expect(chips[2].prompt).toMatch(/cell_type/);
+    expect(chips[3].prompt).toMatch(/UMAP/i);
+  });
+
+  it("falls back to generic chips when no categorical columns exist", () => {
+    const ctx: ContextResponse = {
+      ...baseCtx,
+      obs_columns: [
+        { name: "percent_mt", dtype: "numeric", cardinality: null, values: null },
+      ],
+    };
+    const chips = deriveSuggestionChips(ctx);
+    expect(chips).toHaveLength(2);
+    expect(chips[0].prompt).toMatch(/describe/i);
+    expect(chips[1].prompt).toMatch(/UMAP/i);
+  });
+
+  it("skips specific-group chip when categorical column has no values", () => {
+    const ctx: ContextResponse = {
+      ...baseCtx,
+      obs_columns: [
+        { name: "donor", dtype: "categorical", cardinality: 200, values: null },
+      ],
+    };
+    const chips = deriveSuggestionChips(ctx);
+    expect(chips.some((c) => c.prompt.match(/Top genes in/))).toBe(false);
+    expect(chips.some((c) => c.prompt.match(/Compare two groups in/))).toBe(true);
+  });
+
+  it("uses the first low-cardinality categorical column for specific chips", () => {
+    const ctx: ContextResponse = {
+      ...baseCtx,
+      obs_columns: [
+        { name: "donor", dtype: "categorical", cardinality: 200, values: null },
+        {
+          name: "cell_type",
+          dtype: "categorical",
+          cardinality: 3,
+          values: ["T", "B", "M"],
+        },
+      ],
+    };
+    const chips = deriveSuggestionChips(ctx);
+    expect(chips.find((c) => c.prompt.includes("Top genes in T"))).toBeDefined();
+  });
+
+  it("always returns between 1 and 4 chips", () => {
+    const minimal: ContextResponse = {
+      ...baseCtx,
+      obs_columns: [],
+      embedding_keys: [],
+    };
+    const chips = deriveSuggestionChips(minimal);
+    expect(chips.length).toBeGreaterThanOrEqual(1);
+    expect(chips.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/packages/highperformer/src/chat/suggestionChips.ts
+++ b/packages/highperformer/src/chat/suggestionChips.ts
@@ -1,0 +1,53 @@
+import type { ChipDef, ContextResponse, ObsColumnInfo } from "./types";
+
+const LOW_CARDINALITY_MAX = 50;
+
+function isLowCardinalityCategorical(col: ObsColumnInfo): boolean {
+  return (
+    col.dtype === "categorical" &&
+    col.cardinality !== null &&
+    col.cardinality <= LOW_CARDINALITY_MAX
+  );
+}
+
+export function deriveSuggestionChips(ctx: ContextResponse): ChipDef[] {
+  const chips: ChipDef[] = [];
+
+  const hasCategorical = ctx.obs_columns.some((c) => c.dtype === "categorical");
+  chips.push(
+    hasCategorical
+      ? { label: "What cell types are here?", prompt: "What cell types are here?" }
+      : { label: "Describe this dataset", prompt: "Describe this dataset" },
+  );
+
+  const firstLowCardCat = ctx.obs_columns.find(isLowCardinalityCategorical);
+  const firstCatCol = ctx.obs_columns.find((c) => c.dtype === "categorical");
+
+  if (firstLowCardCat) {
+    if (firstLowCardCat.values && firstLowCardCat.values.length > 0) {
+      const v = firstLowCardCat.values[0];
+      chips.push({
+        label: `Top genes in ${v}`,
+        prompt: `Top genes in ${v}`,
+      });
+    }
+    chips.push({
+      label: `Compare groups in ${firstLowCardCat.name}`,
+      prompt: `Compare two groups in ${firstLowCardCat.name}`,
+    });
+  } else if (firstCatCol) {
+    chips.push({
+      label: `Compare groups in ${firstCatCol.name}`,
+      prompt: `Compare two groups in ${firstCatCol.name}`,
+    });
+  }
+
+  if (ctx.embedding_keys.length > 0) {
+    chips.push({
+      label: "Show me on the UMAP",
+      prompt: "Show me an interesting view on the UMAP",
+    });
+  }
+
+  return chips.slice(0, 4);
+}

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Wire types for the chat backend (Plan 2 — /api/chat/{slug}).
+ *
+ * Hand-maintained mirror of the backend Pydantic models. When Plan 2 ships
+ * and the openapi schema regenerates, this file can be replaced by a typed
+ * wrapper around openapi-fetch. Streaming responses (NDJSON) still need a
+ * hand-written shape since openapi-fetch doesn't model AsyncIterable.
+ */
+
+// ---------- /context response ----------
+
+export type ObsColumnInfo = {
+  name: string;
+  dtype: "categorical" | "numeric" | "string";
+  cardinality: number | null;
+  values: string[] | null; // populated for categorical with cardinality <= 50
+};
+
+export type ContextResponse = {
+  slug: string;
+  name: string;
+  description: string;
+  n_obs: number;
+  n_var: number;
+  obs_columns: ObsColumnInfo[];
+  embedding_keys: string[];
+  available_tools: string[];
+};
+
+// ---------- /turns wire request ----------
+
+export type WireMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export type TurnRequest = {
+  messages: WireMessage[];
+};
+
+// ---------- /turns wire events ----------
+
+export type TextDelta    = { type: "text_delta"; text: string };
+export type ToolProgress = {
+  type: "tool_progress";
+  tool: string;
+  status: "started" | "ok" | "error";
+  summary?: string;
+};
+export type UIAction     = { type: "ui_action"; payload: Record<string, unknown> };
+export type ErrorEvent   = { type: "error"; message: string; retryable: boolean };
+export type DoneEvent    = {
+  type: "done";
+  usage: { input_tokens: number; output_tokens: number };
+};
+
+export type ChatEvent =
+  | TextDelta
+  | ToolProgress
+  | UIAction
+  | ErrorEvent
+  | DoneEvent;
+
+// ---------- in-memory chat state (component-local) ----------
+
+export type TextPart  = { kind: "text";  text: string };
+export type ToolPart  = {
+  kind: "tool";
+  tool: string;
+  status: "started" | "ok" | "error";
+  summary?: string;
+};
+export type ErrorPart = { kind: "error"; message: string };
+export type MessagePart = TextPart | ToolPart | ErrorPart;
+
+export type ChatMessage = {
+  role: "user" | "assistant";
+  parts: MessagePart[];
+};
+
+// ---------- chip definitions ----------
+
+export type ChipDef = { label: string; prompt: string };
+
+// ---------- error class for non-2xx pre-stream HTTP failures ----------
+
+export class HttpError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`HTTP ${status}: ${body.slice(0, 200)}`);
+    this.name = "HttpError";
+  }
+}

--- a/packages/highperformer/src/chat/useChatContext.test.ts
+++ b/packages/highperformer/src/chat/useChatContext.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "./types";
+import { useChatContext } from "./useChatContext";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("useChatContext", () => {
+  it("returns ContextResponse after fetch resolves", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          slug: "s",
+          name: "S",
+          description: "d",
+          n_obs: 1,
+          n_var: 1,
+          obs_columns: [],
+          embedding_keys: [],
+          available_tools: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const { result } = renderHook(() => useChatContext("s"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.slug).toBe("s");
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("returns error on non-2xx, data is undefined", async () => {
+    fetchMock.mockResolvedValue(new Response("nope", { status: 404 }));
+    const { result } = renderHook(() => useChatContext("s"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeInstanceOf(HttpError);
+    expect((result.current.error as HttpError).status).toBe(404);
+  });
+
+  it("aborts the previous request when slug changes mid-flight", async () => {
+    const seenSignals: AbortSignal[] = [];
+    fetchMock.mockImplementation((_url, init: RequestInit) => {
+      seenSignals.push(init.signal as AbortSignal);
+      return new Promise(() => {}); // never resolves; we only care about abort
+    });
+
+    const { rerender } = renderHook(({ slug }) => useChatContext(slug), {
+      initialProps: { slug: "a" },
+    });
+    rerender({ slug: "b" });
+
+    await waitFor(() => expect(seenSignals[0].aborted).toBe(true));
+    expect(seenSignals[1].aborted).toBe(false);
+  });
+});

--- a/packages/highperformer/src/chat/useChatContext.ts
+++ b/packages/highperformer/src/chat/useChatContext.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { chat } from "../api";
+import { HttpError, type ContextResponse } from "./types";
+
+export type UseChatContextResult = {
+  data: ContextResponse | undefined;
+  error: HttpError | Error | undefined;
+  loading: boolean;
+};
+
+export function useChatContext(slug: string): UseChatContextResult {
+  const [data, setData] = useState<ContextResponse | undefined>(undefined);
+  const [error, setError] = useState<HttpError | Error | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setData(undefined);
+    setError(undefined);
+    setLoading(true);
+    chat
+      .getContext(slug, controller.signal)
+      .then((d) => {
+        if (!controller.signal.aborted) {
+          setData(d);
+          setLoading(false);
+        }
+      })
+      .catch((e: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [slug]);
+
+  return { data, error, loading };
+}

--- a/packages/highperformer/src/chat/useChatTurn.test.ts
+++ b/packages/highperformer/src/chat/useChatTurn.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError, type ChatEvent } from "./types";
+import { useChatTurn } from "./useChatTurn";
+
+function streamFromLines(lines: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      for (const l of lines) c.enqueue(enc.encode(l + "\n"));
+      c.close();
+    },
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("useChatTurn", () => {
+  it("yields events in order and toggles streaming", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        streamFromLines([
+          JSON.stringify({ type: "text_delta", text: "hi" }),
+          JSON.stringify({ type: "done", usage: { input_tokens: 1, output_tokens: 1 } }),
+        ]),
+        { status: 200, headers: { "content-type": "application/x-ndjson" } },
+      ),
+    );
+
+    const { result } = renderHook(() => useChatTurn());
+    expect(result.current.streaming).toBe(false);
+
+    const events: ChatEvent[] = [];
+    await act(async () => {
+      await result.current.start("spectrum", [{ role: "user", content: "hi" }], (e) =>
+        events.push(e),
+      );
+    });
+
+    expect(events.map((e) => e.type)).toEqual(["text_delta", "done"]);
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it("throws HttpError on non-2xx and resets streaming", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+
+    const { result } = renderHook(() => useChatTurn());
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.start("nope", [{ role: "user", content: "hi" }], () => {});
+      } catch (e) {
+        caught = e;
+      }
+    });
+    expect(caught).toBeInstanceOf(HttpError);
+    expect((caught as HttpError).status).toBe(404);
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it("stop() aborts the iteration with AbortError", async () => {
+    let abortSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation((_url, init: RequestInit) => {
+      abortSignal = init.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        abortSignal!.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+    });
+
+    const { result } = renderHook(() => useChatTurn());
+    let caught: unknown;
+    const startPromise = act(async () => {
+      try {
+        await result.current.start("s", [{ role: "user", content: "hi" }], () => {});
+      } catch (e) {
+        caught = e;
+      }
+    });
+    // Stop immediately.
+    act(() => result.current.stop());
+    await startPromise;
+    expect((caught as Error).name).toBe("AbortError");
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it("resets streaming on network error", async () => {
+    fetchMock.mockRejectedValue(new TypeError("network down"));
+    const { result } = renderHook(() => useChatTurn());
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.start("s", [{ role: "user", content: "hi" }], () => {});
+      } catch (e) {
+        caught = e;
+      }
+    });
+    expect((caught as Error).message).toMatch(/network down/);
+    expect(result.current.streaming).toBe(false);
+  });
+});

--- a/packages/highperformer/src/chat/useChatTurn.ts
+++ b/packages/highperformer/src/chat/useChatTurn.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from "react";
+import { chat } from "../api";
+import type { ChatEvent, WireMessage } from "./types";
+
+export function useChatTurn() {
+  const [streaming, setStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const start = useCallback(
+    async (
+      slug: string,
+      messages: WireMessage[],
+      onEvent: (e: ChatEvent) => void,
+    ): Promise<void> => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setStreaming(true);
+      try {
+        for await (const ev of chat.streamTurn(slug, messages, controller.signal)) {
+          onEvent(ev);
+        }
+      } finally {
+        setStreaming(false);
+        if (abortRef.current === controller) abortRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  return { streaming, start, stop };
+}

--- a/packages/highperformer/src/index.css
+++ b/packages/highperformer/src/index.css
@@ -1,3 +1,21 @@
 body {
   margin: 0;
 }
+
+/* Make antd Tabs' inner layout fill the parent height so its TabPane can
+   give children (e.g. ChatPanel with a sticky-bottom input) full height. */
+.chat-tabs {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.chat-tabs .ant-tabs-content-holder {
+  flex: 1;
+  min-height: 0;
+}
+.chat-tabs .ant-tabs-content {
+  height: 100%;
+}
+.chat-tabs .ant-tabs-tabpane {
+  height: 100%;
+}

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -861,7 +861,7 @@ function View() {
             <Tabs
               size="small"
               defaultActiveKey="summary"
-              style={{ height: '100%' }}
+              className="chat-tabs"
               items={[
                 {
                   key: 'summary',

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useNavigate, Link } from 'react-router-dom'
-import { Button, Collapse, InputNumber, Layout, Popover, Switch, Typography, Select, Spin, message } from 'antd'
+import { Button, Collapse, InputNumber, Layout, Popover, Switch, Tabs, Typography, Select, Spin, message } from 'antd'
 import { BgColorsOutlined, DatabaseOutlined, DotChartOutlined, HolderOutlined, InfoCircleOutlined, LeftOutlined, LinkOutlined, RightOutlined, SettingOutlined } from '@ant-design/icons'
 import { DeckGL } from '@deck.gl/react'
 import { OrthographicView } from '@deck.gl/core'
@@ -20,6 +20,7 @@ import ColorBySection from '../components/ColorBySection'
 import SelectionOverlay from '../components/SelectionOverlay'
 import SelectionToolbar from '../components/SelectionToolbar'
 import SummaryPanel from '../components/SummaryPanel'
+import { ChatPanel } from '../chat/ChatPanel'
 import { loadDatasets, saveDatasets } from '../utils/datasets'
 
 const { Sider, Content } = Layout
@@ -746,6 +747,7 @@ function View() {
   const openCatalogDataset = useAppStore((s) => s.openCatalogDataset)
   const loadingError = useAppStore((s) => s.loadingError)
   const datasetUrl = useAppStore((s) => s.datasetUrl)
+  const datasetSlug = useAppStore((s) => s.datasetSlug)
   const [leftCollapsed, setLeftCollapsed] = useState(false)
   const [rightWidth, setRightWidth] = useState(RIGHT_SIDEBAR_WIDTH)
   const deckRef = useRef<DeckGL>(null)
@@ -853,7 +855,31 @@ function View() {
               zIndex: 10,
             }}
           />
-          <SummaryPanel collapsed={rightWidth <= SIDEBAR_COLLAPSED_WIDTH} onExpand={() => setRightWidth(RIGHT_SIDEBAR_WIDTH)} />
+          {rightWidth <= SIDEBAR_COLLAPSED_WIDTH ? (
+            <SummaryPanel collapsed onExpand={() => setRightWidth(RIGHT_SIDEBAR_WIDTH)} />
+          ) : (
+            <Tabs
+              size="small"
+              defaultActiveKey="summary"
+              style={{ height: '100%' }}
+              items={[
+                {
+                  key: 'summary',
+                  label: 'Summary',
+                  children: <SummaryPanel collapsed={false} onExpand={() => {}} />,
+                },
+                ...(datasetSlug
+                  ? [
+                      {
+                        key: 'chat',
+                        label: 'Chat',
+                        children: <ChatPanel slug={datasetSlug} />,
+                      },
+                    ]
+                  : []),
+              ]}
+            />
+          )}
         </Sider>
       </Layout>
       {ENABLE_PROFILER && <ProfileBarWrapper />}

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -748,6 +748,7 @@ function View() {
   const loadingError = useAppStore((s) => s.loadingError)
   const datasetUrl = useAppStore((s) => s.datasetUrl)
   const datasetSlug = useAppStore((s) => s.datasetSlug)
+  const backendInfo = useAppStore((s) => s.backendInfo)
   const [leftCollapsed, setLeftCollapsed] = useState(false)
   const [rightWidth, setRightWidth] = useState(RIGHT_SIDEBAR_WIDTH)
   const deckRef = useRef<DeckGL>(null)
@@ -868,7 +869,7 @@ function View() {
                   label: 'Summary',
                   children: <SummaryPanel collapsed={false} onExpand={() => {}} />,
                 },
-                ...(datasetSlug
+                ...(datasetSlug && backendInfo?.chat_enabled
                   ? [
                       {
                         key: 'chat',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,9 +182,15 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -270,7 +276,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
@@ -3479,6 +3485,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
@@ -5595,6 +5602,9 @@ packages:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
 
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -7367,6 +7377,12 @@ packages:
     peerDependencies:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: 18.3.1
 
   react-router-config@5.1.1:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
@@ -12671,15 +12687,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.2.3(@types/react@18.3.28)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -13022,9 +13038,9 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.3(@types/react@18.3.28)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 18.3.28
     optional: true
 
   '@types/react-router-config@5.0.11':
@@ -15827,6 +15843,8 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-url-attributes@3.0.1: {}
+
   html-void-elements@3.0.0: {}
 
   html-webpack-plugin@5.6.6(webpack@5.105.0):
@@ -17871,6 +17889,24 @@ snapshots:
       '@babel/runtime': 7.28.6
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
       webpack: 5.105.0
+
+  react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.28
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Adds Plan 3: a chat panel in the highperformer SPA that consumes the Plan 2 backend NDJSON streaming chat endpoints and dispatches `ui_action` payloads into the existing `applyConfig()` pipeline.

- New right-sidebar tab (`Summary` / `Chat`) — antd `Tabs` wraps the existing summary panel.
- Empty state: one-line welcome + up to 4 suggestion chips derived from the `/context` response.
- Streaming text + tool pills render in real time. `ui_action` events update the scatterplot via `applyConfig` (silent in chat — the visible app *is* the feedback).
- `Stop` button aborts the in-flight `fetch`; server cancels via the existing `asyncio.CancelledError` path on the backend (Plan 2 PR #64).
- In-chat error rendering with a Retry button.

## Pivot mid-implementation: Drawer → Sidebar Tab

The original plan used an antd `Drawer` overlay opened by a header button + `Cmd-K` shortcut. We pivoted to a sidebar tab during Task 7 implementation because:

- Architecturally simpler — no portal, no overlay state, reuses the existing right-sidebar resize/collapse logic.
- Eliminates the `ChatTrigger` component and the Cmd-K keybinding (~30 fewer LOC).
- Matches the long-term intent — the original brainstorm noted this as "option A; promote later". Promoting now while we're already touching this code is good timing.

## Test plan

- [x] 6 new test files (`ChatPanel`, `useChatTurn`, `useChatContext`, `eventReducer`, `ndjsonParser`, `suggestionChips`), 29 new tests; full `pnpm test` from `packages/highperformer`: 283 passing.
- [x] All mocked — no live network or real backend.
- [x] `pnpm typecheck` — no new errors (pre-existing unrelated errors remain).
- [ ] Manual smoke test against the Plan 2 backend (deploy both, navigate to a registered dataset slug, click the Chat tab).

## Out of scope / followups

- **Plan 2b:** server-side conversation persistence + history list UI.
- **Plan 2c:** decoupled background-task agent runs surviving disconnect, replay via `Last-Event-ID`.
- **Plan 4:** type-while-streaming with auto-cancel of the previous turn.
- LocalStorage/sessionStorage chat history (component-local in v1; refresh = empty).
- Tab selection persistence — currently resets to Summary on sidebar collapse/re-expand.

Backend Plan 2: cell-explorer-py PR #64 (merged).
Spec: `cell-explorer-py/docs/superpowers/specs/2026-05-05-frontend-chat-panel-design.md` (gitignored locally).