### PR TITLE
fix(highperformer): preserve selectionDisplayMode across ID-based selection

### DIFF
--- a/.changeset/preserve-selection-display-mode.md
+++ b/.changeset/preserve-selection-display-mode.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix: ID-based selection (`selectByIds` / `commitCustomGroupToggle`) no longer
+forces `selectionDisplayMode = 'hide'`. The current mode is preserved (default
+`'dim'`), so a follow-up "color by gene/category" recolors the full canvas
+with the selection highlighted instead of culling non-selected points. Users
+can still toggle to 'hide' via the SelectionToolbar.

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1011,6 +1011,112 @@ describe('useAppStore', () => {
       expect(buf[2]).toBe(1) // in both groups (overlap)
       expect(buf[3]).toBe(0) // in neither
     })
+
+    // Regression: selectByIds and commitCustomGroupToggle previously hardcoded
+    // selectionDisplayMode to 'hide', which made follow-up "color by gene/category"
+    // requests look broken (rest of canvas culled by DataFilterExtension).
+    // They must now preserve the user's chosen mode.
+    it('selectByIds preserves "dim" display mode (does not force hide)', async () => {
+      const mockAdata = {
+        obsColumn: vi.fn().mockResolvedValue(['T_cell', 'B_cell', 'T_cell']),
+      }
+      useAppStore.setState({
+        adata: mockAdata as any,
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1, 2, 2]),
+          numPoints: 3,
+          bounds: { minX: 0, maxX: 2, minY: 0, maxY: 2 },
+        },
+        selectionDisplayMode: 'dim',
+      })
+      mockDispatch.mockResolvedValueOnce({
+        type: 'matchByIds',
+        indices: new Uint32Array([0, 2]),
+        matchedIds: ['T_cell'],
+        unmatchedIds: [],
+        indexMap: { T_cell: [0, 2], B_cell: [1] },
+        isContinuous: false,
+        version: 1,
+      })
+
+      useAppStore.getState().selectByIds('cell_type', ['T_cell'])
+
+      await vi.waitFor(() => {
+        expect(useAppStore.getState().customGroupLoading).toBe(false)
+      })
+
+      expect(useAppStore.getState().selectionDisplayMode).toBe('dim')
+    })
+
+    it('selectByIds preserves "hide" display mode if user has it set', async () => {
+      const mockAdata = {
+        obsColumn: vi.fn().mockResolvedValue(['T_cell', 'B_cell']),
+      }
+      useAppStore.setState({
+        adata: mockAdata as any,
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1]),
+          numPoints: 2,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+        selectionDisplayMode: 'hide',
+      })
+      mockDispatch.mockResolvedValueOnce({
+        type: 'matchByIds',
+        indices: new Uint32Array([0]),
+        matchedIds: ['T_cell'],
+        unmatchedIds: [],
+        indexMap: { T_cell: [0], B_cell: [1] },
+        isContinuous: false,
+        version: 1,
+      })
+
+      useAppStore.getState().selectByIds('cell_type', ['T_cell'])
+
+      await vi.waitFor(() => {
+        expect(useAppStore.getState().customGroupLoading).toBe(false)
+      })
+
+      expect(useAppStore.getState().selectionDisplayMode).toBe('hide')
+    })
+
+    it('commitCustomGroupToggle preserves "dim" display mode', () => {
+      useAppStore.setState({
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1]),
+          numPoints: 2,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+        customGroupEnabledIds: new Set(['T_cell']),
+        customGroupIndexMap: { T_cell: [0], B_cell: [1] },
+        selectionGroups: [],
+        selectionDisplayMode: 'dim',
+      })
+
+      useAppStore.getState().commitCustomGroupToggle()
+      vi.runAllTimers()
+
+      expect(useAppStore.getState().selectionDisplayMode).toBe('dim')
+    })
+
+    it('commitCustomGroupToggle preserves "hide" display mode if user has it set', () => {
+      useAppStore.setState({
+        embeddingData: {
+          positions: new Float32Array([0, 0, 1, 1]),
+          numPoints: 2,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+        customGroupEnabledIds: new Set(['T_cell']),
+        customGroupIndexMap: { T_cell: [0], B_cell: [1] },
+        selectionGroups: [],
+        selectionDisplayMode: 'hide',
+      })
+
+      useAppStore.getState().commitCustomGroupToggle()
+      vi.runAllTimers()
+
+      expect(useAppStore.getState().selectionDisplayMode).toBe('hide')
+    })
   })
 
   describe('UI toggle fields', () => {

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -782,7 +782,6 @@ const useAppStore = create<AppState>((set, get) => ({
             customGroupIndexMap: response.indexMap,
             customGroupEnabledIds: enabledIds,
             customGroupCommittedCount: committedCount,
-            selectionDisplayMode: 'hide',
           })
 
           if (!get().summaryPanelOpen) set({ summaryPanelOpen: true })
@@ -850,7 +849,7 @@ const useAppStore = create<AppState>((set, get) => ({
         indices: new Uint32Array(0), // indices read from customGroupIndexMap instead
         color: GROUP_COLORS[3],
       }
-      set({ selectionGroups: [...withoutCustom, customGroup], customGroupRecomputing: false, customGroupPreviousEnabledIds: null, customGroupCommittedCount: totalLen, selectionDisplayMode: 'hide' })
+      set({ selectionGroups: [...withoutCustom, customGroup], customGroupRecomputing: false, customGroupPreviousEnabledIds: null, customGroupCommittedCount: totalLen })
       get()._mergeFilterBuffer()
     }, 0)
   },


### PR DESCRIPTION
## Summary

`selectByIds()` and `commitCustomGroupToggle()` previously hardcoded `selectionDisplayMode = 'hide'`. The moment a user (or the agent's `filter_by_ids` tool) applied an ID-based selection, the rest of the canvas was culled by deck.gl's `DataFilterExtension`. A follow-up "color by gene" or "color by category" then re-coloured the buffer correctly, but only the filtered cells were visible — looking like "color-by stopped working" to the user.

## Fix

Drop the `'hide'` override in both call sites. The current `selectionDisplayMode` (default `'dim'`) is preserved. Users opt in to `'hide'` explicitly via the SelectionToolbar when isolation is what they want.

## Test plan

- [x] 4 new regression tests in `useAppStore.test.ts` covering both call sites in both `'dim'` and `'hide'` starting states (assertion: mode is unchanged after the call).
- [x] All 299 highperformer tests pass.
- [x] App-package test failures (58) are pre-existing on `main` — unrelated to this change.

## Merge strategy

Use **Create a merge commit** (`gh pr merge --merge`).