### PR TITLE
feat(highperformer): filterByExpression — select cells by gene expression range

### DIFF
--- a/.changeset/filter-by-expression.md
+++ b/.changeset/filter-by-expression.md
@@ -1,0 +1,22 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `filterByExpression: { gene, min?, max? }` to AppConfig. Selects cells
+whose `gene` expression falls within `[min, max]` (null bounds mean ±∞).
+Implemented as a new `ExpressionSelectionGroup` variant alongside the
+existing spatial / custom groups; participates in the same
+`selectionFilterBuffer` machinery (no new color buffer rebuild, no new
+deck.gl re-render paths).
+
+Cross-field rules in `applyConfig`:
+- At least one of `min` / `max` must be set
+- `min <= max` when both are set
+- `gene` accepts either a var index or a symbol (resolved via
+  `geneLabelMap`, same as `gene` / `summaryGenes`)
+- Defaults `summaryContext` to `'selections'` unless the caller specified
+  otherwise (parallels `filter`)
+
+`SelectionToolbar` renders an expression-filter chip (e.g. `"CD8A ≥ 2"`)
+that can be dismissed to clear the filter. Display mode is forced to
+`'hide'` on apply (same convention as ID-based filter).

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -52,6 +52,38 @@
       ],
       "additionalProperties": false
     },
