### PR TITLE
feat(highperformer): summary panel removal fields in AppConfig

### DIFF
--- a/.changeset/summary-removal-fields.md
+++ b/.changeset/summary-removal-fields.md
@@ -1,0 +1,17 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add summary panel removal semantics to AppConfig. Pairs with the
+upcoming `remove_summary_obs_column`, `remove_summary_gene`, and
+`clear_summary` agent tools.
+
+- New fields: `removeSummaryObsColumns: string[]?` and
+  `removeSummaryGenes: string[]?` — call `removeSummaryObsColumn` /
+  `removeSummaryGene` per name. Symbols resolve to var indices via
+  `geneLabelMap`.
+- `summaryObsColumns: null` and `summaryGenes: null` are reset
+  sentinels: clear the entire pinned list. (`string[]` retains the
+  existing additive semantics.)
+- Unknown names in the remove arrays are a silent no-op (store filter
+  doesn't match).

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -153,12 +153,38 @@
       ]
     },
     "summaryObsColumns": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "summaryGenes": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "removeSummaryObsColumns": {
       "type": "array",
       "items": {
         "type": "string"
       }
     },
-    "summaryGenes": {
+    "removeSummaryGenes": {
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -642,6 +642,97 @@ describe('applyConfig — clear semantics (null)', () => {
   })
 })
 
