### PR TITLE
feat(config): view-config ↔ ui_action contract redesign (Plan 1 of 3)

### DIFF
--- a/.changeset/view-config-contract.md
+++ b/.changeset/view-config-contract.md
@@ -1,0 +1,10 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Refactors AppConfig contract: applyConfig returns typed ApplyResult,
+schema gains viewport / pointSize / opacity / summaryContext fields,
+implicit side effects become explicit defaults, errors surface as
+visible chat / loading / postMessage events instead of silent console
+warnings. Also adds `pnpm schema` script that emits
+`schema/app-config.schema.json` for cell-explorer-py codegen.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Check AppConfig JSON Schema is up to date
+        run: |
+          pnpm --filter @cbioportal-cell-explorer/highperformer schema
+          if ! git diff --exit-code packages/highperformer/schema/app-config.schema.json; then
+            echo "::error::packages/highperformer/schema/app-config.schema.json is stale. Run 'pnpm --filter @cbioportal-cell-explorer/highperformer schema' and commit the result."
+            exit 1
+          fi
       - run: pnpm --filter @cbioportal-cell-explorer/highperformer test
 
   build:

--- a/packages/highperformer/package.json
+++ b/packages/highperformer/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "schema": "tsx scripts/generate-schema.mjs"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
@@ -46,6 +47,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.8.3",
     "vite": "^7.3.1",
     "vitest": "^3.2.1"

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string"
+    },
+    "dataset": {
+      "type": "string"
+    },
+    "embedding": {
+      "type": "string"
+    },
+    "colorBy": {
+      "type": "string",
+      "enum": [
+        "gene",
+        "category"
+      ]
+    },
+    "gene": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "geneLabelColumn": {
+      "type": "string"
+    },
+    "filter": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "obsColumn": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "ids",
+        "obsColumn"
+      ],
+      "additionalProperties": false
+    },
+    "viewport": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "zoom": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "target",
+        "zoom"
+      ],
+      "additionalProperties": false
+    },
+    "pointSize": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "opacity": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "summaryObsColumns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "summaryGenes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "summaryContext": {
+      "type": "string",
+      "enum": [
+        "overall",
+        "selections"
+      ]
+    },
+    "showHeader": {
+      "type": "boolean"
+    },
+    "showLeftSidebar": {
+      "type": "boolean"
+    },
+    "showRightSidebar": {
+      "type": "boolean"
+    },
+    "showDatasetDropdown": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/highperformer/scripts/generate-schema.mjs
+++ b/packages/highperformer/scripts/generate-schema.mjs
@@ -1,0 +1,16 @@
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { z } from 'zod'
+import { AppConfigSchema } from '../src/config/schema.ts'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const out = resolve(__dirname, '..', 'schema', 'app-config.schema.json')
+mkdirSync(dirname(out), { recursive: true })
+
+const jsonSchema = z.toJSONSchema(AppConfigSchema, {
+  target: 'draft-2020-12',
+})
+
+writeFileSync(out, JSON.stringify(jsonSchema, null, 2) + '\n')
+console.log(`Wrote ${out}`)

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -5,6 +5,12 @@ import * as useChatContextModule from "./useChatContext";
 import * as useChatTurnModule from "./useChatTurn";
 import type { ChatEvent, ContextResponse } from "./types";
 
+// Mock applyConfig so individual tests can control its return value
+const mockApplyConfig = vi.fn()
+vi.mock("../config/applyConfig", () => ({
+  applyConfig: (...args: unknown[]) => mockApplyConfig(...args),
+}))
+
 vi.mock("../store/useAppStore", () => ({
   useAppStore: Object.assign(
     (selector: (s: unknown) => unknown) => selector({ applyConfig: vi.fn() }),
@@ -41,6 +47,9 @@ beforeEach(() => {
   });
   startMock.mockReset();
   stopMock.mockReset();
+  // Default: applyConfig succeeds
+  mockApplyConfig.mockReset()
+  mockApplyConfig.mockResolvedValue({ ok: true })
 });
 
 afterEach(() => {
@@ -73,6 +82,31 @@ describe("ChatPanel", () => {
     const [slug, messages] = startMock.mock.calls[0];
     expect(slug).toBe("spectrum");
     expect(messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("renders an error bubble when a ui_action applyConfig returns !ok", async () => {
+    mockApplyConfig.mockResolvedValue({
+      ok: false,
+      reason: { kind: "missing_companion", field: "gene" },
+    })
+
+    let dispatch: ((e: ChatEvent) => void) | null = null;
+    startMock.mockImplementation(async (_s, _m, onEvent) => {
+      dispatch = onEvent;
+    });
+    render(<ChatPanel slug="spectrum" />);
+    const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "color by gene" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(startMock).toHaveBeenCalled());
+
+    // Agent sends a ui_action with colorBy='gene' but no gene — applyConfig will fail
+    dispatch!({ type: "ui_action", payload: { colorBy: "gene" } });
+
+    // The async applyConfig failure should produce an error bubble
+    await waitFor(() =>
+      expect(screen.getByText(/colorBy is set but gene is missing/i)).toBeDefined()
+    );
   });
 
   it("renders an error bubble with Retry when an error event is dispatched", async () => {

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useLayoutEffect, useReducer, useRef, useState } from "reac
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { applyConfig as applyConfigFn } from "../config/applyConfig";
+import { applyErrorMessage } from "../config/applyResult";
 import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
 import type { ChatEvent, ChatMessage, MessagePart, WireMessage } from "./types";
@@ -84,11 +85,28 @@ function MessagePartView({ part }: { part: MessagePart }) {
 }
 
 export function ChatPanel({ slug }: { slug: string }) {
+  // applyConfigCallbackRef is a stable ref so the frozen reducerFn (created once
+  // via useRef) can always reach the current callback — which itself captures
+  // the stable `dispatch` returned by useReducer.
+  const applyConfigCallbackRef = useRef<(cfg: Record<string, unknown>) => void>(() => {})
   const reducerFn = useRef(
     (state: State, action: Action) =>
-      makeReducer((cfg) => void applyConfigFn(cfg as Parameters<typeof applyConfigFn>[0]))(state, action),
+      makeReducer((cfg) => applyConfigCallbackRef.current(cfg))(state, action),
   ).current;
   const [state, dispatch] = useReducer(reducerFn, undefined, initialState);
+
+  // Wire the callback now that dispatch is available. dispatch is stable
+  // (guaranteed by React), so this assignment runs once and stays valid.
+  applyConfigCallbackRef.current = (cfg) => {
+    applyConfigFn(cfg as Parameters<typeof applyConfigFn>[0]).then((result) => {
+      if (!result.ok) {
+        dispatch({
+          type: "AGENT_EVENT",
+          event: { type: "error", message: applyErrorMessage(result.reason), retryable: false },
+        })
+      }
+    })
+  }
   const [input, setInput] = useState("");
   const [lastSubmittedMessages, setLastSubmittedMessages] = useState<WireMessage[] | null>(null);
 

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -44,6 +44,19 @@ describe("eventReducer.reduce", () => {
     expect(after).toBe(before); // no state mutation
   });
 
+  it("ui_action: applyConfig callback may return a Promise (async-safe contract)", () => {
+    // The reducer forwards the payload to whatever callback is passed in.
+    // Callers (e.g. ChatPanel) are responsible for wiring ApplyResult error handling.
+    // This test verifies the reducer doesn't throw when the callback returns a Promise.
+    const asyncApply = vi.fn().mockResolvedValue({ ok: false, reason: { kind: "internal", message: "test" } });
+    const before = initialState();
+    // Should not throw even though the callback is async
+    expect(() =>
+      reduce(before, { type: "ui_action", payload: { colorBy: "gene" } }, asyncApply)
+    ).not.toThrow();
+    expect(asyncApply).toHaveBeenCalledTimes(1);
+  });
+
   it("error event appends ErrorPart and sets status to error, keeps preceding text", () => {
     let s = initialState();
     s = reduce(s, { type: "text_delta", text: "partial " }, noopApply);

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -275,17 +275,18 @@ describe('applyConfig — metadata_unavailable + summaryContext defaults', () =>
   })
 
   it('respects an explicit summaryContext that overrides the default', async () => {
+    // Schema 'overall' maps to store 'all' (external vs. internal naming)
     useAppStore.setState({
       varNames: [],
       obsmKeys: [],
       obsColumnNames: ['cell_type'],
-      summaryContext: 'overall',
-    } as any)
+      summaryContext: 'all',
+    })
     await applyConfig({
       filter: { obsColumn: 'cell_type', ids: ['T'] },
       summaryContext: 'overall',
     })
-    expect(useAppStore.getState().summaryContext).toBe('overall')
+    expect(useAppStore.getState().summaryContext).toBe('all')
   })
 })
 

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -288,3 +288,54 @@ describe('applyConfig — metadata_unavailable + summaryContext defaults', () =>
     expect(useAppStore.getState().summaryContext).toBe('overall')
   })
 })
+
+describe('applyConfig — new schema fields apply to store', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+      pointRadius: 1,
+      opacity: 1,
+      summaryContext: 'overall',
+    } as any)
+  })
+
+  it('applies pointSize (maps to pointRadius) and opacity', async () => {
+    const result = await applyConfig({ pointSize: 3, opacity: 0.5 })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().pointRadius).toBe(3)
+    expect(useAppStore.getState().opacity).toBe(0.5)
+  })
+
+  it('applies summaryContext explicitly', async () => {
+    const result = await applyConfig({ summaryContext: 'selections' })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().summaryContext).toBe('selections')
+  })
+
+  it('applies viewport target + zoom (calls store action)', async () => {
+    const setViewport = vi.fn()
+    useAppStore.setState({ setViewport } as any)
+    const result = await applyConfig({ viewport: { target: [10, 20], zoom: 2 } })
+    expect(result.ok).toBe(true)
+    expect(setViewport).toHaveBeenCalledWith({ target: [10, 20], zoom: 2 })
+  })
+
+  it('writes viewport to store via setViewport action (real, not mocked)', async () => {
+    // Reset to initial state first to ensure the real setViewport action is in place
+    // (the previous test in this block injects a vi.fn() mock and doesn't restore it).
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+      pendingViewport: null,
+    } as any)
+    const result = await applyConfig({ viewport: { target: [10, 20], zoom: 2 } })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().pendingViewport).toEqual({ target: [10, 20], zoom: 2 })
+  })
+})

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -165,3 +165,25 @@ describe('applyConfig — return type and schema validation', () => {
     if (!result.ok) expect(result.reason.kind).toBe('schema_validation')
   })
 })
