### PR TITLE
fix(highperformer): apply set_viewport imperatively via deck.gl ref

### DIFF
--- a/.changeset/viewport-runtime-reset.md
+++ b/.changeset/viewport-runtime-reset.md
@@ -1,0 +1,17 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Fix `set_viewport` to actually take effect at runtime. Previously deck.gl
+ignored `initialViewState` changes after the initial mount, so
+programmatic viewport overrides only applied on the next embedding switch.
+
+The fix uses deck.gl's prescribed pattern per the perf rule: a
+`viewportEpoch` counter signals View.tsx, which imperatively calls
+`deckRef.current.deck.setProps({ viewState })` on the underlying Deck
+instance. An `onViewStateChange` ref handler keeps deck.gl in sync on
+subsequent pan/zoom. No React state for viewState — no per-frame
+re-render cost.
+
+Also adds `viewport: null` as a reset-to-fit-to-view sentinel. Pairs with
+the upcoming `clear_viewport` agent tool in cell-explorer-py.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -106,28 +106,35 @@
       "additionalProperties": false
     },
     "viewport": {
-      "type": "object",
-      "properties": {
-        "target": {
-          "type": "array",
-          "prefixItems": [
-            {
-              "type": "number"
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
             },
-            {
+            "zoom": {
               "type": "number"
             }
-          ]
+          },
+          "required": [
+            "target",
+            "zoom"
+          ],
+          "additionalProperties": false
         },
-        "zoom": {
-          "type": "number"
+        {
+          "type": "null"
         }
-      },
-      "required": [
-        "target",
-        "zoom"
-      ],
-      "additionalProperties": false
+      ]
     },
     "pointSize": {
       "anyOf": [

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -518,6 +518,33 @@ describe('applyConfig — new schema fields apply to store', () => {
     expect(result.ok).toBe(true)
     expect(useAppStore.getState().pendingViewport).toEqual({ target: [10, 20], zoom: 2 })
   })
+
+  it('setViewport bumps viewportEpoch on every call (signals View.tsx to apply imperatively)', () => {
+    useAppStore.setState(useAppStore.getInitialState())
+    const before = useAppStore.getState().viewportEpoch
+    useAppStore.getState().setViewport({ target: [1, 2], zoom: 3 })
+    expect(useAppStore.getState().viewportEpoch).toBe(before + 1)
+    useAppStore.getState().setViewport({ target: [4, 5], zoom: 6 })
+    expect(useAppStore.getState().viewportEpoch).toBe(before + 2)
+    useAppStore.getState().setViewport(null)
+    expect(useAppStore.getState().viewportEpoch).toBe(before + 3)
+  })
+
+  it("viewport: null is the reset sentinel — clears pendingViewport and bumps epoch", async () => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+      pendingViewport: { target: [10, 20], zoom: 2 },
+    } as any)
+    const beforeEpoch = useAppStore.getState().viewportEpoch
+    const result = await applyConfig({ viewport: null })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().pendingViewport).toBeNull()
+    expect(useAppStore.getState().viewportEpoch).toBe(beforeEpoch + 1)
+  })
 })
 
 describe('applyConfig — filterByExpression', () => {

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -82,7 +82,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     config.summaryGenes !== undefined ||  // null = clear
     config.removeSummaryObsColumns ||
     config.removeSummaryGenes ||
-    config.viewport ||
+    config.viewport !== undefined ||  // null = reset to fit-to-view
     config.pointSize !== undefined ||  // null is a valid clear sentinel
     config.opacity !== undefined ||  // null is a valid clear sentinel
     config.summaryContext ||
@@ -360,7 +360,10 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     store.setState({ opacity: config.opacity ?? 0.5 })
   }
 
-  // Viewport — delegate to the store action (talks to deck.gl on next mount)
+  // Viewport — delegate to the store action.
+  // setViewport(viewport) sets pendingViewport and bumps viewportEpoch.
+  // setViewport(null) bumps too; View.tsx's epoch-watching effect computes a
+  // fit-to-view target from the embedding bounds and applies via setProps.
   if (config.viewport !== undefined) {
     const { setViewport } = store.getState()
     setViewport(config.viewport)

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -40,8 +40,10 @@ export const AppConfigSchema = z.object({
     max: z.number().nullable().optional(),
   }).optional(),
 
-  // viewport (tightly bound — nested, NEW)
-  viewport: ViewportSchema.optional(),
+  // viewport (tightly bound — nested, NEW).
+  // `null` = reset to fit-to-view (applied imperatively at runtime via
+  // deckRef.setProps); object = explicit override; absent = no change.
+  viewport: ViewportSchema.nullable().optional(),
 
   // rendering (flat, NEW).
   // `null` = reset to the store defaults (0.5 for both); number = override;

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -553,6 +553,7 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
   const selectionTool = useAppStore((s) => s.selectionTool)
   const pendingViewport = useAppStore((s) => s.pendingViewport)
   const setViewport = useAppStore((s) => s.setViewport)
+  const viewportEpoch = useAppStore((s) => s.viewportEpoch)
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Derive initial view state from data bounds + container size.
@@ -589,13 +590,73 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     return { target, zoom, minZoom, maxZoom }
   }, [embeddingData, pendingViewport])
 
