### PR TITLE
feat(highperformer): expose selectionDisplayMode in AppConfig

### DIFF
--- a/.changeset/selection-display-mode-field.md
+++ b/.changeset/selection-display-mode-field.md
@@ -1,0 +1,10 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `selectionDisplayMode: 'dim' | 'hide'` to AppConfig. Mirrors the
+SelectionToolbar dim/hide toggle. Applied AFTER filter phases so an
+explicit value overrides the `'hide'` default that `selectByIds` /
+`selectByExpression` set internally — letting URL configs (and the
+upcoming `set_selection_display_mode` agent tool) request "filter but
+keep context visible" in a single payload.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -136,6 +136,13 @@
         "selections"
       ]
     },
+    "selectionDisplayMode": {
+      "type": "string",
+      "enum": [
+        "dim",
+        "hide"
+      ]
+    },
     "showHeader": {
       "type": "boolean"
     },

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -593,3 +593,46 @@ describe('applyConfig — filterByExpression', () => {
     selectByExpression.mockRestore()
   })
 })
+
+describe('applyConfig — selectionDisplayMode', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: [],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+    } as any)
+  })
+
+  it("applies selectionDisplayMode='dim'", async () => {
+    useAppStore.setState({ selectionDisplayMode: 'hide' } as any)
+    const result = await applyConfig({ selectionDisplayMode: 'dim' })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().selectionDisplayMode).toBe('dim')
+  })
+
+  it("applies selectionDisplayMode='hide'", async () => {
+    useAppStore.setState({ selectionDisplayMode: 'dim' } as any)
+    const result = await applyConfig({ selectionDisplayMode: 'hide' })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().selectionDisplayMode).toBe('hide')
+  })
+
+  it('overrides the hide default set internally by selectByIds', async () => {
+    const selectByIds = vi
+      .spyOn(useAppStore.getState(), 'selectByIds')
+      .mockImplementation(() => {
+        // Mimic selectByIds's internal side effect
+        useAppStore.setState({ selectionDisplayMode: 'hide' } as any)
+      })
+
+    const result = await applyConfig({
+      filter: { obsColumn: 'cell_type', ids: ['T'] },
+      selectionDisplayMode: 'dim',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().selectionDisplayMode).toBe('dim')
+    selectByIds.mockRestore()
+  })
+})

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -83,7 +83,8 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     config.viewport ||
     config.pointSize !== undefined ||
     config.opacity !== undefined ||
-    config.summaryContext
+    config.summaryContext ||
+    config.selectionDisplayMode
 
   if (!hasPostLoadConfig) return ok()
 
@@ -308,6 +309,13 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.setState({
       summaryContext: config.summaryContext === 'overall' ? 'all' : config.summaryContext,
     })
+  }
+
+  // Selection display mode (applied AFTER filter phases so explicit value
+  // overrides the 'hide' default that selectByIds / selectByExpression set
+  // internally). Standalone field — does not require any filter to be set.
+  if (config.selectionDisplayMode !== undefined) {
+    store.getState().setSelectionDisplayMode(config.selectionDisplayMode)
   }
 
   // Rendering controls — map schema field names to store field names

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -50,6 +50,12 @@ export const AppConfigSchema = z.object({
   summaryGenes: z.array(z.string()).optional(),
   summaryContext: z.enum(['overall', 'selections']).optional(),
 
+  // Selection display: 'dim' keeps non-selected cells visible at low alpha,
+  // 'hide' culls them entirely via deck.gl's DataFilterExtension. Applies AFTER
+  // filter / filterByExpression so the explicit value wins over the 'hide'
+  // default that ID-based filters set internally.
+  selectionDisplayMode: z.enum(['dim', 'hide']).optional(),
+
   // UI chrome
   showHeader: z.boolean().optional(),
   showLeftSidebar: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds `selectionDisplayMode: 'dim' | 'hide'` to AppConfig. Mirrors the existing SelectionToolbar dim/hide toggle. Pairs with the upcoming `set_selection_display_mode` agent tool in cell-explorer-py.

## Why

After applying a filter, the store hardcodes `selectionDisplayMode = 'hide'` — non-selected points get culled by deck.gl. That's the right product default for explicit isolation, but users sometimes want to keep context visible (filter + dim). The sidebar toolbar has the toggle; the agent and URL configs had no way to express it.

Phase ordering: applied AFTER filter phases so the explicit value wins over the internal 'hide' set by `selectByIds` / `selectByExpression`. One applyConfig call with `{filter: {...}, selectionDisplayMode: 'dim'}` lands a filter and a dim render in one shot.

## What

- `AppConfigSchema` gains `selectionDisplayMode: z.enum(['dim', 'hide']).optional()`.
- New `applyConfig` phase after summaryContext (before rendering controls). No new store action — the existing `setSelectionDisplayMode` handles it.
- `hasPostLoadConfig` includes the new field so payloads with only this field don't short-circuit.

## Test plan

- [x] 3 new tests in `applyConfig.test.ts`: applies dim, applies hide, overrides the internal 'hide' default set by selectByIds.
- [x] 315 highperformer tests pass.
- [x] JSON Schema artifact regenerated and committed.

## Follow-up

cell-explorer-py PR: copy artifact, regen Pydantic, add `set_selection_display_mode` agent tool.

## Merge strategy

Use Create a merge commit (gh pr merge --merge).