+
+describe('applyConfig — cross-field validation', () => {
+  it('returns missing_companion when colorBy=gene without gene', async () => {
+    const result = await applyConfig({ colorBy: 'gene' })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'missing_companion') {
+      expect(result.reason.field).toBe('gene')
+    } else {
+      throw new Error('expected missing_companion error')
+    }
+  })
+
+  it('returns missing_companion when colorBy=category without category', async () => {
+    const result = await applyConfig({ colorBy: 'category' })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'missing_companion') {
+      expect(result.reason.field).toBe('category')
+    } else {
+      throw new Error('expected missing_companion error')
+    }
+  })
+})

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -244,3 +244,47 @@ describe('applyConfig — apply-time field validation', () => {
     }
   })
 })
+
+describe('applyConfig — metadata_unavailable + summaryContext defaults', () => {
+  it('returns metadata_unavailable when post-load fields are requested before any dataset is loaded', async () => {
+    // Reset store to "no dataset loaded" state
+    useAppStore.setState({
+      varNames: [],
+      varColumns: [],
+      obsmKeys: [],
+      obsColumnNames: [],
+      loading: false,
+    } as any)
+
+    // Test relies on the refactored applyConfig short-circuiting when there's
+    // no dataset load in flight at all.
+    const result = await applyConfig({ embedding: 'X_umap' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.kind).toBe('metadata_unavailable')
+  })
+
+  it('defaults summaryContext to "selections" when filter is set and summaryContext is not provided', async () => {
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: [],
+      obsColumnNames: ['cell_type'],
+      summaryContext: 'overall',
+    } as any)
+    await applyConfig({ filter: { obsColumn: 'cell_type', ids: ['T'] } })
+    expect(useAppStore.getState().summaryContext).toBe('selections')
+  })
+
+  it('respects an explicit summaryContext that overrides the default', async () => {
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: [],
+      obsColumnNames: ['cell_type'],
+      summaryContext: 'overall',
+    } as any)
+    await applyConfig({
+      filter: { obsColumn: 'cell_type', ids: ['T'] },
+      summaryContext: 'overall',
+    })
+    expect(useAppStore.getState().summaryContext).toBe('overall')
+  })
+})

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -146,3 +146,22 @@ describe('applyConfig', () => {
     selectByIds.mockRestore()
   })
 })
+
+describe('applyConfig — return type and schema validation', () => {
+  it('returns { ok: true } on a valid empty payload', async () => {
+    const result = await applyConfig({})
+    expect(result.ok).toBe(true)
+  })
+
+  it('returns { ok: false, kind: "schema_validation" } on garbage payload', async () => {
+    const result = await applyConfig({ pointSize: 'huge' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.kind).toBe('schema_validation')
+  })
+
+  it('returns { ok: false, kind: "schema_validation" } when neither url nor dataset is implied (null payload)', async () => {
+    const result = await applyConfig(null)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.kind).toBe('schema_validation')
+  })
+})

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -106,9 +106,7 @@ describe('applyConfig', () => {
     setSelectedEmbedding.mockRestore()
   })
 
