### PR TITLE
feat(highperformer): null as reset sentinel for color and render fields

### DIFF
--- a/.changeset/clear-tool-fields.md
+++ b/.changeset/clear-tool-fields.md
@@ -1,0 +1,18 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `null` as a reset sentinel for `colorBy` / `gene` / `category` /
+`pointSize` / `opacity` in AppConfig. Pairs with the upcoming
+`clear_color_by` and `clear_render_controls` agent tools.
+
+- `colorBy: null` → clears both color paths (calls `clearGene` +
+  `clearObsColumn`); falls back to the default gray rendering.
+- `pointSize: null` / `opacity: null` → resets to the store defaults
+  (0.5 / 0.5).
+- `gene: null` / `category: null` accepted by the schema for symmetry
+  but currently no-op on their own (use `colorBy: null` to clear).
+
+`clear_viewport` deferred — `set_viewport` itself only takes effect at
+the next deck.gl mount (initialViewState is consumed once); a proper
+runtime viewport reset needs a separate frontend refactor.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -12,17 +12,38 @@
       "type": "string"
     },
     "colorBy": {
-      "type": "string",
-      "enum": [
-        "gene",
-        "category"
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "gene",
+            "category"
+          ]
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "gene": {
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "category": {
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "highlightedCategories": {
       "type": "array",
@@ -109,13 +130,27 @@
       "additionalProperties": false
     },
     "pointSize": {
-      "type": "number",
-      "exclusiveMinimum": 0
+      "anyOf": [
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "opacity": {
-      "type": "number",
-      "minimum": 0,
-      "maximum": 1
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "summaryObsColumns": {
       "type": "array",

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -594,6 +594,54 @@ describe('applyConfig — filterByExpression', () => {
   })
 })
 
+describe('applyConfig — clear semantics (null)', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: ['CD8A'],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+    } as any)
+  })
+
+  it("colorBy: null clears both gene and obs column", async () => {
+    const clearGene = vi.spyOn(useAppStore.getState(), 'clearGene').mockImplementation(() => {})
+    const clearObsColumn = vi
+      .spyOn(useAppStore.getState(), 'clearObsColumn')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({ colorBy: null })
+
+    expect(result.ok).toBe(true)
+    expect(clearGene).toHaveBeenCalled()
+    expect(clearObsColumn).toHaveBeenCalled()
+    clearGene.mockRestore()
+    clearObsColumn.mockRestore()
+  })
+
+  it("pointSize: null resets to default (0.5)", async () => {
+    useAppStore.setState({ pointRadius: 5 } as any)
+    const result = await applyConfig({ pointSize: null })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().pointRadius).toBe(0.5)
+  })
+
+  it("opacity: null resets to default (0.5)", async () => {
+    useAppStore.setState({ opacity: 0.1 } as any)
+    const result = await applyConfig({ opacity: null })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().opacity).toBe(0.5)
+  })
+
+  it("pointSize and opacity together reset both", async () => {
+    useAppStore.setState({ pointRadius: 5, opacity: 0.1 } as any)
+    const result = await applyConfig({ pointSize: null, opacity: null })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().pointRadius).toBe(0.5)
+    expect(useAppStore.getState().opacity).toBe(0.5)
+  })
+})
+
 describe('applyConfig — selectionDisplayMode', () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -74,15 +74,15 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   // at all, surface that as metadata_unavailable instead of silently dropping.
   const hasPostLoadConfig =
     config.embedding ||
-    config.colorBy ||
+    config.colorBy !== undefined ||  // null is a valid clear sentinel
     config.geneLabelColumn ||
     config.filter ||
     config.filterByExpression ||
     config.summaryObsColumns ||
     config.summaryGenes ||
     config.viewport ||
-    config.pointSize !== undefined ||
-    config.opacity !== undefined ||
+    config.pointSize !== undefined ||  // null is a valid clear sentinel
+    config.opacity !== undefined ||  // null is a valid clear sentinel
     config.summaryContext ||
     config.selectionDisplayMode
 
@@ -130,8 +130,13 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.getState().setSelectedEmbedding(config.embedding)
   }
 