-  // Clear pendingViewport after it has been consumed by the initialViewState useMemo above.
-  // Without this, the override would re-apply on every embedding change.
+  // Imperative viewport reset for runtime updates.
+  //
+  // deck.gl's `initialViewState` is only consumed at first mount; after that,
+  // the controller manages viewState internally. To apply a programmatic
+  // viewport change at runtime (e.g. agent calls set_viewport after the canvas
+  // is already drawn), we use the prescribed pattern: deckRef.current.setProps
+  // with a `viewState` object. This switches deck.gl to controlled mode; an
+  // onViewStateChange handler below keeps it in sync as the user pans/zooms.
+  //
+  // The didMount + viewportEpoch idiom skips the first effect run (the
+  // initial mount, which initialViewState handles) and fires only on
+  // subsequent setViewport calls.
+  const isControlledRef = useRef(false)
+  const didMountRef = useRef(false)
   useEffect(() => {
-    if (pendingViewport) {
-      setViewport(null)
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
     }
-  }, [pendingViewport, setViewport])
+    // @deck.gl/react v9 exposes the underlying Deck instance on the ref as
+    // `.deck`. The React component itself doesn't have setProps — calling it
+    // directly errors with "setProps is not a function".
+    const deck = deckRef.current?.deck
+    if (!deck || !embeddingData?.bounds) return
+
+    // Compute target viewState. If pendingViewport is null (reset request),
+    // fall back to fit-to-view from bounds + container size.
+    let target: [number, number, number]
+    let zoom: number
+    if (pendingViewport) {
+      target = [pendingViewport.target[0], pendingViewport.target[1], 0]
+      zoom = pendingViewport.zoom
+    } else {
+      const { minX, maxX, minY, maxY } = embeddingData.bounds
+      const centerX = (minX + maxX) / 2
+      const centerY = (minY + maxY) / 2
+      const dataWidth = maxX - minX || 1
+      const dataHeight = maxY - minY || 1
+      const el = containerRef.current
+      const viewWidth = el?.clientWidth || 800
+      const viewHeight = el?.clientHeight || 600
+      const padding = 1.1
+      target = [centerX, centerY, 0]
+      zoom = Math.log2(Math.min(
+        viewWidth / (dataWidth * padding),
+        viewHeight / (dataHeight * padding),
+      ))
+    }
+    isControlledRef.current = true
+    deck.setProps({ viewState: { target, zoom } })
+    // Clear pendingViewport without bumping epoch (use setState bypass).
+    if (pendingViewport) {
+      useAppStore.setState({ pendingViewport: null })
+    }
+  }, [viewportEpoch, embeddingData, pendingViewport])
+
+  // Pan/zoom handler — only matters once deck.gl is in controlled mode.
+  // Uses ref-based tracking (no React state) per the perf rule.
+  const onViewStateChange = useCallback(
+    ({ viewState }: { viewState: Record<string, unknown> }) => {
+      const deck = deckRef.current?.deck
+      if (isControlledRef.current && deck) {
+        deck.setProps({ viewState })
+      }
+    },
+    [deckRef],
+  )
 
   // Memoize layer data object — only recreate when position or color buffer changes
   const layerData = useMemo(() => {
@@ -680,6 +741,13 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     [embeddingData],
   )
 
+  // Reset controlled mode on embedding switch — the new deck.gl mount starts
+  // uncontrolled and consumes the new initialViewState fresh.
+  useEffect(() => {
+    isControlledRef.current = false
+    didMountRef.current = false
+  }, [deckKey])
+
   return (
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
       <DeckGL
@@ -688,6 +756,7 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
         views={new OrthographicView()}
         initialViewState={initialViewState}
         controller={selectionTool === 'pan'}
+        onViewStateChange={onViewStateChange}
         layers={layers}
         widgets={WIDGETS}
       />

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -231,8 +231,19 @@ export interface AppState {
   setGeneLabelColumn: (col: string | null) => void
   _resolveGeneLabels: () => Promise<void>
 
-  // Viewport override — applied as initialViewState on next deck.gl mount
+  // Viewport override.
+  //
+  // `pendingViewport` is the requested target (null = fit-to-view reset).
+  // `viewportEpoch` is a monotonic counter that bumps on every setViewport call.
+  // View.tsx's effect watches the epoch (not the value) so we can request a
+  // viewport change to the same coordinates twice in a row and still trigger
+  // an imperative deck.gl update.
+  //
+  // Runtime updates apply via deckRef.current.setProps({viewState}) — the
+  // deck.gl prescribed pattern per the perf rule. Once applied, deck.gl is
+  // in controlled mode; an onViewStateChange handler keeps it in sync on pan.
   pendingViewport: { target: [number, number]; zoom: number } | null
+  viewportEpoch: number
   setViewport: (v: { target: [number, number]; zoom: number } | null) => void
 }
 
@@ -508,7 +519,12 @@ const useAppStore = create<AppState>((set, get) => ({
 
   // Viewport override
   pendingViewport: null,
-  setViewport: (v) => set({ pendingViewport: v }),
+  viewportEpoch: 0,
+  setViewport: (v) =>
+    set((state) => ({
+      pendingViewport: v,
+      viewportEpoch: state.viewportEpoch + 1,
+    })),
 
   // Error state
   loadingError: null,


### PR DESCRIPTION
## Summary

Makes `set_viewport` actually take effect at runtime (previously deck.gl ignored `initialViewState` changes after the initial mount, so programmatic overrides were invisible until the next embedding switch).

## Approach

Uses deck.gl's prescribed runtime pattern per the perf rule — ref-based, no React state for viewState, no remount.

- Store tracks `viewportEpoch` that bumps on every `setViewport` call.
- View.tsx watches the epoch and imperatively calls `deckRef.current.deck.setProps({ viewState })` on the underlying `Deck` instance.
- An `onViewStateChange` ref handler keeps deck.gl in sync on subsequent pan/zoom (no per-frame React re-render).
- A `didMount + viewportEpoch` idiom skips the initial mount; `isControlledRef` + `didMountRef` reset on embedding switch.

Also adds `viewport: null` as a reset-to-fit-to-view sentinel — applyConfig calls `setViewport(null)`, which bumps the epoch; the effect computes a fit-to-view target from embedding bounds and applies it.

## Postmortem of the previous attempt

PR #248 (reverted) used a `deckKey` remount. That caused WebGL crashes (`getUniformBlockIndex` on invalid program) because Layer instances were memoized without `viewportEpoch` in deps, so they referenced GL programs that were destroyed during context teardown. Even fixing the dep array would likely have hit in-flight render frames against destroyed contexts.

Then I tried `deckRef.current.setProps(...)` directly — that errored with `setProps is not a function` because `@deck.gl/react`'s ref shape is `DeckGLRef { deck?: Deck, ... }`, not the `Deck` instance itself. The first call APPEARED to work because deck.gl reactively re-read `initialViewState` (which changed when `pendingViewport` changed); subsequent calls errored.

This PR uses the correct API: `deckRef.current?.deck.setProps(...)`.

## Test plan

- [x] 2 new applyConfig tests (epoch bump on each call; `viewport: null` clears pendingViewport and bumps epoch).
- [x] 326 highperformer tests pass.
- [x] Manual test in browser: agent set_viewport works on first call; manual pan/zoom afterward works; agent set_viewport again works (the previously failing case).

## Follow-up

Backend PR: add `clear_viewport` and `fit_viewport_to_selection` agent tools.

## Merge strategy

Use Create a merge commit.