### PR TITLE
feat(highperformer): colorScaleName field in AppConfig

### DIFF
--- a/.changeset/color-scale-field.md
+++ b/.changeset/color-scale-field.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `colorScaleName: 'viridis' | 'magma' | 'plasma' | 'inferno'` to AppConfig.
+Pairs with the upcoming `set_color_scale` agent tool. The enum matches the
+four scales already supported by `COLOR_SCALES` in the color buffer worker;
+applyConfig calls the existing `setColorScaleName` store action (rebuilds
+the color buffer only if currently in gene mode).

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -45,6 +45,15 @@
         }
       ]
     },
+    "colorScaleName": {
+      "type": "string",
+      "enum": [
+        "viridis",
+        "magma",
+        "plasma",
+        "inferno"
+      ]
+    },
     "highlightedCategories": {
       "type": "array",
       "items": {

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -667,6 +667,35 @@ describe('applyConfig — filterByExpression', () => {
   })
 })
 
+describe('applyConfig — colorScaleName', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      varNames: ['CD8A'],
+      obsmKeys: ['X_umap'],
+      obsColumnNames: ['cell_type'],
+      loading: false,
+    } as any)
+  })
+
+  it('calls setColorScaleName with the chosen scale', async () => {
+    const setColorScaleName = vi
+      .spyOn(useAppStore.getState(), 'setColorScaleName')
+      .mockImplementation(() => {})
+
+    const result = await applyConfig({ colorScaleName: 'plasma' })
+
+    expect(result.ok).toBe(true)
+    expect(setColorScaleName).toHaveBeenCalledWith('plasma')
+    setColorScaleName.mockRestore()
+  })
+
+  it('rejects unknown scale via schema validation', async () => {
+    const result = await applyConfig({ colorScaleName: 'rainbow' as any })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.kind).toBe('schema_validation')
+  })
+})
+
 describe('applyConfig — clear semantics (null)', () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -75,6 +75,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   const hasPostLoadConfig =
     config.embedding ||
     config.colorBy !== undefined ||  // null is a valid clear sentinel
+    config.colorScaleName ||
     config.geneLabelColumn ||
     config.filter ||
     config.filterByExpression ||
@@ -203,6 +204,13 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
       store.setState({ highlightedCategories: new Set(codes) })
       store.getState().rebuildColorBuffer()
     }
+  }
+
+  // Color scale for gene-mode coloring. Applied after colorBy so the new
+  // scale takes effect on the just-set gene; the store action rebuilds the
+  // color buffer only if currently in gene mode (no-op otherwise).
+  if (config.colorScaleName) {
+    store.getState().setColorScaleName(config.colorScaleName)
   }
 
   // 3d: Summary panel.

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -22,6 +22,9 @@ export const AppConfigSchema = z.object({
   colorBy: z.enum(['gene', 'category']).nullable().optional(),
   gene: z.string().nullable().optional(),
   category: z.string().nullable().optional(),
+  // Continuous color scale for gene coloring. Categorical colors are
+  // independent (palette built into the worker).
+  colorScaleName: z.enum(['viridis', 'magma', 'plasma', 'inferno']).optional(),
   // Subset of category values to highlight (full-opacity); others render dimmed/gray.
   // Requires colorBy='category' + category. Labels are matched against the loaded
   // categoryMap; unknown labels yield a field_value_invalid error.


### PR DESCRIPTION
## Summary

Adds `colorScaleName: 'viridis' | 'magma' | 'plasma' | 'inferno'` to AppConfig. Pairs with the upcoming `set_color_scale` agent tool.

The enum matches the four scales already supported by `COLOR_SCALES` in the color buffer worker. applyConfig calls the existing `setColorScaleName` store action (which rebuilds the color buffer only if currently in gene mode).

## Test plan

- [x] 2 new tests (happy path + schema rejection of unknown scale).
- [x] 330 highperformer tests pass.
- [x] JSON Schema artifact regenerated.

## Merge strategy

Use Create a merge commit.