-  // 3c: Color mapping (cross-field check is at the top of applyConfig)
-  if (config.colorBy === 'gene' && config.gene) {
+  // 3c: Color mapping (cross-field check is at the top of applyConfig).
+  // Treat `colorBy: null` as an explicit reset — clear both color paths and
+  // fall back to the default gray rendering.
+  if (config.colorBy === null) {
+    store.getState().clearGene()
+    store.getState().clearObsColumn()
+  } else if (config.colorBy === 'gene' && config.gene) {
     // If a gene label column was auto-detected, wait for the symbol→index
     // map to resolve so we can accept either the var index or the symbol.
     if (store.getState().geneLabelColumn && store.getState().geneLabelMap === null) {
@@ -318,12 +323,13 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.getState().setSelectionDisplayMode(config.selectionDisplayMode)
   }
 
-  // Rendering controls — map schema field names to store field names
+  // Rendering controls — map schema field names to store field names.
+  // `null` is the reset sentinel: restore the store defaults (0.5 / 0.5).
   if (config.pointSize !== undefined) {
-    store.setState({ pointRadius: config.pointSize })
+    store.setState({ pointRadius: config.pointSize ?? 0.5 })
   }
   if (config.opacity !== undefined) {
-    store.setState({ opacity: config.opacity })
+    store.setState({ opacity: config.opacity ?? 0.5 })
   }
 
   // Viewport — delegate to the store action (talks to deck.gl on next mount)

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -17,9 +17,11 @@ export const AppConfigSchema = z.object({
 
   // data view
   embedding: z.string().optional(),
-  colorBy: z.enum(['gene', 'category']).optional(),
-  gene: z.string().optional(),
-  category: z.string().optional(),
+  // colorBy/gene/category: `null` is a reset sentinel ("clear coloring"); a
+  // string sets the mode/value normally; absent = no change.
+  colorBy: z.enum(['gene', 'category']).nullable().optional(),
+  gene: z.string().nullable().optional(),
+  category: z.string().nullable().optional(),
   // Subset of category values to highlight (full-opacity); others render dimmed/gray.
   // Requires colorBy='category' + category. Labels are matched against the loaded
   // categoryMap; unknown labels yield a field_value_invalid error.
@@ -41,9 +43,11 @@ export const AppConfigSchema = z.object({
   // viewport (tightly bound — nested, NEW)
   viewport: ViewportSchema.optional(),
 
-  // rendering (flat, NEW)
-  pointSize: z.number().positive().optional(),
-  opacity: z.number().min(0).max(1).optional(),
+  // rendering (flat, NEW).
+  // `null` = reset to the store defaults (0.5 for both); number = override;
+  // absent = no change.
+  pointSize: z.number().positive().nullable().optional(),
+  opacity: z.number().min(0).max(1).nullable().optional(),
 
   // summary panel
   summaryObsColumns: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Adds nullable to `colorBy` / `gene` / `category` / `pointSize` / `opacity` in AppConfig so `null` works as a reset sentinel. Pairs with the upcoming `clear_color_by` and `clear_render_controls` agent tools.

## Semantics

| Field | absent | string/number | `null` |
|---|---|---|---|
| `colorBy` | no change | set mode | call `clearGene` + `clearObsColumn` |
| `gene` / `category` | no change | set value | (no-op on its own; use `colorBy: null` to clear) |
| `pointSize` / `opacity` | no change | override | reset to 0.5 / 0.5 (store default) |

`hasPostLoadConfig` updated to use `!== undefined` checks so null sentinels don't short-circuit applyConfig.

## What's NOT in this PR

- `clear_viewport`: pre-existing limitation in `set_viewport` (only takes effect at next deck.gl mount via `initialViewState`). Proper runtime viewport reset needs a separate refactor — defer.
- Summary panel removal tools (`remove_summary_obs_column`, `clear_summary`): different pattern, follow-up PR.

## Test plan

- [x] 4 new tests in `applyConfig.test.ts` (colorBy=null clears both paths, pointSize=null resets, opacity=null resets, both reset together).
- [x] 319 highperformer tests pass.
- [x] JSON Schema artifact regenerated and committed.

## Merge strategy

Use Create a merge commit (gh pr merge --merge).