+    "filterByExpression": {
+      "type": "object",
+      "properties": {
+        "gene": {
+          "type": "string"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "gene"
+      ],
+      "additionalProperties": false
+    },
     "viewport": {
       "type": "object",
       "properties": {

--- a/packages/highperformer/src/components/SelectionToolbar.tsx
+++ b/packages/highperformer/src/components/SelectionToolbar.tsx
@@ -9,7 +9,20 @@ import {
   ClearOutlined,
   CloseOutlined,
 } from '@ant-design/icons'
-import useAppStore, { CUSTOM_GROUP_ID } from '../store/useAppStore'
+import useAppStore, { CUSTOM_GROUP_ID, EXPRESSION_GROUP_ID } from '../store/useAppStore'
+
+function formatExpressionLabel(
+  gene: string,
+  min: number | null,
+  max: number | null,
+  geneLabelMap: Map<string, string> | null,
+): string {
+  const display = geneLabelMap?.get(gene) ?? gene
+  if (min != null && max != null) return `${display} ∈ [${min}, ${max}]`
+  if (min != null) return `${display} ≥ ${min}`
+  if (max != null) return `${display} ≤ ${max}`
+  return display
+}
 
 function useCustomGroupCount() {
   return useAppStore((s) => s.customGroupCommittedCount)
@@ -24,6 +37,7 @@ export default function SelectionToolbar() {
   const clearGroup = useAppStore((s) => s.clearGroup)
   const clearAllSelections = useAppStore((s) => s.clearAllSelections)
   const customGroupCount = useCustomGroupCount()
+  const geneLabelMap = useAppStore((s) => s.geneLabelMap)
   const summaryPanelOpen = useAppStore((s) => s.summaryPanelOpen)
   const setSummaryPanelOpen = useAppStore((s) => s.setSummaryPanelOpen)
 
@@ -114,10 +128,16 @@ export default function SelectionToolbar() {
                 borderRadius: '50%',
                 backgroundColor: `rgb(${group.color[0]}, ${group.color[1]}, ${group.color[2]})`,
               }} />
-              <span>{group.id === CUSTOM_GROUP_ID ? (() => {
-                const { customGroupEnabledIds, customGroupIndexMap, customGroupColumn } = useAppStore.getState()
-                return `Custom${customGroupColumn ? ` (${customGroupColumn})` : ''}: ${customGroupEnabledIds.size}/${Object.keys(customGroupIndexMap).length}`
-              })() : `Group ${group.id}`}</span>
+              <span>{(() => {
+                if (group.id === CUSTOM_GROUP_ID) {
+                  const { customGroupEnabledIds, customGroupIndexMap, customGroupColumn } = useAppStore.getState()
+                  return `Custom${customGroupColumn ? ` (${customGroupColumn})` : ''}: ${customGroupEnabledIds.size}/${Object.keys(customGroupIndexMap).length}`
+                }
+                if (group.type === 'expression') {
+                  return formatExpressionLabel(group.gene, group.min, group.max, geneLabelMap)
+                }
+                return `Group ${group.id}`
+              })()}</span>
               <span style={{ fontSize: 10, color: '#999' }}>
                 {(() => {
                   const count = group.id === CUSTOM_GROUP_ID ? customGroupCount : group.indices.length

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -519,3 +519,77 @@ describe('applyConfig — new schema fields apply to store', () => {
     expect(useAppStore.getState().pendingViewport).toEqual({ target: [10, 20], zoom: 2 })
   })
 })
+
+describe('applyConfig — filterByExpression', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: ['ENSG_CD8A'],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+      geneLabelColumn: 'feature_name',
+      geneLabelMap: new Map([['ENSG_CD8A', 'CD8A']]),
+    } as any)
+  })
+
+  it('resolves a gene symbol to a var index and calls selectByExpression', async () => {
+    const selectByExpression = vi
+      .spyOn(useAppStore.getState(), 'selectByExpression')
+      .mockResolvedValue()
+
+    const result = await applyConfig({
+      filterByExpression: { gene: 'CD8A', min: 2 },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(selectByExpression).toHaveBeenCalledWith('ENSG_CD8A', 2, null)
+    selectByExpression.mockRestore()
+  })
+
+  it('returns field_value_invalid when neither min nor max is set', async () => {
+    const result = await applyConfig({ filterByExpression: { gene: 'CD8A' } })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('filterByExpression')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('returns field_value_invalid when min > max', async () => {
+    const result = await applyConfig({
+      filterByExpression: { gene: 'CD8A', min: 5, max: 1 },
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('filterByExpression')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('returns field_value_invalid for unknown gene', async () => {
+    const result = await applyConfig({
+      filterByExpression: { gene: 'NOT_A_GENE', min: 0 },
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('filterByExpression.gene')
+      expect(result.reason.value).toBe('NOT_A_GENE')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('defaults summaryContext to "selections" when filterByExpression is set', async () => {
+    const selectByExpression = vi
+      .spyOn(useAppStore.getState(), 'selectByExpression')
+      .mockResolvedValue()
+    useAppStore.setState({ summaryContext: 'all' } as any)
+
+    await applyConfig({ filterByExpression: { gene: 'CD8A', min: 2 } })
+
+    expect(useAppStore.getState().summaryContext).toBe('selections')
+    selectByExpression.mockRestore()
+  })
+})

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -77,6 +77,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     config.colorBy ||
     config.geneLabelColumn ||
     config.filter ||
+    config.filterByExpression ||
     config.summaryObsColumns ||
     config.summaryGenes ||
     config.viewport ||
@@ -247,6 +248,50 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.getState().selectByIds(config.filter.obsColumn, config.filter.ids)
     // Default: when filter is set, switch summary to selections — UNLESS the
     // caller explicitly specified summaryContext (then their value wins).
+    if (config.summaryContext === undefined) {
+      store.setState({ summaryContext: 'selections' })
+    }
+  }
+
+  // 3f: Expression-range filter
+  if (config.filterByExpression) {
+    const { gene, min, max } = config.filterByExpression
+    if (min == null && max == null) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'filterByExpression',
+        value: config.filterByExpression,
+        reason: 'specify at least one of min or max',
+      })
+    }
+    if (min != null && max != null && min > max) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'filterByExpression',
+        value: { min, max },
+        reason: `min (${min}) > max (${max})`,
+      })
+    }
+    if (store.getState().geneLabelColumn && store.getState().geneLabelMap === null) {
+      try {
+        await waitForStore(store, (s) => s.geneLabelMap !== null)
+      } catch {
+        return err({ kind: 'metadata_unavailable', field: 'filterByExpression.gene' })
+      }
+    }
+    const { varNames, geneLabelMap } = store.getState()
+    const varIndex = resolveGeneToVarIndex(gene, varNames, geneLabelMap)
+    if (!varIndex) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'filterByExpression.gene',
+        value: gene,
+        reason: 'not found in dataset (checked var index and gene labels)',
+      })
+    }
+    await store.getState().selectByExpression(varIndex, min ?? null, max ?? null)
+    // Same convention as the ID-based filter: default summaryContext to 'selections'
+    // unless the caller specified otherwise.
     if (config.summaryContext === undefined) {
       store.setState({ summaryContext: 'selections' })
     }

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -29,6 +29,15 @@ export const AppConfigSchema = z.object({
   // filter (tightly bound — nested)
   filter: FilterSchema.optional(),
 
+  // Expression-range filter: select cells where `gene` expression is in [min, max].
+  // null bounds mean -∞ / +∞. At least one bound must be set. Requires that `gene`
+  // resolve to a known var index (symbol or raw index — same as `gene` field).
+  filterByExpression: z.object({
+    gene: z.string(),
+    min: z.number().nullable().optional(),
+    max: z.number().nullable().optional(),
+  }).optional(),
+
   // viewport (tightly bound — nested, NEW)
   viewport: ViewportSchema.optional(),
 

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -653,7 +653,9 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
       }),
     })
 
-    const spatialGroups = selectionGroups.filter((g): g is SpatialSelectionGroup => g.type !== 'custom')
+    const spatialGroups = selectionGroups.filter(
+      (g): g is SpatialSelectionGroup => g.type === 'rectangle' || g.type === 'lasso',
+    )
     const polygonLayer = spatialGroups.length > 0
       ? new PolygonLayer({
           id: 'selection-polygons',

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1011,6 +1011,96 @@ describe('useAppStore', () => {
       expect(buf[2]).toBe(1) // in both groups (overlap)
       expect(buf[3]).toBe(0) // in neither
     })
+
+    describe('selectByExpression', () => {
+      it('builds an expression group with cells matching [min, max]', async () => {
+        const mockAdata = {
+          geneExpression: vi.fn().mockResolvedValue(new Float32Array([0.5, 2.0, 3.5, 1.0])),
+        }
+        useAppStore.setState({
+          adata: mockAdata as any,
+          embeddingData: {
+            positions: new Float32Array([0, 0, 1, 1, 2, 2, 3, 3]),
+            numPoints: 4,
+            bounds: { minX: 0, maxX: 3, minY: 0, maxY: 3 },
+          },
+        })
+
+        await useAppStore.getState().selectByExpression('ENSG_CD8A', 1.5, null)
+
+        const groups = useAppStore.getState().selectionGroups
+        const expr = groups.find((g) => g.type === 'expression') as any
+        expect(expr).toBeDefined()
+        expect(expr.gene).toBe('ENSG_CD8A')
+        expect(expr.min).toBe(1.5)
+        expect(expr.max).toBeNull()
+        expect(Array.from(expr.indices)).toEqual([1, 2]) // values 2.0 and 3.5 match
+      })
+
+      it('replaces the prior expression group instead of stacking', async () => {
+        const mockAdata = {
+          geneExpression: vi.fn().mockResolvedValue(new Float32Array([1, 2, 3])),
+        }
+        useAppStore.setState({
+          adata: mockAdata as any,
+          embeddingData: {
+            positions: new Float32Array([0, 0, 1, 1, 2, 2]),
+            numPoints: 3,
+            bounds: { minX: 0, maxX: 2, minY: 0, maxY: 2 },
+          },
+        })
+
+        await useAppStore.getState().selectByExpression('ENSG_A', 0, null)
+        await useAppStore.getState().selectByExpression('ENSG_B', 2, null)
+
+        const exprGroups = useAppStore
+          .getState()
+          .selectionGroups.filter((g) => g.type === 'expression')
+        expect(exprGroups).toHaveLength(1)
+        expect((exprGroups[0] as any).gene).toBe('ENSG_B')
+      })
+
+      it('forces selectionDisplayMode to "hide" (parallels selectByIds)', async () => {
+        const mockAdata = {
+          geneExpression: vi.fn().mockResolvedValue(new Float32Array([1, 2, 3])),
+        }
+        useAppStore.setState({
+          adata: mockAdata as any,
+          embeddingData: {
+            positions: new Float32Array([0, 0, 1, 1, 2, 2]),
+            numPoints: 3,
+            bounds: { minX: 0, maxX: 2, minY: 0, maxY: 2 },
+          },
+          selectionDisplayMode: 'dim',
+        })
+
+        await useAppStore.getState().selectByExpression('ENSG_A', 1.5, null)
+
+        expect(useAppStore.getState().selectionDisplayMode).toBe('hide')
+      })
+
+      it('contributes to selectionFilterBuffer through _mergeFilterBuffer', async () => {
+        const mockAdata = {
+          geneExpression: vi.fn().mockResolvedValue(new Float32Array([0, 5, 0, 5])),
+        }
+        useAppStore.setState({
+          adata: mockAdata as any,
+          embeddingData: {
+            positions: new Float32Array([0, 0, 1, 1, 2, 2, 3, 3]),
+            numPoints: 4,
+            bounds: { minX: 0, maxX: 3, minY: 0, maxY: 3 },
+          },
+        })
+
+        await useAppStore.getState().selectByExpression('ENSG_A', 1, null)
+        const buf = useAppStore.getState().selectionFilterBuffer!
+        expect(buf).toBeInstanceOf(Float32Array)
+        expect(buf[0]).toBe(0)
+        expect(buf[1]).toBe(1)
+        expect(buf[2]).toBe(0)
+        expect(buf[3]).toBe(1)
+      })
+    })
   })
 
   describe('UI toggle fields', () => {

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -50,7 +50,20 @@ export interface CustomSelectionGroup {
   color: [number, number, number]
 }
 
-export type SelectionGroup = SpatialSelectionGroup | CustomSelectionGroup
+export interface ExpressionSelectionGroup {
+  id: number
+  type: 'expression'
+  gene: string  // canonical var index (Ensembl ID or whatever varNames uses)
+  min: number | null
+  max: number | null
+  indices: Uint32Array
+  color: [number, number, number]
+}
+
+export type SelectionGroup =
+  | SpatialSelectionGroup
+  | CustomSelectionGroup
+  | ExpressionSelectionGroup
 
 export interface AppState {
   // Dataset
@@ -141,6 +154,7 @@ export interface AppState {
   clearAllSelections: () => void
   loadCustomGroupColumn: (column: string) => void
   selectByIds: (column: string, ids: string[]) => void
+  selectByExpression: (geneVarIndex: string, min: number | null, max: number | null) => Promise<void>
   clearCustomGroup: () => void
   toggleCustomGroupId: (id: string) => void
   setAllCustomGroupIds: (enabled: boolean) => void
@@ -256,9 +270,11 @@ const GROUP_COLORS: [number, number, number][] = [
   [0, 122, 255],   // blue
   [52, 199, 89],   // green
   [255, 149, 0],   // orange — custom group
+  [175, 82, 222],  // purple — expression filter
 ]
 
 export const CUSTOM_GROUP_ID = 4
+export const EXPRESSION_GROUP_ID = 5
 
 let selectionVersion = 0
 export function getSelectionVersion(): number { return selectionVersion }
@@ -789,6 +805,41 @@ const useAppStore = create<AppState>((set, get) => ({
           get()._mergeFilterBuffer()
         })
     })
+  },
+
+  selectByExpression: async (geneVarIndex, min, max) => {
+    const { adata, embeddingData, selectionGroups } = get()
+    if (!adata || !embeddingData) return
+
+    const expression = await adata.geneExpression(geneVarIndex)
+    const data = expression instanceof Float32Array
+      ? expression
+      : new Float32Array(expression as ArrayLike<number>)
+
+    const lo = min ?? -Infinity
+    const hi = max ?? Infinity
+    const matched: number[] = []
+    for (let i = 0; i < data.length; i++) {
+      if (data[i] >= lo && data[i] <= hi) matched.push(i)
+    }
+    const indices = new Uint32Array(matched)
+
+    const withoutExpr = selectionGroups.filter((g) => g.id !== EXPRESSION_GROUP_ID)
+    const group: ExpressionSelectionGroup = {
+      id: EXPRESSION_GROUP_ID,
+      type: 'expression',
+      gene: geneVarIndex,
+      min,
+      max,
+      indices,
+      color: GROUP_COLORS[4],
+    }
+    set({
+      selectionGroups: [...withoutExpr, group],
+      selectionDisplayMode: 'hide',
+    })
+    if (!get().summaryPanelOpen) set({ summaryPanelOpen: true })
+    get()._mergeFilterBuffer()
   },
 
   clearCustomGroup: () => {


### PR DESCRIPTION
## Summary

New AppConfig field `filterByExpression: { gene, min?, max? }`. Selects cells whose `gene` expression falls in `[min, max]` (null bounds mean ±∞). Frontend half of the cross-repo `filter_by_gene_expression` feature; the backend agent tool follows in a separate cell-explorer-py PR.

## Why

The agent currently has no path for "show me cells with high CD8A" / "filter to high-MS4A1 cells". `filter_by_ids` requires an obs-column ID list — it can't take an expression threshold. This adds a semantic schema field that the backend tool can emit and the frontend can apply cleanly.

## What

- **Schema**: `filterByExpression: { gene: string, min: number | null, max: number | null }` (both bounds optional).
- **Store**: new `ExpressionSelectionGroup` (id=5, purple). Lives alongside spatial / custom groups in `selectionGroups`; participates in `_mergeFilterBuffer` — same `selectionFilterBuffer` output, **no new color buffer rebuild, no new deck.gl attribute uploads** beyond what `filter_by_ids` already triggers.
- **Store action**: `selectByExpression(geneVarIndex, min, max)` fetches `adata.geneExpression(...)`, builds a Uint32Array of matched indices, replaces any prior expression group, calls `_mergeFilterBuffer()`. Forces `selectionDisplayMode='hide'` (matches `selectByIds` convention).
- **applyConfig**: validates `min`/`max` (at least one set, min ≤ max), resolves gene symbol → var index via `geneLabelMap` (same helper as `gene` / `summaryGenes`), dispatches to `selectByExpression`. Defaults `summaryContext='selections'` unless the caller specified otherwise.
- **SelectionToolbar**: renders an expression-filter chip (e.g. `"CD8A ≥ 2"`); clearGroup dismisses it.
- **View.tsx**: fixes the type predicate `g.type !== 'custom'` → `g.type === 'rectangle' || g.type === 'lasso'`. The old predicate would have misclassified the new expression group as `SpatialSelectionGroup` and tried to render a non-existent `polygon`.

## Performance audit

Per `packages/highperformer/CLAUDE.local.md` perf rules:

| Concern | Result |
|---|---|
| New color buffer rebuild? | No — `selectByExpression` doesn't call `rebuildColorBuffer`. |
| New deck.gl attribute re-uploads? | No — same updateTriggers deps (`colorBuffer`, `selectionFilterBuffer`, `selectionDisplayMode`) used by `filter_by_ids`. |
| New subscriptions in `Visualization`? | No — the component is unchanged. |
| `SelectionToolbar` new subscription | `geneLabelMap` — atomic, changes once per dataset load, outside `Visualization`. |
| Non-atomic selectors added? | None. |

## Test plan

- [x] 4 new store tests in `useAppStore.test.ts` (group construction, replace semantics, force 'hide', filter buffer merge).
- [x] 5 new applyConfig tests (symbol resolution, neither-bound error, min>max error, unknown gene error, summaryContext default).
- [x] All 312 highperformer tests pass.
- [x] JSON Schema artifact regenerated and committed.

## Follow-up

cell-explorer-py PR: copy artifact, regen Pydantic, add `filter_by_gene_expression_tool`, update system prompt.

## Merge strategy

Use Create a merge commit (gh pr merge --merge).