### PR TITLE
fix(applyConfig): accept gene symbols via geneLabelMap resolution

### DIFF
--- a/.changeset/applyconfig-resolve-gene-symbols.md
+++ b/.changeset/applyconfig-resolve-gene-symbols.md
@@ -1,0 +1,14 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix: `applyConfig` now accepts gene symbols (e.g. 'DAPL1') in addition to raw
+var indices (e.g. 'ENSG00000176566') for both `gene` and `summaryGenes`. When a
+gene label column is auto-detected, the resolved `geneLabelMap` is consulted to
+translate the symbol to the canonical var index before calling `selectGene` /
+`addSummaryGene` — matching what the sidebar UI already does internally and what
+the agent tool catalog emits.
+
+Previously, agent tool calls like `set_color_by_gene(gene='DAPL1')` against a
+Spectrum-style dataset failed `applyConfig` with `field_value_invalid` because
+`varNames` contains Ensembl IDs, not symbols.

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -342,6 +342,77 @@ describe('applyConfig — apply-time field validation', () => {
     }
   })
 
+  it('accepts a gene symbol (resolved via geneLabelMap) and calls selectGene with the var index', async () => {
+    // Spectrum-style: varNames are Ensembl IDs, geneLabelMap resolves them to HGNC symbols.
+    useAppStore.setState({
+      varNames: ['ENSG_DAPL1', 'ENSG_GAPDH'],
+      geneLabelColumn: 'feature_name',
+      geneLabelMap: new Map([
+        ['ENSG_DAPL1', 'DAPL1'],
+        ['ENSG_GAPDH', 'GAPDH'],
+      ]),
+    } as any)
+    const selectGene = vi.spyOn(useAppStore.getState(), 'selectGene').mockImplementation(() => {})
+
+    const result = await applyConfig({ colorBy: 'gene', gene: 'DAPL1' })
+
+    expect(result.ok).toBe(true)
+    expect(selectGene).toHaveBeenCalledWith('ENSG_DAPL1')
+    selectGene.mockRestore()
+  })
+
+  it('still accepts a raw var index when the gene matches varNames directly', async () => {
+    useAppStore.setState({
+      varNames: ['ENSG_DAPL1'],
+      geneLabelColumn: 'feature_name',
+      geneLabelMap: new Map([['ENSG_DAPL1', 'DAPL1']]),
+    } as any)
+    const selectGene = vi.spyOn(useAppStore.getState(), 'selectGene').mockImplementation(() => {})
+
+    const result = await applyConfig({ colorBy: 'gene', gene: 'ENSG_DAPL1' })
+
+    expect(result.ok).toBe(true)
+    expect(selectGene).toHaveBeenCalledWith('ENSG_DAPL1')
+    selectGene.mockRestore()
+  })
+
+  it('returns field_value_invalid when a gene is in neither varNames nor geneLabelMap', async () => {
+    useAppStore.setState({
+      varNames: ['ENSG_DAPL1'],
+      geneLabelColumn: 'feature_name',
+      geneLabelMap: new Map([['ENSG_DAPL1', 'DAPL1']]),
+    } as any)
+    const result = await applyConfig({ colorBy: 'gene', gene: 'NOT_A_GENE' })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('gene')
+      expect(result.reason.value).toBe('NOT_A_GENE')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('summaryGenes accepts symbols and resolves to var indices', async () => {
+    useAppStore.setState({
+      varNames: ['ENSG_DAPL1', 'ENSG_GAPDH'],
+      geneLabelColumn: 'feature_name',
+      geneLabelMap: new Map([
+        ['ENSG_DAPL1', 'DAPL1'],
+        ['ENSG_GAPDH', 'GAPDH'],
+      ]),
+    } as any)
+    const addSummaryGene = vi
+      .spyOn(useAppStore.getState(), 'addSummaryGene')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({ summaryGenes: ['DAPL1', 'GAPDH'] })
+
+    expect(result.ok).toBe(true)
+    expect(addSummaryGene).toHaveBeenCalledWith('ENSG_DAPL1')
+    expect(addSummaryGene).toHaveBeenCalledWith('ENSG_GAPDH')
+    addSummaryGene.mockRestore()
+  })
+
   it('returns field_value_invalid for unknown geneLabelColumn', async () => {
     const result = await applyConfig({ geneLabelColumn: 'not_a_var_col' })
     expect(result.ok).toBe(false)

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -3,6 +3,30 @@ import useAppStore from '../store/useAppStore'
 import { waitForStore } from './waitForStore'
 import { ok, err, type ApplyResult } from './applyResult'
 
+/**
+ * Resolve a user-facing gene identifier (var index or symbol) to the canonical
+ * var index that `adata.geneExpression` requires.
+ *
+ * Datasets like MSK SPECTRUM store Ensembl IDs in `varNames` and HGNC symbols
+ * in a `feature_name` column; `geneLabelMap` maps varIndex → symbol. Both the
+ * agent and the sidebar UI surface symbols (DAPL1) to the user, but the
+ * underlying lookup needs the index (ENSG00000176566). This accepts either
+ * form and returns the index, or null if not found in either direction.
+ */
+function resolveGeneToVarIndex(
+  label: string,
+  varNames: string[],
+  geneLabelMap: Map<string, string> | null,
+): string | null {
+  if (varNames.includes(label)) return label
+  if (geneLabelMap) {
+    for (const [varIndex, symbol] of geneLabelMap) {
+      if (symbol === label) return varIndex
+    }
+  }
+  return null
+}
+
 export async function applyConfig(input: unknown): Promise<ApplyResult> {
   const parsed = AppConfigSchema.safeParse(input)
   if (!parsed.success) {
@@ -106,17 +130,27 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
 
   // 3c: Color mapping (cross-field check is at the top of applyConfig)
   if (config.colorBy === 'gene' && config.gene) {
-    const { varNames } = store.getState()
-    if (!varNames.includes(config.gene)) {
+    // If a gene label column was auto-detected, wait for the symbol→index
+    // map to resolve so we can accept either the var index or the symbol.
+    if (store.getState().geneLabelColumn && store.getState().geneLabelMap === null) {
+      try {
+        await waitForStore(store, (s) => s.geneLabelMap !== null)
+      } catch {
+        return err({ kind: 'metadata_unavailable', field: 'gene' })
+      }
+    }
+    const { varNames, geneLabelMap } = store.getState()
+    const varIndex = resolveGeneToVarIndex(config.gene, varNames, geneLabelMap)
+    if (!varIndex) {
       return err({
         kind: 'field_value_invalid',
         field: 'gene',
         value: config.gene,
-        reason: 'not found in dataset',
+        reason: 'not found in dataset (checked var index and gene labels)',
       })
     }
     store.getState().setColorMode('gene')
-    store.getState().selectGene(config.gene)
+    store.getState().selectGene(varIndex)
   } else if (config.colorBy === 'category' && config.category) {
     const { obsColumnNames } = store.getState()
     if (!obsColumnNames.includes(config.category)) {
@@ -177,17 +211,25 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     }
   }
   if (config.summaryGenes) {
-    const { varNames } = store.getState()
+    if (store.getState().geneLabelColumn && store.getState().geneLabelMap === null) {
+      try {
+        await waitForStore(store, (s) => s.geneLabelMap !== null)
+      } catch {
+        return err({ kind: 'metadata_unavailable', field: 'summaryGenes' })
+      }
+    }
+    const { varNames, geneLabelMap } = store.getState()
     for (const gene of config.summaryGenes) {
-      if (!varNames.includes(gene)) {
+      const varIndex = resolveGeneToVarIndex(gene, varNames, geneLabelMap)
+      if (!varIndex) {
         return err({
           kind: 'field_value_invalid',
           field: 'summaryGenes',
           value: gene,
-          reason: 'not found in dataset',
+          reason: 'not found in dataset (checked var index and gene labels)',
         })
       }
-      store.getState().addSummaryGene(gene)
+      store.getState().addSummaryGene(varIndex)
     }
   }
 


### PR DESCRIPTION
## Summary

`applyConfig` now accepts gene **symbols** (e.g. `DAPL1`) in addition to raw var indices (e.g. `ENSG00000176566`) for both `gene` and `summaryGenes`. When the dataset has an auto-detected gene-label column, the resolved `geneLabelMap` is consulted to translate the symbol to the canonical var index before calling `selectGene` / `addSummaryGene`.

## Why

The agent's tool catalog emits gene symbols — the backend's `var_names()` resolves through `GENE_SYMBOL_COLUMNS` (e.g. `feature_name`) and returns HGNC symbols. The frontend's `varNames` is the raw `.var` index (Ensembl IDs). The sidebar UI already handles this asymmetry by setting `selectedGene` to the var index and rendering `geneLabelMap.get(varIndex)` for display — but applyConfig was not doing the same translation.

Concrete failure on Spectrum:

```
set_color_by_gene(gene='DAPL1')  → tool OK
applyConfig                       → field_value_invalid("DAPL1" not in varNames)
```

User sees a red error bubble while the agent confidently narrates that DAPL1 expression was applied. (The "no backchannel" design from Plan 1 §Q4-B is a separate concern.)

## What

- New helper `resolveGeneToVarIndex(label, varNames, geneLabelMap) → string | null`. Checks `varNames` first, then the reverse direction of `geneLabelMap` (varIndex → symbol).
- `gene` branch and `summaryGenes` branch both use the helper. On miss, return `field_value_invalid` with `reason: 'not found in dataset (checked var index and gene labels)'`.
- Before validating, `await waitForStore(s => s.geneLabelMap !== null)` if a label column was auto-detected but the map hasn't resolved yet.
- `selectGene` / `addSummaryGene` continue to receive the canonical var index, so the underlying `adata.geneExpression` call still works.

## Test plan

- [x] 4 new tests: symbol resolution, raw-index resolution, unknown gene rejected, summaryGenes symbol resolution. All in `applyConfig.test.ts`.
- [x] All 303 highperformer tests pass (299 baseline + 4 new).
- [x] No backend change needed — the agent already emits symbols.

## Merge strategy

Use Create a merge commit (gh pr merge --merge).