+describe('applyConfig — summary panel removal', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: ['ENSG_CD8A'],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type', 'cluster'],
+      loading: false,
+      geneLabelColumn: 'feature_name',
+      geneLabelMap: new Map([['ENSG_CD8A', 'CD8A']]),
+    } as any)
+  })
+
+  it('removeSummaryObsColumns calls the store removal action per name', async () => {
+    const removeSummaryObsColumn = vi
+      .spyOn(useAppStore.getState(), 'removeSummaryObsColumn')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({
+      removeSummaryObsColumns: ['cell_type', 'cluster'],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(removeSummaryObsColumn).toHaveBeenCalledWith('cell_type')
+    expect(removeSummaryObsColumn).toHaveBeenCalledWith('cluster')
+    removeSummaryObsColumn.mockRestore()
+  })
+
+  it('removeSummaryGenes resolves symbol → var index before removing', async () => {
+    const removeSummaryGene = vi
+      .spyOn(useAppStore.getState(), 'removeSummaryGene')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({ removeSummaryGenes: ['CD8A'] })
+
+    expect(result.ok).toBe(true)
+    expect(removeSummaryGene).toHaveBeenCalledWith('ENSG_CD8A')
+    removeSummaryGene.mockRestore()
+  })
+
+  it("summaryObsColumns: null clears all pinned obs columns", async () => {
+    useAppStore.setState({ summaryObsColumns: ['cell_type', 'cluster'] } as any)
+    const removeSummaryObsColumn = vi
+      .spyOn(useAppStore.getState(), 'removeSummaryObsColumn')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({ summaryObsColumns: null })
+
+    expect(result.ok).toBe(true)
+    expect(removeSummaryObsColumn).toHaveBeenCalledWith('cell_type')
+    expect(removeSummaryObsColumn).toHaveBeenCalledWith('cluster')
+    removeSummaryObsColumn.mockRestore()
+  })
+
+  it("summaryGenes: null clears all pinned genes", async () => {
+    useAppStore.setState({ summaryGenes: ['ENSG_CD8A'] } as any)
+    const removeSummaryGene = vi
+      .spyOn(useAppStore.getState(), 'removeSummaryGene')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({ summaryGenes: null })
+
+    expect(result.ok).toBe(true)
+    expect(removeSummaryGene).toHaveBeenCalledWith('ENSG_CD8A')
+    removeSummaryGene.mockRestore()
+  })
+
+  it("clear_summary-style payload (both nulls) clears both lists in one call", async () => {
+    useAppStore.setState({
+      summaryObsColumns: ['cell_type'],
+      summaryGenes: ['ENSG_CD8A'],
+    } as any)
+    const removeObs = vi
+      .spyOn(useAppStore.getState(), 'removeSummaryObsColumn')
+      .mockImplementation(() => {})
+    const removeGene = vi
+      .spyOn(useAppStore.getState(), 'removeSummaryGene')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({
+      summaryObsColumns: null,
+      summaryGenes: null,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(removeObs).toHaveBeenCalledWith('cell_type')
+    expect(removeGene).toHaveBeenCalledWith('ENSG_CD8A')
+    removeObs.mockRestore()
+    removeGene.mockRestore()
+  })
+})
+
 describe('applyConfig — selectionDisplayMode', () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -78,8 +78,10 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     config.geneLabelColumn ||
     config.filter ||
     config.filterByExpression ||
-    config.summaryObsColumns ||
-    config.summaryGenes ||
+    config.summaryObsColumns !== undefined ||  // null = clear
+    config.summaryGenes !== undefined ||  // null = clear
+    config.removeSummaryObsColumns ||
+    config.removeSummaryGenes ||
     config.viewport ||
     config.pointSize !== undefined ||  // null is a valid clear sentinel
     config.opacity !== undefined ||  // null is a valid clear sentinel
@@ -202,8 +204,14 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     }
   }
 
-  // 3d: Summary panel
-  if (config.summaryObsColumns) {
+  // 3d: Summary panel.
+  // `null` on summaryObsColumns / summaryGenes clears the pinned list;
+  // array adds each name (additive — current behavior).
+  if (config.summaryObsColumns === null) {
+    for (const col of [...store.getState().summaryObsColumns]) {
+      store.getState().removeSummaryObsColumn(col)
+    }
+  } else if (config.summaryObsColumns) {
     const { obsColumnNames } = store.getState()
     for (const col of config.summaryObsColumns) {
       if (!obsColumnNames.includes(col)) {
@@ -217,7 +225,17 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
       store.getState().addSummaryObsColumn(col)
     }
   }
-  if (config.summaryGenes) {
+  // Per-name removal — independent of the add/clear path above.
+  if (config.removeSummaryObsColumns) {
+    for (const col of config.removeSummaryObsColumns) {
+      store.getState().removeSummaryObsColumn(col)
+    }
+  }
+  if (config.summaryGenes === null) {
+    for (const gene of [...store.getState().summaryGenes]) {
+      store.getState().removeSummaryGene(gene)
+    }
+  } else if (config.summaryGenes) {
     if (store.getState().geneLabelColumn && store.getState().geneLabelMap === null) {
       try {
         await waitForStore(store, (s) => s.geneLabelMap !== null)
@@ -237,6 +255,16 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
         })
       }
       store.getState().addSummaryGene(varIndex)
+    }
+  }
+  // Per-name removal for summary genes. Resolve symbol → var index if possible
+  // (matches how addSummaryGene stores the canonical key); falls back to the
+  // raw name otherwise. Unknown names are a silent no-op in the store.
+  if (config.removeSummaryGenes) {
+    const { varNames, geneLabelMap } = store.getState()
+    for (const gene of config.removeSummaryGenes) {
+      const varIndex = resolveGeneToVarIndex(gene, varNames, geneLabelMap)
+      store.getState().removeSummaryGene(varIndex ?? gene)
     }
   }
 

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -49,9 +49,14 @@ export const AppConfigSchema = z.object({
   pointSize: z.number().positive().nullable().optional(),
   opacity: z.number().min(0).max(1).nullable().optional(),
 
-  // summary panel
-  summaryObsColumns: z.array(z.string()).optional(),
-  summaryGenes: z.array(z.string()).optional(),
+  // summary panel.
+  // summaryObsColumns / summaryGenes: array adds each name (additive);
+  // `null` clears the entire pinned list. removeSummaryObsColumns /
+  // removeSummaryGenes remove each named entry without touching the rest.
+  summaryObsColumns: z.array(z.string()).nullable().optional(),
+  summaryGenes: z.array(z.string()).nullable().optional(),
+  removeSummaryObsColumns: z.array(z.string()).optional(),
+  removeSummaryGenes: z.array(z.string()).optional(),
   summaryContext: z.enum(['overall', 'selections']).optional(),
 
   // Selection display: 'dim' keeps non-selected cells visible at low alpha,


### PR DESCRIPTION
## Summary

Schema half of the summary-removal tool family. Pairs with the upcoming `remove_summary_obs_column`, `remove_summary_gene`, and `clear_summary` agent tools.

## Schema additions

| Field | Type | Semantic |
|---|---|---|
| `removeSummaryObsColumns` | `string[]?` | call `removeSummaryObsColumn(name)` for each |
| `removeSummaryGenes` | `string[]?` | call `removeSummaryGene(varIndex)` for each (symbols resolve via `geneLabelMap`) |
| `summaryObsColumns: null` | — | clear all pinned obs columns |
| `summaryGenes: null` | — | clear all pinned genes |

Existing additive array semantics for `summaryObsColumns` / `summaryGenes` preserved.

## Test plan

- [x] 5 new tests: per-name removal (both fields), null-clear (both), composite "clear summary" payload with both nulls.
- [x] 324 highperformer tests pass.
- [x] JSON Schema artifact regenerated and committed.

## Merge strategy

Use Create a merge commit.