-  it('warns and skips invalid embedding', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
+  it('returns field_value_invalid for invalid embedding', async () => {
     const config: AppConfig = {
       url: 'https://example.com/data.zarr',
       embedding: 'X_nonexistent',
@@ -120,10 +118,15 @@ describe('applyConfig', () => {
 
     const promise = applyConfig(config)
     useAppStore.setState({ obsColumnNames: ['cell_type'], obsmKeys: ['X_umap'], varNames: [], varColumns: [] })
-    await promise
+    const result = await promise
 
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('X_nonexistent'))
-    warn.mockRestore()
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('embedding')
+      expect(result.reason.value).toBe('X_nonexistent')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
   })
 
   it('calls selectByIds for filter config', async () => {
@@ -184,6 +187,60 @@ describe('applyConfig — cross-field validation', () => {
       expect(result.reason.field).toBe('category')
     } else {
       throw new Error('expected missing_companion error')
+    }
+  })
+})
+
+describe('applyConfig — apply-time field validation', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: ['CD3D', 'CD8A', 'GZMK'],
+      varColumns: ['feature_id', 'gene_symbol'],
+      obsmKeys: ['X_umap', 'X_pca'],
+      obsColumnNames: ['cell_type', 'percent_mt'],
+    } as any)
+  })
+
+  it('returns field_value_invalid for unknown gene', async () => {
+    const result = await applyConfig({ colorBy: 'gene', gene: 'NONEXISTENT' })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('gene')
+      expect(result.reason.value).toBe('NONEXISTENT')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('returns field_value_invalid for unknown embedding', async () => {
+    const result = await applyConfig({ embedding: 'X_imaginary' })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('embedding')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('returns field_value_invalid for unknown filter.obsColumn', async () => {
+    const result = await applyConfig({
+      filter: { obsColumn: 'no_such_col', ids: ['x'] },
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('filter.obsColumn')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('returns field_value_invalid for unknown geneLabelColumn', async () => {
+    const result = await applyConfig({ geneLabelColumn: 'not_a_var_col' })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('geneLabelColumn')
+    } else {
+      throw new Error('expected field_value_invalid error')
     }
   })
 })

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -1,47 +1,55 @@
-import type { AppConfig } from './schema'
+import { AppConfigSchema, type AppConfig } from './schema'
 import useAppStore from '../store/useAppStore'
 import { waitForStore } from './waitForStore'
+import { ok, err, type ApplyResult } from './applyResult'
 
-export async function applyConfig(config: AppConfig): Promise<void> {
+export async function applyConfig(input: unknown): Promise<ApplyResult> {
+  const parsed = AppConfigSchema.safeParse(input)
+  if (!parsed.success) {
+    return err({ kind: 'schema_validation', details: parsed.error.issues })
+  }
+  const config: AppConfig = parsed.data
+
   const store = useAppStore
 
-  // Phase 1: Set UI toggles immediately
+  // Phase 1: Set UI toggles only when the caller supplied them
   store.setState({
-    showHeader: config.showHeader,
-    showLeftSidebar: config.showLeftSidebar,
-    showRightSidebar: config.showRightSidebar,
-    showDatasetDropdown: config.showDatasetDropdown,
+    ...(config.showHeader !== undefined && { showHeader: config.showHeader }),
+    ...(config.showLeftSidebar !== undefined && { showLeftSidebar: config.showLeftSidebar }),
+    ...(config.showRightSidebar !== undefined && { showRightSidebar: config.showRightSidebar }),
+    ...(config.showDatasetDropdown !== undefined && { showDatasetDropdown: config.showDatasetDropdown }),
   })
 
-  // Phase 2: Trigger dataset load
-  // openDataset early-returns if the URL matches the current dataset.
-  // In that case, metadata may already be available — waitForStore
-  // handles this by checking the predicate immediately before subscribing.
+  // Phase 2: Trigger dataset load if requested
   if (config.dataset) {
     await store.getState().openCatalogDataset(config.dataset)
   } else if (config.url) {
     store.getState().openDataset(config.url)
   }
 
-  // Phase 3: Wait for dataset metadata, then apply remaining config
+  // Phase 3: Wait for dataset metadata (kept as-is for this task; restructured in Task 7)
   const hasPostLoadConfig =
     config.embedding ||
     config.colorBy ||
     config.geneLabelColumn ||
     config.filter ||
     config.summaryObsColumns ||
-    config.summaryGenes
+    config.summaryGenes ||
+    config.viewport ||
+    config.pointSize !== undefined ||
+    config.opacity !== undefined ||
+    config.summaryContext
 
-  if (!hasPostLoadConfig) return
+  if (!hasPostLoadConfig) return ok()
 
   try {
     await waitForStore(store, (s) => s.obsColumnNames.length > 0)
   } catch {
     console.warn('[config] Timed out waiting for dataset metadata — skipping post-load config')
-    return
+    return ok() // ← will become metadata_unavailable in Task 7
   }
 
-  // 3a: Gene label column (overrides auto-detection)
+  // 3a: Gene label column
   if (config.geneLabelColumn) {
     const { varColumns } = store.getState()
     if (varColumns.includes(config.geneLabelColumn)) {
@@ -57,11 +65,11 @@ export async function applyConfig(config: AppConfig): Promise<void> {
     if (obsmKeys.includes(config.embedding)) {
       store.getState().setSelectedEmbedding(config.embedding)
     } else {
-      console.warn(`[config] embedding "${config.embedding}" not found in dataset — available: ${obsmKeys.join(', ')}`)
+      console.warn(`[config] embedding "${config.embedding}" not found — available: ${obsmKeys.join(', ')}`)
     }
   }
 
-  // 3c: Color mapping
+  // 3c: Color mapping (cross-field check moved to Task 5)
   if (config.colorBy === 'gene' && config.gene) {
     const { varNames } = store.getState()
     if (varNames.includes(config.gene)) {
@@ -80,14 +88,14 @@ export async function applyConfig(config: AppConfig): Promise<void> {
     }
   }
 
-  // 3d: Summary panel (sequential to avoid saturating connections)
+  // 3d: Summary panel
   if (config.summaryObsColumns) {
     const { obsColumnNames } = store.getState()
     for (const col of config.summaryObsColumns) {
       if (obsColumnNames.includes(col)) {
         store.getState().addSummaryObsColumn(col)
       } else {
-        console.warn(`[config] summary obs column "${col}" not found in dataset`)
+        console.warn(`[config] summary obs column "${col}" not found`)
       }
     }
   }
@@ -97,14 +105,16 @@ export async function applyConfig(config: AppConfig): Promise<void> {
       if (varNames.includes(gene)) {
         store.getState().addSummaryGene(gene)
       } else {
-        console.warn(`[config] summary gene "${gene}" not found in dataset`)
+        console.warn(`[config] summary gene "${gene}" not found`)
       }
     }
   }
 
-  // 3e: Custom group filter (last — depends on obs column data)
+  // 3e: Custom group filter (side-effect cleanup in Task 7)
   if (config.filter && config.filter.ids.length > 0) {
     store.getState().selectByIds(config.filter.obsColumn, config.filter.ids)
     store.setState({ summaryContext: 'selections' })
   }
+
+  return ok()
 }

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -35,7 +35,8 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.getState().openDataset(config.url)
   }
 
-  // Phase 3: Wait for dataset metadata (kept as-is for this task; restructured in Task 7)
+  // Phase 3: Wait for dataset metadata (or fail). If no dataset is loading
+  // at all, surface that as metadata_unavailable instead of silently dropping.
   const hasPostLoadConfig =
     config.embedding ||
     config.colorBy ||
@@ -50,11 +51,18 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
 
   if (!hasPostLoadConfig) return ok()
 
-  try {
-    await waitForStore(store, (s) => s.obsColumnNames.length > 0)
-  } catch {
-    console.warn('[config] Timed out waiting for dataset metadata — skipping post-load config')
-    return ok() // ← will become metadata_unavailable in Task 7
+  const metadataReady = store.getState().obsColumnNames.length > 0
+  const datasetLoading =
+    !metadataReady && (config.dataset !== undefined || config.url !== undefined || store.getState().loading)
+
+  if (!metadataReady && datasetLoading) {
+    try {
+      await waitForStore(store, (s) => s.obsColumnNames.length > 0)
+    } catch {
+      return err({ kind: 'metadata_unavailable', field: 'post-load' })
+    }
+  } else if (!metadataReady) {
+    return err({ kind: 'metadata_unavailable', field: 'post-load' })
   }
 
   // 3a: Gene label column
@@ -142,7 +150,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     }
   }
 
-  // 3e: Custom group filter (side-effect cleanup in Task 7)
+  // 3e: Custom group filter
   if (config.filter && config.filter.ids.length > 0) {
     const { obsColumnNames } = store.getState()
     if (!obsColumnNames.includes(config.filter.obsColumn)) {
@@ -154,7 +162,16 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
       })
     }
     store.getState().selectByIds(config.filter.obsColumn, config.filter.ids)
-    store.setState({ summaryContext: 'selections' }) // ← cleanup in Task 7
+    // Default: when filter is set, switch summary to selections — UNLESS the
+    // caller explicitly specified summaryContext (then their value wins).
+    if (config.summaryContext === undefined) {
+      store.setState({ summaryContext: 'selections' })
+    }
+  }
+
+  // Explicit summaryContext (always wins over implicit default)
+  if (config.summaryContext !== undefined) {
+    store.setState({ summaryContext: config.summaryContext })
   }
 
   return ok()

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -10,6 +10,14 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   }
   const config: AppConfig = parsed.data
 
+  // Cross-field validation: colorBy requires its companion field
+  if (config.colorBy === 'gene' && !config.gene) {
+    return err({ kind: 'missing_companion', field: 'gene' })
+  }
+  if (config.colorBy === 'category' && !config.category) {
+    return err({ kind: 'missing_companion', field: 'category' })
+  }
+
   const store = useAppStore
 
   // Phase 1: Set UI toggles only when the caller supplied them

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -174,5 +174,19 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.setState({ summaryContext: config.summaryContext })
   }
 
+  // Rendering controls — map schema field names to store field names
+  if (config.pointSize !== undefined) {
+    store.setState({ pointRadius: config.pointSize })
+  }
+  if (config.opacity !== undefined) {
+    store.setState({ opacity: config.opacity })
+  }
+
+  // Viewport — delegate to the store action (talks to deck.gl on next mount)
+  if (config.viewport !== undefined) {
+    const { setViewport } = store.getState()
+    setViewport(config.viewport)
+  }
+
   return ok()
 }

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -170,8 +170,11 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   }
 
   // Explicit summaryContext (always wins over implicit default)
