### PR TITLE
feat(highperformer): add highlightedCategories to AppConfig

### DIFF
--- a/.changeset/highlighted-categories.md
+++ b/.changeset/highlighted-categories.md
@@ -1,0 +1,12 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `highlightedCategories: string[]` to AppConfig. Specifies a subset of the
+active category column's values that should render at full opacity while
+the rest fade to gray — the same effect produced by clicking swatches in the
+categorical legend, now expressible via URL config / applyConfig payloads.
+
+Requires `colorBy='category'` + `category` set in the same payload. Labels
+are matched against the loaded `categoryMap`; unknown labels yield a
+`field_value_invalid` error.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -24,6 +24,12 @@
     "category": {
       "type": "string"
     },
+    "highlightedCategories": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "geneLabelColumn": {
       "type": "string"
     },

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -189,6 +189,114 @@ describe('applyConfig — cross-field validation', () => {
       throw new Error('expected missing_companion error')
     }
   })
+
+  it('returns field_value_invalid when highlightedCategories is provided without colorBy=category', async () => {
+    const result = await applyConfig({ highlightedCategories: ['T cell'] })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('highlightedCategories')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+})
+
+describe('applyConfig — highlightedCategories', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: ['CD8A'],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+    } as any)
+  })
+
+  it('translates labels → codes and writes to store when category load completes', async () => {
+    // Stub selectObsColumn to populate categoryMap synchronously so waitForStore
+    // resolves without needing a real worker dispatch.
+    const selectObsColumn = vi
+      .spyOn(useAppStore.getState(), 'selectObsColumn')
+      .mockImplementation((name: string) => {
+        useAppStore.setState({
+          selectedObsColumn: name,
+          categoryMap: [
+            { label: 'T cell', color: [255, 0, 0] },
+            { label: 'B cell', color: [0, 255, 0] },
+            { label: 'Monocyte', color: [0, 0, 255] },
+          ],
+        } as any)
+      })
+    const rebuildColorBuffer = vi
+      .spyOn(useAppStore.getState(), 'rebuildColorBuffer')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({
+      colorBy: 'category',
+      category: 'cell_type',
+      highlightedCategories: ['T cell', 'Monocyte'],
+    })
+
+    expect(result.ok).toBe(true)
+    const codes = useAppStore.getState().highlightedCategories
+    expect(codes.size).toBe(2)
+    expect(codes.has(0)).toBe(true) // T cell
+    expect(codes.has(2)).toBe(true) // Monocyte
+    expect(rebuildColorBuffer).toHaveBeenCalled()
+
+    selectObsColumn.mockRestore()
+    rebuildColorBuffer.mockRestore()
+  })
+
+  it('returns field_value_invalid when a label does not exist in categoryMap', async () => {
+    const selectObsColumn = vi
+      .spyOn(useAppStore.getState(), 'selectObsColumn')
+      .mockImplementation((name: string) => {
+        useAppStore.setState({
+          selectedObsColumn: name,
+          categoryMap: [{ label: 'T cell', color: [255, 0, 0] }],
+        } as any)
+      })
+
+    const result = await applyConfig({
+      colorBy: 'category',
+      category: 'cell_type',
+      highlightedCategories: ['Imaginary cell'],
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('highlightedCategories')
+      expect(result.reason.value).toBe('Imaginary cell')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+
+    selectObsColumn.mockRestore()
+  })
+
+  it('empty highlightedCategories array clears highlights (no-op set)', async () => {
+    const selectObsColumn = vi
+      .spyOn(useAppStore.getState(), 'selectObsColumn')
+      .mockImplementation((name: string) => {
+        useAppStore.setState({
+          selectedObsColumn: name,
+          categoryMap: [{ label: 'T cell', color: [255, 0, 0] }],
+        } as any)
+      })
+
+    useAppStore.setState({ highlightedCategories: new Set([0]) } as any)
+
+    const result = await applyConfig({
+      colorBy: 'category',
+      category: 'cell_type',
+      highlightedCategories: [],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().highlightedCategories.size).toBe(0)
+
+    selectObsColumn.mockRestore()
+  })
 })
 
 describe('applyConfig — apply-time field validation', () => {

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -17,6 +17,17 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   if (config.colorBy === 'category' && !config.category) {
     return err({ kind: 'missing_companion', field: 'category' })
   }
+  // highlightedCategories is only meaningful when coloring by category.
+  // Require colorBy='category' in the same payload to keep the contract explicit
+  // (no implicit state-merge against current store).
+  if (config.highlightedCategories !== undefined && config.colorBy !== 'category') {
+    return err({
+      kind: 'field_value_invalid',
+      field: 'highlightedCategories',
+      value: config.highlightedCategories,
+      reason: "requires colorBy='category' and category to be set in the same payload",
+    })
+  }
 
   const store = useAppStore
 
@@ -118,6 +129,36 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     }
     store.getState().setColorMode('category')
     store.getState().selectObsColumn(config.category)
+
+    // Apply optional highlight subset. We need the categoryMap to be populated
+    // (it's only ready after selectObsColumn's async fetch resolves) so we wait
+    // on the store before translating labels → codes.
+    if (config.highlightedCategories !== undefined) {
+      try {
+        await waitForStore(
+          store,
+          (s) => s.selectedObsColumn === config.category && s.categoryMap.length > 0,
+        )
+      } catch {
+        return err({ kind: 'metadata_unavailable', field: 'highlightedCategories' })
+      }
+      const { categoryMap } = store.getState()
+      const codes: number[] = []
+      for (const label of config.highlightedCategories) {
+        const idx = categoryMap.findIndex((c) => c.label === label)
+        if (idx === -1) {
+          return err({
+            kind: 'field_value_invalid',
+            field: 'highlightedCategories',
+            value: label,
+            reason: `not a value of category '${config.category}' (available: ${categoryMap.map((c) => c.label).join(', ')})`,
+          })
+        }
+        codes.push(idx)
+      }
+      store.setState({ highlightedCategories: new Set(codes) })
+      store.getState().rebuildColorBuffer()
+    }
   }
 
   // 3d: Summary panel

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -20,6 +20,10 @@ export const AppConfigSchema = z.object({
   colorBy: z.enum(['gene', 'category']).optional(),
   gene: z.string().optional(),
   category: z.string().optional(),
+  // Subset of category values to highlight (full-opacity); others render dimmed/gray.
+  // Requires colorBy='category' + category. Labels are matched against the loaded
+  // categoryMap; unknown labels yield a field_value_invalid error.
+  highlightedCategories: z.array(z.string()).optional(),
   geneLabelColumn: z.string().optional(),
 
   // filter (tightly bound — nested)


### PR DESCRIPTION
## Summary

Adds `highlightedCategories: string[]` to AppConfig. Specifies a subset of the active category column's values that render at full opacity while the rest fade to gray — same effect as clicking swatches in the categorical legend, now expressible via URL config / applyConfig payloads.

## Why

The agent has a tool to color by category (`set_color_by_category`), but no way to also highlight specific values within that column. Currently "show me T cells" requires the user to click "T cell" in the legend after the agent recolors. This PR adds the schema field; a follow-up in cell-explorer-py will extend the agent tool to take an optional `highlight` arg so the full "show me X" intent can be one tool call.

## What

- `AppConfigSchema` gains `highlightedCategories: z.array(z.string()).optional()`.
- `applyConfig` cross-field check: `highlightedCategories` requires `colorBy='category'` in the same payload (no implicit state-merge against current store).
- After `selectObsColumn` resolves and `categoryMap` is loaded, applyConfig translates labels → category codes; unknown labels yield `field_value_invalid`.
- Regenerated `schema/app-config.schema.json` artifact for downstream Pydantic codegen.

## Test plan

- [x] 4 new tests in `applyConfig.test.ts`: cross-field check, happy path label translation, unknown-label rejection, empty-array clears.
- [x] All 299 highperformer tests pass.
- [x] JSON Schema artifact regenerated and committed.

## Follow-up

A separate PR in cell-explorer-py will regenerate the Pydantic model and extend `set_color_by_category(category, highlight=None)` to emit the new field.

## Merge strategy

Use Create a merge commit (gh pr merge --merge).