### PR TITLE
feat(highperformer): fitViewportToSelection field in AppConfig

### DIFF
--- a/.changeset/fit-viewport-to-selection.md
+++ b/.changeset/fit-viewport-to-selection.md
@@ -1,0 +1,12 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `fitViewportToSelection: boolean` to AppConfig. When true, applyConfig
+computes the bounding box of the currently selected cells (from
+`selectionFilterBuffer` × `embeddingData.positions`) and applies a viewport
+that fits them. No-op when no selection is active.
+
+Pairs with the upcoming `fit_viewport_to_selection` agent tool — the agent
+doesn't have access to embedding coordinates, so it can't compute the bbox
+itself; this lets the frontend do it.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -136,6 +136,9 @@
         }
       ]
     },
+    "fitViewportToSelection": {
+      "type": "boolean"
+    },
     "pointSize": {
       "anyOf": [
         {

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -545,6 +545,52 @@ describe('applyConfig — new schema fields apply to store', () => {
     expect(useAppStore.getState().pendingViewport).toBeNull()
     expect(useAppStore.getState().viewportEpoch).toBe(beforeEpoch + 1)
   })
+
+  it("fitViewportToSelection computes bbox from selection and sets viewport", async () => {
+    // Set up: 4 cells at (0,0), (10,0), (0,10), (100,100). Selection includes
+    // first 3 only. Expected center = (5, 5).
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+      embeddingData: {
+        positions: new Float32Array([0, 0, 10, 0, 0, 10, 100, 100]),
+        numPoints: 4,
+        bounds: { minX: 0, maxX: 100, minY: 0, maxY: 100 },
+      },
+      selectionFilterBuffer: new Float32Array([1, 1, 1, 0]),
+    } as any)
+    const result = await applyConfig({ fitViewportToSelection: true })
+    expect(result.ok).toBe(true)
+    const pv = useAppStore.getState().pendingViewport
+    expect(pv).not.toBeNull()
+    expect(pv!.target[0]).toBe(5)  // (0 + 10) / 2
+    expect(pv!.target[1]).toBe(5)  // (0 + 10) / 2
+  })
+
+  it("fitViewportToSelection is a no-op when no selection is active", async () => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      varNames: [],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+      embeddingData: {
+        positions: new Float32Array([0, 0, 10, 10]),
+        numPoints: 2,
+        bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+      },
+      selectionFilterBuffer: null,
+      pendingViewport: null,
+    } as any)
+    const beforeEpoch = useAppStore.getState().viewportEpoch
+    const result = await applyConfig({ fitViewportToSelection: true })
+    expect(result.ok).toBe(true)
+    expect(useAppStore.getState().pendingViewport).toBeNull()
+    expect(useAppStore.getState().viewportEpoch).toBe(beforeEpoch)  // no bump
+  })
 })
 
 describe('applyConfig — filterByExpression', () => {

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -83,6 +83,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     config.removeSummaryObsColumns ||
     config.removeSummaryGenes ||
     config.viewport !== undefined ||  // null = reset to fit-to-view
+    config.fitViewportToSelection ||
     config.pointSize !== undefined ||  // null is a valid clear sentinel
     config.opacity !== undefined ||  // null is a valid clear sentinel
     config.summaryContext ||
@@ -367,6 +368,12 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   if (config.viewport !== undefined) {
     const { setViewport } = store.getState()
     setViewport(config.viewport)
+  }
+
+  // Fit-to-selection: compute bbox of currently selected cells and apply.
+  // No-op if no selection is active (the store action checks).
+  if (config.fitViewportToSelection) {
+    store.getState().fitViewportToSelection()
   }
 
   return ok()

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -45,6 +45,13 @@ export const AppConfigSchema = z.object({
   // deckRef.setProps); object = explicit override; absent = no change.
   viewport: ViewportSchema.nullable().optional(),
 
+  // Compute viewport from the current selection's bbox (positions of cells
+  // where selectionFilterBuffer === 1) and apply. No-op if no selection is
+  // active. Useful for "zoom into my filter" agent tool calls — the agent
+  // doesn't have access to embedding coordinates, so it can't compute the
+  // bbox itself.
+  fitViewportToSelection: z.boolean().optional(),
+
   // rendering (flat, NEW).
   // `null` = reset to the store defaults (0.5 for both); number = override;
   // absent = no change.

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -245,6 +245,9 @@ export interface AppState {
   pendingViewport: { target: [number, number]; zoom: number } | null
   viewportEpoch: number
   setViewport: (v: { target: [number, number]; zoom: number } | null) => void
+  // Compute target+zoom from the current selectionFilterBuffer bbox and apply.
+  // No-op if no selection is active.
+  fitViewportToSelection: () => void
 }
 
 const DEFAULT_RGB: RGB = [200, 200, 200]
@@ -525,6 +528,36 @@ const useAppStore = create<AppState>((set, get) => ({
       pendingViewport: v,
       viewportEpoch: state.viewportEpoch + 1,
     })),
+  fitViewportToSelection: () => {
+    const { embeddingData, selectionFilterBuffer } = get()
+    if (!embeddingData || !selectionFilterBuffer) return
+    const positions = embeddingData.positions
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+    let count = 0
+    for (let i = 0; i < selectionFilterBuffer.length; i++) {
+      if (selectionFilterBuffer[i] !== 1) continue
+      const x = positions[i * 2]
+      const y = positions[i * 2 + 1]
+      if (x < minX) minX = x
+      if (x > maxX) maxX = x
+      if (y < minY) minY = y
+      if (y > maxY) maxY = y
+      count++
+    }
+    if (count === 0) return
+    const centerX = (minX + maxX) / 2
+    const centerY = (minY + maxY) / 2
+    // Zoom: log2 of the ratio between (assumed) container size and the bbox
+    // span, with padding. Mirrors the fit-to-view computation in View.tsx but
+    // uses the selection bbox instead of the full dataset bounds. The store
+    // doesn't know the real container size, so 800x600 is a reasonable
+    // default; View.tsx's effect will apply via setProps at runtime.
+    const dataWidth = maxX - minX || 1
+    const dataHeight = maxY - minY || 1
+    const padding = 1.1
+    const zoom = Math.log2(Math.min(800 / (dataWidth * padding), 600 / (dataHeight * padding)))
+    get().setViewport({ target: [centerX, centerY], zoom })
+  },
 
   // Error state
   loadingError: null,


### PR DESCRIPTION
## Summary

Frontend half of fit-to-selection. Pairs with the upcoming `fit_viewport_to_selection` agent tool — the agent doesn't have access to embedding coordinates, so it can't compute the bbox itself; this lets the frontend do it.

## What

- **Schema**: new `fitViewportToSelection: boolean` field.
- **Store**: new `fitViewportToSelection()` action. Iterates `selectionFilterBuffer × embeddingData.positions`, computes bbox of selected cells, derives target+zoom, calls `setViewport({target, zoom})` which bumps `viewportEpoch`.
- The viewport-runtime-reset effect in View.tsx (PR #249) picks up the epoch bump and applies via `deckRef.deck.setProps`. User sees a smooth zoom to the selection region.
- applyConfig handles the field by calling the store action.

## Test plan

- [x] 2 new applyConfig tests: bbox math is correct over a selection subset; no-op when no selection is active.
- [x] 328 highperformer tests pass.
- [x] JSON Schema artifact regenerated.

## Merge strategy

Use Create a merge commit.