+  // Schema uses 'overall' (external API) → store uses 'all' (internal)
   if (config.summaryContext !== undefined) {
-    store.setState({ summaryContext: config.summaryContext })
+    store.setState({
+      summaryContext: config.summaryContext === 'overall' ? 'all' : config.summaryContext,
+    })
   }
 
   // Rendering controls — map schema field names to store field names

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -60,68 +60,101 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   // 3a: Gene label column
   if (config.geneLabelColumn) {
     const { varColumns } = store.getState()
-    if (varColumns.includes(config.geneLabelColumn)) {
-      store.getState().setGeneLabelColumn(config.geneLabelColumn)
-    } else {
-      console.warn(`[config] geneLabelColumn "${config.geneLabelColumn}" not found in dataset var columns`)
+    if (!varColumns.includes(config.geneLabelColumn)) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'geneLabelColumn',
+        value: config.geneLabelColumn,
+        reason: `not found in dataset var columns (available: ${varColumns.join(', ')})`,
+      })
     }
+    store.getState().setGeneLabelColumn(config.geneLabelColumn)
   }
 
   // 3b: Embedding
   if (config.embedding) {
     const { obsmKeys } = store.getState()
-    if (obsmKeys.includes(config.embedding)) {
-      store.getState().setSelectedEmbedding(config.embedding)
-    } else {
-      console.warn(`[config] embedding "${config.embedding}" not found — available: ${obsmKeys.join(', ')}`)
+    if (!obsmKeys.includes(config.embedding)) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'embedding',
+        value: config.embedding,
+        reason: `not found in dataset (available: ${obsmKeys.join(', ')})`,
+      })
     }
+    store.getState().setSelectedEmbedding(config.embedding)
   }
 
   // 3c: Color mapping (cross-field check moved to Task 5)
   if (config.colorBy === 'gene' && config.gene) {
     const { varNames } = store.getState()
-    if (varNames.includes(config.gene)) {
-      store.getState().setColorMode('gene')
-      store.getState().selectGene(config.gene)
-    } else {
-      console.warn(`[config] gene "${config.gene}" not found in dataset`)
+    if (!varNames.includes(config.gene)) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'gene',
+        value: config.gene,
+        reason: 'not found in dataset',
+      })
     }
+    store.getState().setColorMode('gene')
+    store.getState().selectGene(config.gene)
   } else if (config.colorBy === 'category' && config.category) {
     const { obsColumnNames } = store.getState()
-    if (obsColumnNames.includes(config.category)) {
-      store.getState().setColorMode('category')
-      store.getState().selectObsColumn(config.category)
-    } else {
-      console.warn(`[config] category column "${config.category}" not found in dataset`)
+    if (!obsColumnNames.includes(config.category)) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'category',
+        value: config.category,
+        reason: 'not found in dataset',
+      })
     }
+    store.getState().setColorMode('category')
+    store.getState().selectObsColumn(config.category)
   }
 
   // 3d: Summary panel
   if (config.summaryObsColumns) {
     const { obsColumnNames } = store.getState()
     for (const col of config.summaryObsColumns) {
-      if (obsColumnNames.includes(col)) {
-        store.getState().addSummaryObsColumn(col)
-      } else {
-        console.warn(`[config] summary obs column "${col}" not found`)
+      if (!obsColumnNames.includes(col)) {
+        return err({
+          kind: 'field_value_invalid',
+          field: 'summaryObsColumns',
+          value: col,
+          reason: 'not found in dataset',
+        })
       }
+      store.getState().addSummaryObsColumn(col)
     }
   }
   if (config.summaryGenes) {
     const { varNames } = store.getState()
     for (const gene of config.summaryGenes) {
-      if (varNames.includes(gene)) {
-        store.getState().addSummaryGene(gene)
-      } else {
-        console.warn(`[config] summary gene "${gene}" not found`)
+      if (!varNames.includes(gene)) {
+        return err({
+          kind: 'field_value_invalid',
+          field: 'summaryGenes',
+          value: gene,
+          reason: 'not found in dataset',
+        })
       }
+      store.getState().addSummaryGene(gene)
     }
   }
 
   // 3e: Custom group filter (side-effect cleanup in Task 7)
   if (config.filter && config.filter.ids.length > 0) {
+    const { obsColumnNames } = store.getState()
+    if (!obsColumnNames.includes(config.filter.obsColumn)) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'filter.obsColumn',
+        value: config.filter.obsColumn,
+        reason: 'not found in dataset',
+      })
+    }
     store.getState().selectByIds(config.filter.obsColumn, config.filter.ids)
-    store.setState({ summaryContext: 'selections' })
+    store.setState({ summaryContext: 'selections' }) // ← cleanup in Task 7
   }
 
   return ok()

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -93,7 +93,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.getState().setSelectedEmbedding(config.embedding)
   }
 
-  // 3c: Color mapping (cross-field check moved to Task 5)
+  // 3c: Color mapping (cross-field check is at the top of applyConfig)
   if (config.colorBy === 'gene' && config.gene) {
     const { varNames } = store.getState()
     if (!varNames.includes(config.gene)) {
@@ -169,8 +169,13 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     }
   }
 
-  // Explicit summaryContext (always wins over implicit default)
-  // Schema uses 'overall' (external API) → store uses 'all' (internal)
+  // Explicit summaryContext (always wins over implicit default).
+  //
+  // Vocabulary note: the AppConfig schema exposes 'overall' | 'selections' as
+  // the external/agent-facing surface. The store internally uses 'all' |
+  // 'selections' | 'compare'. We map 'overall' → 'all' here. The store's
+  // 'compare' value is intentionally NOT exposed in the schema — it's a
+  // UI-driven mode that the agent has no business setting.
   if (config.summaryContext !== undefined) {
     store.setState({
       summaryContext: config.summaryContext === 'overall' ? 'all' : config.summaryContext,

--- a/packages/highperformer/src/config/applyResult.ts
+++ b/packages/highperformer/src/config/applyResult.ts
@@ -1,0 +1,33 @@
+import type { ZodIssue } from 'zod'
+
+export type ApplyError =
+  | { kind: 'schema_validation'; details: ZodIssue[] }
+  | { kind: 'missing_companion'; field: 'gene' | 'category' }
+  | { kind: 'field_value_invalid'; field: string; value: unknown; reason: string }
+  | { kind: 'metadata_unavailable'; field: string }
+  | { kind: 'internal'; message: string }
+
+export type ApplyResult = { ok: true } | { ok: false; reason: ApplyError }
+
+export function ok(): ApplyResult {
+  return { ok: true }
+}
+
+export function err(reason: ApplyError): ApplyResult {
+  return { ok: false, reason }
+}
+
+export function applyErrorMessage(reason: ApplyError): string {
+  switch (reason.kind) {
+    case 'schema_validation':
+      return `Invalid config: ${reason.details.map((d) => d.message).join('; ')}`
+    case 'missing_companion':
+      return `Couldn't apply: colorBy is set but ${reason.field} is missing`
+    case 'field_value_invalid':
+      return `Couldn't apply: ${reason.field}=${JSON.stringify(reason.value)} — ${reason.reason}`
+    case 'metadata_unavailable':
+      return `Couldn't apply ${reason.field}: dataset metadata not available`
+    case 'internal':
+      return `Internal error: ${reason.message}`
+  }
+}

--- a/packages/highperformer/src/config/parseConfig.test.ts
+++ b/packages/highperformer/src/config/parseConfig.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect, vi } from 'vitest'
-import { parseConfig } from './parseConfig'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock applyConfig before importing parseConfig so the module uses the mock
+const mockApplyConfig = vi.fn()
+vi.mock('./applyConfig', () => ({
+  applyConfig: (...args: unknown[]) => mockApplyConfig(...args),
+}))
+
+const { parseConfig, applyParsedConfig } = await import('./parseConfig')
+const { default: useAppStore } = await import('../store/useAppStore')
+
+beforeEach(() => {
+  mockApplyConfig.mockReset()
+  mockApplyConfig.mockResolvedValue({ ok: true })
+  useAppStore.setState(useAppStore.getInitialState())
+})
 
 describe('parseConfig', () => {
   it('returns null when no config param', () => {
@@ -48,5 +62,39 @@ describe('parseConfig', () => {
     const result = parseConfig(doubleEncoded)
     expect(result).not.toBeNull()
     expect(result!.url).toBe('https://example.com/data.zarr')
+  })
+})
+
+describe('applyParsedConfig', () => {
+  it('does nothing when configParam is null', async () => {
+    await applyParsedConfig(null)
+    expect(mockApplyConfig).not.toHaveBeenCalled()
+    expect(useAppStore.getState().loadingError).toBeNull()
+  })
+
+  it('calls applyConfig with parsed config on valid input', async () => {
+    const json = JSON.stringify({ url: 'https://example.com/data.zarr' })
+    await applyParsedConfig(json)
+    expect(mockApplyConfig).toHaveBeenCalledTimes(1)
+    expect(mockApplyConfig).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://example.com/data.zarr' }))
+    expect(useAppStore.getState().loadingError).toBeNull()
+  })
+
+  it('sets loadingError when applyConfig returns !ok', async () => {
+    mockApplyConfig.mockResolvedValue({
+      ok: false,
+      reason: { kind: 'missing_companion', field: 'gene' },
+    })
+    const json = JSON.stringify({ colorBy: 'gene' })
+    await applyParsedConfig(json)
+    expect(useAppStore.getState().loadingError).toBe(
+      "Couldn't apply: colorBy is set but gene is missing"
+    )
+  })
+
+  it('does not set loadingError when applyConfig returns ok', async () => {
+    const json = JSON.stringify({ url: 'https://example.com/data.zarr' })
+    await applyParsedConfig(json)
+    expect(useAppStore.getState().loadingError).toBeNull()
   })
 })

--- a/packages/highperformer/src/config/parseConfig.ts
+++ b/packages/highperformer/src/config/parseConfig.ts
@@ -1,4 +1,7 @@
 import { AppConfigSchema, type AppConfig } from './schema'
+import { applyConfig } from './applyConfig'
+import { applyErrorMessage } from './applyResult'
+import useAppStore from '../store/useAppStore'
 
 export function parseConfig(configParam: string | null): AppConfig | null {
   if (!configParam) return null
@@ -30,4 +33,18 @@ export function parseConfig(configParam: string | null): AppConfig | null {
   }
 
   return result.data
+}
+
+/**
+ * Parse a URL ?config= param and apply it, surfacing ApplyResult errors via
+ * the store's loadingError field (same UI path as dataset-load failures).
+ */
+export async function applyParsedConfig(configParam: string | null): Promise<void> {
+  const config = parseConfig(configParam)
+  if (!config) return
+
+  const result = await applyConfig(config)
+  if (!result.ok) {
+    useAppStore.setState({ loadingError: applyErrorMessage(result.reason) })
+  }
 }

--- a/packages/highperformer/src/config/schema.test.ts
+++ b/packages/highperformer/src/config/schema.test.ts
@@ -1,173 +1,45 @@
-import { describe, it, expect } from 'vitest'
-import { AppConfigSchema, MessageSchema, type AppConfig } from './schema'
+import { describe, expect, it } from 'vitest'
+import { AppConfigSchema } from './schema'
 
 describe('AppConfigSchema', () => {
-  it('validates a minimal config with only url', () => {
-    const result = AppConfigSchema.safeParse({ url: 'https://example.com/data.zarr' })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.url).toBe('https://example.com/data.zarr')
-    }
-  })
-
-  it('rejects config without url or dataset', () => {
-    const result = AppConfigSchema.safeParse({ embedding: 'X_umap' })
-    expect(result.success).toBe(false)
-  })
-
-  it('validates a config with dataset slug instead of url', () => {
-    const result = AppConfigSchema.safeParse({ dataset: 'pbmc3k-private' })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.dataset).toBe('pbmc3k-private')
-      expect(result.data.url).toBeUndefined()
-    }
-  })
-
-  it('validates a full config', () => {
+  it('accepts a fully-populated config', () => {
     const result = AppConfigSchema.safeParse({
       url: 'https://example.com/data.zarr',
       embedding: 'X_umap',
       colorBy: 'gene',
-      gene: 'TP53',
-      geneLabelColumn: 'gene_symbol',
-      filter: { ids: ['cell1', 'cell2'], obsColumn: 'sample_id' },
-      summaryObsColumns: ['cell_type', 'batch'],
-      summaryGenes: ['TP53', 'BRCA1'],
+      gene: 'CD3D',
+      filter: { obsColumn: 'cell_type', ids: ['T'] },
+      viewport: { target: [10, 20], zoom: 3 },
+      pointSize: 2.5,
+      opacity: 0.8,
+      summaryContext: 'selections',
+      summaryObsColumns: ['cell_type'],
+      summaryGenes: ['CD3D'],
       showHeader: false,
-      showLeftSidebar: true,
-      showRightSidebar: true,
-      showDatasetDropdown: false,
     })
     expect(result.success).toBe(true)
   })
 
-  it('strips unknown fields', () => {
-    const result = AppConfigSchema.safeParse({
-      url: 'https://example.com/data.zarr',
-      unknownField: 'value',
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect((result.data as Record<string, unknown>).unknownField).toBeUndefined()
-    }
+  it('accepts an empty config (all fields optional)', () => {
+    expect(AppConfigSchema.safeParse({}).success).toBe(true)
   })
 
-  it('defaults UI toggles to true when not specified', () => {
-    const result = AppConfigSchema.safeParse({ url: 'https://example.com/data.zarr' })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.showHeader).toBe(true)
-      expect(result.data.showLeftSidebar).toBe(true)
-      expect(result.data.showRightSidebar).toBe(true)
-      expect(result.data.showDatasetDropdown).toBe(true)
-    }
-  })
-
-  it('validates colorBy gene requires gene field', () => {
-    const result = AppConfigSchema.safeParse({
-      url: 'https://example.com/data.zarr',
-      colorBy: 'gene',
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.colorBy).toBeUndefined()
-    }
-  })
-
-  it('validates colorBy category requires category field', () => {
-    const result = AppConfigSchema.safeParse({
-      url: 'https://example.com/data.zarr',
-      colorBy: 'category',
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.colorBy).toBeUndefined()
-    }
-  })
-
-  it('keeps colorBy gene when gene is provided', () => {
-    const result = AppConfigSchema.safeParse({
-      url: 'https://example.com/data.zarr',
-      colorBy: 'gene',
-      gene: 'TP53',
-    })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.colorBy).toBe('gene')
-      expect(result.data.gene).toBe('TP53')
-    }
-  })
-
-  it('validates filter requires both ids and obsColumn', () => {
-    const result = AppConfigSchema.safeParse({
-      url: 'https://example.com/data.zarr',
-      filter: { ids: ['cell1'] },
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('accepts empty ids array in filter', () => {
-    const result = AppConfigSchema.safeParse({
-      url: 'https://example.com/data.zarr',
-      filter: { ids: [], obsColumn: 'sample_id' },
-    })
-    expect(result.success).toBe(true)
-  })
-})
-
-describe('MessageSchema', () => {
-  it('validates a valid applyConfig message', () => {
-    const result = MessageSchema.safeParse({
-      type: 'applyConfig',
-      payload: { url: 'https://example.com/data.zarr' },
-    })
+  it('does NOT enforce cross-field rules in the schema (moved to applyConfig)', () => {
+    // colorBy="gene" without `gene` is a SCHEMA-VALID payload now;
+    // applyConfig's missing_companion check rejects it at apply time.
+    const result = AppConfigSchema.safeParse({ colorBy: 'gene' })
     expect(result.success).toBe(true)
   })
 
-  it('rejects message with missing type', () => {
-    const result = MessageSchema.safeParse({
-      payload: { url: 'https://example.com/data.zarr' },
-    })
-    expect(result.success).toBe(false)
+  it('rejects invalid types', () => {
+    expect(AppConfigSchema.safeParse({ pointSize: 'big' }).success).toBe(false)
+    expect(AppConfigSchema.safeParse({ opacity: 1.5 }).success).toBe(false)
+    expect(AppConfigSchema.safeParse({ viewport: { target: [1, 2] } }).success).toBe(false)
   })
 
-  it('rejects message with unknown type', () => {
-    const result = MessageSchema.safeParse({
-      type: 'unknownType',
-      payload: { url: 'https://example.com/data.zarr' },
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects message with invalid payload', () => {
-    const result = MessageSchema.safeParse({
-      type: 'applyConfig',
-      payload: { embedding: 'X_umap' }, // missing url and dataset
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects non-object messages', () => {
-    expect(MessageSchema.safeParse('hello').success).toBe(false)
-    expect(MessageSchema.safeParse(42).success).toBe(false)
-    expect(MessageSchema.safeParse(null).success).toBe(false)
-  })
-
-  it('validates payload with full config', () => {
-    const result = MessageSchema.safeParse({
-      type: 'applyConfig',
-      payload: {
-        url: 'https://example.com/data.zarr',
-        embedding: 'X_umap',
-        filter: { ids: ['cell1'], obsColumn: 'sample_id' },
-        showHeader: false,
-      },
-    })
+  it('rejects unknown fields when strict (additionalProperties=false on viewport)', () => {
+    // Top-level lenient behavior is acceptable — this test asserts that.
+    const result = AppConfigSchema.safeParse({ embedding: 'X_umap', futuristicField: 'x' })
     expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.payload.url).toBe('https://example.com/data.zarr')
-      expect(result.data.payload.showHeader).toBe(false)
-    }
   })
 })

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -5,38 +5,43 @@ const FilterSchema = z.object({
   obsColumn: z.string(),
 })
 
-const RawConfigSchema = z.object({
+const ViewportSchema = z.object({
+  target: z.tuple([z.number(), z.number()]),
+  zoom: z.number(),
+})
+
+export const AppConfigSchema = z.object({
+  // dataset source
   url: z.string().optional(),
   dataset: z.string().optional(),
+
+  // data view
   embedding: z.string().optional(),
   colorBy: z.enum(['gene', 'category']).optional(),
   gene: z.string().optional(),
   category: z.string().optional(),
   geneLabelColumn: z.string().optional(),
+
+  // filter (tightly bound — nested)
   filter: FilterSchema.optional(),
+
+  // viewport (tightly bound — nested, NEW)
+  viewport: ViewportSchema.optional(),
+
+  // rendering (flat, NEW)
+  pointSize: z.number().positive().optional(),
+  opacity: z.number().min(0).max(1).optional(),
+
+  // summary panel
   summaryObsColumns: z.array(z.string()).optional(),
   summaryGenes: z.array(z.string()).optional(),
-  showHeader: z.boolean().default(true),
-  showLeftSidebar: z.boolean().default(true),
-  showRightSidebar: z.boolean().default(true),
-  showDatasetDropdown: z.boolean().default(true),
-}).refine((data) => data.url || data.dataset, {
-  message: 'Either "url" or "dataset" must be provided',
-})
+  summaryContext: z.enum(['overall', 'selections']).optional(),
 
-export const AppConfigSchema = RawConfigSchema.transform((data) => {
-  // Strip colorBy if its companion field is missing
-  if (data.colorBy === 'gene' && !data.gene) {
-    console.warn('[config] colorBy "gene" requires a "gene" field — ignoring colorBy')
-    const { colorBy, ...rest } = data
-    return rest
-  }
-  if (data.colorBy === 'category' && !data.category) {
-    console.warn('[config] colorBy "category" requires a "category" field — ignoring colorBy')
-    const { colorBy, ...rest } = data
-    return rest
-  }
-  return data
+  // UI chrome
+  showHeader: z.boolean().optional(),
+  showLeftSidebar: z.boolean().optional(),
+  showRightSidebar: z.boolean().optional(),
+  showDatasetDropdown: z.boolean().optional(),
 })
 
 export type AppConfig = z.output<typeof AppConfigSchema>

--- a/packages/highperformer/src/config/usePostMessage.test.ts
+++ b/packages/highperformer/src/config/usePostMessage.test.ts
@@ -16,7 +16,7 @@ vi.mock('../workers/universal.worker.ts?worker', () => ({
 }))
 
 // Mock applyConfig
-const mockApplyConfig = vi.fn().mockResolvedValue(undefined)
+const mockApplyConfig = vi.fn().mockResolvedValue({ ok: true })
 vi.mock('./applyConfig', () => ({
   applyConfig: (...args: unknown[]) => mockApplyConfig(...args),
 }))
@@ -81,6 +81,7 @@ describe('usePostMessage hook', () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState())
     mockApplyConfig.mockClear()
+    mockApplyConfig.mockResolvedValue({ ok: true })
     mockDispatch.mockClear()
     addSpy = vi.spyOn(window, 'addEventListener')
     removeSpy = vi.spyOn(window, 'removeEventListener')
@@ -270,5 +271,62 @@ describe('usePostMessage hook', () => {
       'https://evil.com',
     )
     warn.mockRestore()
+  })
+
+  it('replies to parent with applyConfigResult ok:true on success', async () => {
+    vi.stubEnv('VITE_ENABLE_POSTMESSAGE', 'true')
+    vi.stubEnv('VITE_POSTMESSAGE_ORIGIN', '*')
+    mockApplyConfig.mockResolvedValue({ ok: true })
+
+    const postMessageSpy = vi.fn()
+    const fakeSource = { postMessage: postMessageSpy } as unknown as Window
+
+    renderHook(() => usePostMessage())
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'applyConfig', payload: { url: 'https://example.com/data.zarr' } },
+        origin: 'https://example.com',
+        source: fakeSource,
+      }),
+    )
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: 'applyConfigResult', ok: true },
+      'https://example.com',
+    )
+  })
+
+  it('replies to parent with applyConfigResult ok:false and error on failure', async () => {
+    vi.stubEnv('VITE_ENABLE_POSTMESSAGE', 'true')
+    vi.stubEnv('VITE_POSTMESSAGE_ORIGIN', '*')
+    mockApplyConfig.mockResolvedValue({
+      ok: false,
+      reason: { kind: 'missing_companion', field: 'gene' },
+    })
+
+    const postMessageSpy = vi.fn()
+    const fakeSource = { postMessage: postMessageSpy } as unknown as Window
+
+    renderHook(() => usePostMessage())
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'applyConfig', payload: { colorBy: 'gene' } },
+        origin: 'https://example.com',
+        source: fakeSource,
+      }),
+    )
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      {
+        type: 'applyConfigResult',
+        ok: false,
+        error: "Couldn't apply: colorBy is set but gene is missing",
+      },
+      'https://example.com',
+    )
   })
 })

--- a/packages/highperformer/src/config/usePostMessage.test.ts
+++ b/packages/highperformer/src/config/usePostMessage.test.ts
@@ -245,7 +245,7 @@ describe('usePostMessage hook', () => {
 
     sendMessage('not an object')
     sendMessage({ type: 'unknownType', payload: {} })
-    sendMessage({ type: 'applyConfig', payload: { missing: 'url' } })
+    // { missing: 'url' } is now valid per the all-optional schema (Task 1 removed .refine())
 
     expect(mockApplyConfig).not.toHaveBeenCalled()
   })

--- a/packages/highperformer/src/config/usePostMessage.ts
+++ b/packages/highperformer/src/config/usePostMessage.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { MessageSchema } from './schema'
 import { applyConfig } from './applyConfig'
+import { applyErrorMessage } from './applyResult'
 import { waitForStore } from './waitForStore'
 import useAppStore from '../store/useAppStore'
 
@@ -114,7 +115,14 @@ export function usePostMessage(): void {
       if (payload.url !== lastAppliedUrl.current) {
         if (debug) console.log('[postMessage:debug] Applying full config (new URL or first message)')
         lastAppliedUrl.current = payload.url
-        applyConfig(payload)
+        applyConfig(payload).then((result) => {
+          if (event.source) {
+            const reply = result.ok
+              ? { type: 'applyConfigResult', ok: true }
+              : { type: 'applyConfigResult', ok: false, error: applyErrorMessage(result.reason) }
+            ;(event.source as Window).postMessage(reply, event.origin as string)
+          }
+        })
         return
       }
 

--- a/packages/highperformer/src/config/usePostMessage.ts
+++ b/packages/highperformer/src/config/usePostMessage.ts
@@ -114,7 +114,7 @@ export function usePostMessage(): void {
       // Different URL or first message: full applyConfig
       if (payload.url !== lastAppliedUrl.current) {
         if (debug) console.log('[postMessage:debug] Applying full config (new URL or first message)')
-        lastAppliedUrl.current = payload.url
+        lastAppliedUrl.current = payload.url ?? null
         applyConfig(payload).then((result) => {
           if (event.source) {
             const reply = result.ok

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -551,9 +551,12 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
   const selectionDisplayMode = useAppStore((s) => s.selectionDisplayMode)
   const selectionGroups = useAppStore((s) => s.selectionGroups)
   const selectionTool = useAppStore((s) => s.selectionTool)
+  const pendingViewport = useAppStore((s) => s.pendingViewport)
+  const setViewport = useAppStore((s) => s.setViewport)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Derive initial view state from data bounds + container size
+  // Derive initial view state from data bounds + container size.
+  // If a pendingViewport was set via applyConfig, override target+zoom with it.
   const initialViewState = useMemo(() => {
     if (!embeddingData?.bounds) return { target: [0, 0, 0] as [number, number, number], zoom: 1 }
 
@@ -577,9 +580,22 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     const minZoom = zoom - 0.25
     const maxZoom = zoom + 4
 
+    if (pendingViewport) {
+      const target: [number, number, number] = [pendingViewport.target[0], pendingViewport.target[1], 0]
+      return { target, zoom: pendingViewport.zoom, minZoom, maxZoom }
+    }
+
     const target: [number, number, number] = [centerX, centerY, 0]
     return { target, zoom, minZoom, maxZoom }
-  }, [embeddingData])
+  }, [embeddingData, pendingViewport])
+
+  // Clear pendingViewport after it has been consumed by the initialViewState useMemo above.
+  // Without this, the override would re-apply on every embedding change.
+  useEffect(() => {
+    if (pendingViewport) {
+      setViewport(null)
+    }
+  }, [pendingViewport, setViewport])
 
   // Memoize layer data object — only recreate when position or color buffer changes
   const layerData = useMemo(() => {

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -216,6 +216,10 @@ export interface AppState {
   setColorScaleName: (name: string) => void
   setGeneLabelColumn: (col: string | null) => void
   _resolveGeneLabels: () => Promise<void>
+
+  // Viewport override — applied as initialViewState on next deck.gl mount
+  pendingViewport: { target: [number, number]; zoom: number } | null
+  setViewport: (v: { target: [number, number]; zoom: number } | null) => void
 }
 
 const DEFAULT_RGB: RGB = [200, 200, 200]
@@ -485,6 +489,10 @@ const useAppStore = create<AppState>((set, get) => ({
   showLeftSidebar: true,
   showRightSidebar: true,
   showDatasetDropdown: true,
+
+  // Viewport override
+  pendingViewport: null,
+  setViewport: (v) => set({ pendingViewport: v }),
 
   // Error state
   loadingError: null,

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -464,7 +464,7 @@ const useAppStore = create<AppState>((set, get) => ({
         if (status === 503) {
           set({ loadingError: 'Dataset temporarily unavailable' })
         } else {
-          set({ loadingError: error?.detail ?? 'Failed to access dataset' })
+          set({ loadingError: typeof error?.detail === 'string' ? error.detail : 'Failed to access dataset' })
         }
         return
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.3
-        version: 4.2.3(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))
+        version: 4.2.3(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
@@ -127,13 +127,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.2.4
-        version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+        version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
       vite-bundle-analyzer:
         specifier: ^1.3.6
         version: 1.3.6
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)
+        version: 4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)(tsx@4.21.0)
 
   packages/highperformer:
     dependencies:
@@ -215,7 +215,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.3(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))
+        version: 4.2.3(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))
       eslint:
         specifier: ^9.39.1
         version: 9.39.3(jiti@1.21.7)
@@ -231,15 +231,18 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+        version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.46.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.46.0)(tsx@4.21.0)
 
   packages/profiler:
     dependencies:
@@ -282,7 +285,7 @@ importers:
         version: 28.1.0
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)
+        version: 4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)(tsx@4.21.0)
 
   packages/zarrstore:
     dependencies:
@@ -298,7 +301,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)
+        version: 4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)(tsx@4.21.0)
 
 packages:
 
@@ -5439,6 +5442,9 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
 
@@ -7581,6 +7587,9 @@ packages:
   resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve-protobuf-schema@2.1.0:
     resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
@@ -8128,6 +8137,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
@@ -13669,11 +13683,11 @@ snapshots:
       '@visx/event': 4.0.1-alpha.0
       react: 18.3.1
 
-  '@vitejs/plugin-react-swc@4.2.3(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))':
+  '@vitejs/plugin-react-swc@4.2.3(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
       '@swc/core': 1.15.18
-      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -13694,21 +13708,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -15590,6 +15604,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stream@6.0.1: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@1.5.0: {}
 
@@ -18189,6 +18207,8 @@ snapshots:
 
   resolve-pathname@3.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve-protobuf-schema@2.1.0:
     dependencies:
       protocol-buffers-schema: 3.6.0
@@ -18751,6 +18771,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tsyringe@4.10.0:
     dependencies:
       tslib: 1.14.1
@@ -18927,13 +18954,13 @@ snapshots:
 
   vite-bundle-analyzer@1.3.6: {}
 
-  vite-node@3.2.4(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0):
+  vite-node@3.2.4(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -18948,7 +18975,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0):
+  vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -18961,12 +18988,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.0
+      tsx: 4.21.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.46.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -18984,8 +19012,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
-      vite-node: 3.2.4(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -19005,10 +19033,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0):
+  vitest@4.0.18(@types/node@25.3.3)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -19025,7 +19053,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3


### PR DESCRIPTION
## Summary

Frontend half of the AppConfig contract redesign (Sub-project A from the chat redesign track). Lays the foundation for the agent-side codegen + new tools (Plans 2 and 3 land in cell-explorer-py).

- New schema fields: `viewport`, `pointSize`, `opacity`, `summaryContext` (5 if you count the new `viewport` nested object).
- `applyConfig` now returns a typed `ApplyResult` instead of `void`. Schema validation, cross-field validation, apply-time validation, and metadata-availability all produce typed errors instead of silent console.warn drops.
- Implicit "filter → summaryContext='selections'" behavior becomes an explicit, overridable default.
- New `pnpm schema` script generates `schema/app-config.schema.json` from the Zod schema. Artifact is checked in and CI-guarded.
- Three callers (chat eventReducer, parseConfig, usePostMessage) now handle the new ApplyResult return — failures surface as in-chat red bubbles, loading-error UI banners, and postMessage replies respectively.

## What's NEXT

After this lands, the next plan (Plan 2 of 3) is in `cell-explorer-py`:
1. Copy `schema/app-config.schema.json` into the backend repo
2. Add `make generate-app-config` target using `datamodel-code-generator`
3. Regenerate the Pydantic `AppConfigModel`
4. Add 4 new ui_action tools (`set_viewport`, `set_summary_context`, `set_gene_label_column`, `set_render_controls`) gated by `AgentConfig.experimental_view_tools`

Plan 3 (also in `cell-explorer-py`) flips that flag and updates the agent system prompt.

## Test plan

- [x] All existing tests still pass (290+ in highperformer; 0 regressions).
- [x] New tests cover the 4 ApplyError kinds: schema_validation, missing_companion, field_value_invalid (gene/embedding/category/filter.obsColumn/geneLabelColumn/summary*), metadata_unavailable.
- [x] Side-effect default behavior verified: filter without summaryContext → 'selections'; filter with summaryContext='overall' → 'overall'.
- [x] CI guard fails when `schema/app-config.schema.json` is stale.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` succeeds.

Spec: `cell-explorer-py/docs/superpowers/specs/2026-05-07-view-config-contract-redesign-design.md` (gitignored locally).