### PR TITLE
feat(chat): send view-state snapshot with each turn request

### DIFF
--- a/.changeset/view-state-snapshot.md
+++ b/.changeset/view-state-snapshot.md
@@ -1,0 +1,16 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Chat client now sends a compact view-state snapshot with each turn request
+(`view_state` field on `POST /api/chat/<slug>/turns`). Lets the backend
+agent answer relative queries like "zoom in more" / "change to a different
+gene" without a separate tool call.
+
+Snapshot omits fields at their defaults; gene names resolve through
+`geneLabelMap` so the agent sees symbols (CD8A) rather than var indices.
+Filter / selection state is summarised (counts, not full ID lists).
+Typical payload: 50–150 tokens.
+
+Backend wiring follows in a cell-explorer-py PR — until then the field is
+silently ignored by the existing chat endpoint.

--- a/packages/highperformer/src/api.ts
+++ b/packages/highperformer/src/api.ts
@@ -53,13 +53,14 @@ export const chat = {
   async *streamTurn(
     slug: string,
     messages: WireMessage[],
+    viewState: import("./chat/viewStateSnapshot").ViewStateSnapshot,
     signal: AbortSignal,
   ): AsyncIterable<ChatEvent> {
     const res = await fetch(`/api/chat/${encodeURIComponent(slug)}/turns`, {
       method: "POST",
       credentials: "include",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ messages }),
+      body: JSON.stringify({ messages, view_state: viewState }),
       signal,
     });
     if (!res.ok) throw new HttpError(res.status, await res.text());

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -36,6 +36,7 @@ export type WireMessage = {
 
 export type TurnRequest = {
   messages: WireMessage[];
+  view_state?: import("./viewStateSnapshot").ViewStateSnapshot;
 };
 
 // ---------- /turns wire events ----------

--- a/packages/highperformer/src/chat/useChatTurn.ts
+++ b/packages/highperformer/src/chat/useChatTurn.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { chat } from "../api";
 import type { ChatEvent, WireMessage } from "./types";
+import { buildViewStateSnapshot } from "./viewStateSnapshot";
 
 export function useChatTurn() {
   const [streaming, setStreaming] = useState(false);
@@ -17,7 +18,11 @@ export function useChatTurn() {
       abortRef.current = controller;
       setStreaming(true);
       try {
-        for await (const ev of chat.streamTurn(slug, messages, controller.signal)) {
+        // Capture state snapshot at send time. Only non-default fields are
+        // included; agent uses this to answer relative queries ("zoom in
+        // more", "change to a different gene") without a tool round-trip.
+        const viewState = buildViewStateSnapshot();
+        for await (const ev of chat.streamTurn(slug, messages, viewState, controller.signal)) {
           onEvent(ev);
         }
       } finally {

--- a/packages/highperformer/src/chat/viewStateSnapshot.test.ts
+++ b/packages/highperformer/src/chat/viewStateSnapshot.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the WorkerPool before importing the store (same as useAppStore.test.ts).
+vi.mock("../pool/WorkerPool", () => {
+  return {
+    WorkerPool: class MockPool {
+      dispatch = vi.fn().mockResolvedValue({
+        type: "colorBuffer",
+        buffer: new Uint8Array(8),
+        version: 1,
+      });
+      clearQueue = vi.fn();
+      dispose() {}
+    },
+  };
+});
+vi.mock("../workers/universal.worker.ts?worker", () => {
+  return { default: class MockWorker {} };
+});
+
+const { default: useAppStore } = await import("../store/useAppStore");
+const { buildViewStateSnapshot } = await import("./viewStateSnapshot");
+
+describe("buildViewStateSnapshot", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("returns empty object when nothing is set", () => {
+    expect(buildViewStateSnapshot()).toEqual({});
+  });
+
+  it("includes embedding when set", () => {
+    useAppStore.setState({ selectedEmbedding: "X_umap" } as any);
+    expect(buildViewStateSnapshot()).toEqual({ embedding: "X_umap" });
+  });
+
+  it("includes colorMode + gene (resolved to symbol via geneLabelMap)", () => {
+    useAppStore.setState({
+      colorMode: "gene",
+      selectedGene: "ENSG_CD8A",
+      geneLabelMap: new Map([["ENSG_CD8A", "CD8A"]]),
+    } as any);
+    const snap = buildViewStateSnapshot();
+    expect(snap.colorMode).toBe("gene");
+    expect(snap.gene).toBe("CD8A");
+  });
+
+  it("includes colorMode + category when in category mode", () => {
+    useAppStore.setState({
+      colorMode: "category",
+      selectedObsColumn: "cell_type",
+    } as any);
+    const snap = buildViewStateSnapshot();
+    expect(snap.colorMode).toBe("category");
+    expect(snap.category).toBe("cell_type");
+  });
+
+  it("omits colorScale when default (viridis)", () => {
+    useAppStore.setState({ colorScaleName: "viridis" } as any);
+    expect(buildViewStateSnapshot().colorScale).toBeUndefined();
+  });
+
+  it("includes colorScale when non-default", () => {
+    useAppStore.setState({ colorScaleName: "plasma" } as any);
+    expect(buildViewStateSnapshot().colorScale).toBe("plasma");
+  });
+
+  it("includes highlightedCategories resolved to labels", () => {
+    useAppStore.setState({
+      categoryMap: [
+        { label: "T cell", color: [255, 0, 0] },
+        { label: "B cell", color: [0, 255, 0] },
+      ],
+      highlightedCategories: new Set([0]),
+    } as any);
+    expect(buildViewStateSnapshot().highlightedCategories).toEqual(["T cell"]);
+  });
+
+  it("omits pointSize/opacity when at defaults (0.5)", () => {
+    useAppStore.setState({ pointRadius: 0.5, opacity: 0.5 } as any);
+    const snap = buildViewStateSnapshot();
+    expect(snap.pointSize).toBeUndefined();
+    expect(snap.opacity).toBeUndefined();
+  });
+
+  it("includes pointSize/opacity when non-default", () => {
+    useAppStore.setState({ pointRadius: 2, opacity: 0.3 } as any);
+    const snap = buildViewStateSnapshot();
+    expect(snap.pointSize).toBe(2);
+    expect(snap.opacity).toBe(0.3);
+  });
+
+  it("includes summaryGenes resolved to symbols", () => {
+    useAppStore.setState({
+      summaryGenes: ["ENSG_CD8A", "ENSG_DAPL1"],
+      geneLabelMap: new Map([
+        ["ENSG_CD8A", "CD8A"],
+        ["ENSG_DAPL1", "DAPL1"],
+      ]),
+    } as any);
+    expect(buildViewStateSnapshot().summaryGenes).toEqual(["CD8A", "DAPL1"]);
+  });
+
+  it("emits filter snapshot when a custom group is active", () => {
+    useAppStore.setState({
+      selectionFilterBuffer: new Float32Array([1, 0, 1]),
+      selectionGroups: [
+        {
+          id: 4,
+          type: "custom" as const,
+          column: "cell_type",
+          ids: ["T.cell"],
+          unmatchedIds: [],
+          indices: new Uint32Array(0),
+          color: [255, 149, 0] as [number, number, number],
+        },
+      ],
+      customGroupColumn: "cell_type",
+      customGroupCommittedCount: 250334,
+    } as any);
+    expect(buildViewStateSnapshot().filter).toEqual({
+      kind: "ids",
+      obsColumn: "cell_type",
+      matchedCount: 250334,
+    });
+  });
+
+  it("emits filter snapshot when an expression group is active (gene resolved)", () => {
+    useAppStore.setState({
+      selectionFilterBuffer: new Float32Array([1, 0]),
+      selectionGroups: [
+        {
+          id: 5,
+          type: "expression" as const,
+          gene: "ENSG_CD8A",
+          min: 2,
+          max: null,
+          indices: new Uint32Array(0),
+          color: [175, 82, 222] as [number, number, number],
+        },
+      ],
+      geneLabelMap: new Map([["ENSG_CD8A", "CD8A"]]),
+    } as any);
+    expect(buildViewStateSnapshot().filter).toEqual({
+      kind: "expression",
+      gene: "CD8A",
+      min: 2,
+      max: null,
+    });
+  });
+
+  it("includes selectionDisplayMode when non-default ('hide') AND a filter is active", () => {
+    useAppStore.setState({
+      selectionFilterBuffer: new Float32Array([1, 0]),
+      selectionDisplayMode: "hide",
+      selectionGroups: [
+        {
+          id: 4,
+          type: "custom" as const,
+          column: "x",
+          ids: [],
+          unmatchedIds: [],
+          indices: new Uint32Array(0),
+          color: [255, 149, 0] as [number, number, number],
+        },
+      ],
+      customGroupColumn: "x",
+      customGroupCommittedCount: 1,
+    } as any);
+    expect(buildViewStateSnapshot().selectionDisplayMode).toBe("hide");
+  });
+
+  it("omits filter and selectionDisplayMode when no selection buffer", () => {
+    useAppStore.setState({
+      selectionFilterBuffer: null,
+      selectionDisplayMode: "hide",
+    } as any);
+    const snap = buildViewStateSnapshot();
+    expect(snap.filter).toBeUndefined();
+    expect(snap.selectionDisplayMode).toBeUndefined();
+  });
+});

--- a/packages/highperformer/src/chat/viewStateSnapshot.ts
+++ b/packages/highperformer/src/chat/viewStateSnapshot.ts
@@ -1,0 +1,107 @@
+/**
+ * Build a compact JSON snapshot of the current view state for the agent.
+ *
+ * Only fields that differ from their defaults are included. Gene names are
+ * resolved through `geneLabelMap` so the agent sees symbols (CD8A) rather
+ * than internal var indices (ENSG00000...).
+ *
+ * Shipped with each chat turn request so the agent has context for relative
+ * queries like "zoom in more" or "change to a different gene" without a
+ * separate tool call.
+ */
+
+import useAppStore from "../store/useAppStore";
+
+export type FilterSnapshot =
+  | { kind: "ids"; obsColumn: string; matchedCount: number }
+  | { kind: "expression"; gene: string; min: number | null; max: number | null }
+  | { kind: "spatial" };
+
+export type ViewStateSnapshot = {
+  embedding?: string;
+  colorMode?: "gene" | "category";
+  gene?: string;
+  category?: string;
+  colorScale?: string;
+  highlightedCategories?: string[];
+  geneLabelColumn?: string;
+  pointSize?: number;
+  opacity?: number;
+  summaryContext?: "all" | "selections";
+  summaryObsColumns?: string[];
+  summaryGenes?: string[];
+  selectionDisplayMode?: "dim" | "hide";
+  filter?: FilterSnapshot;
+};
+
+export function buildViewStateSnapshot(): ViewStateSnapshot {
+  const s = useAppStore.getState();
+  const snap: ViewStateSnapshot = {};
+
+  if (s.selectedEmbedding) snap.embedding = s.selectedEmbedding;
+
+  if (s.colorMode === "gene" && s.selectedGene) {
+    snap.colorMode = "gene";
+    snap.gene = s.geneLabelMap?.get(s.selectedGene) ?? s.selectedGene;
+  } else if (s.colorMode === "category" && s.selectedObsColumn) {
+    snap.colorMode = "category";
+    snap.category = s.selectedObsColumn;
+  }
+
+  if (s.colorScaleName !== "viridis") snap.colorScale = s.colorScaleName;
+
+  if (s.highlightedCategories.size > 0) {
+    snap.highlightedCategories = Array.from(s.highlightedCategories).map(
+      (code) => s.categoryMap[code]?.label ?? String(code),
+    );
+  }
+
+  if (s.geneLabelColumn) snap.geneLabelColumn = s.geneLabelColumn;
+  if (s.pointRadius !== 0.5) snap.pointSize = s.pointRadius;
+  if (s.opacity !== 0.5) snap.opacity = s.opacity;
+
+  // Map store's internal value ('all' | 'selections' | 'compare') to the
+  // agent-facing surface. 'compare' is intentionally UI-only.
+  if (s.summaryContext === "selections") snap.summaryContext = "selections";
+  // 'all' is the default — omit. 'compare' is also omitted (UI-only).
+
+  if (s.summaryObsColumns.length > 0)
+    snap.summaryObsColumns = [...s.summaryObsColumns];
+
+  if (s.summaryGenes.length > 0) {
+    snap.summaryGenes = s.summaryGenes.map(
+      (g) => s.geneLabelMap?.get(g) ?? g,
+    );
+  }
+
+  // Filter / selection state. Only include if there's a filter buffer
+  // (something actually selected on the canvas).
+  if (s.selectionFilterBuffer) {
+    if (s.selectionDisplayMode !== "dim") {
+      snap.selectionDisplayMode = s.selectionDisplayMode;
+    }
+    const expressionGroup = s.selectionGroups.find(
+      (g) => g.type === "expression",
+    );
+    const customGroup = s.selectionGroups.find((g) => g.type === "custom");
+    if (expressionGroup && expressionGroup.type === "expression") {
+      snap.filter = {
+        kind: "expression",
+        gene:
+          s.geneLabelMap?.get(expressionGroup.gene) ?? expressionGroup.gene,
+        min: expressionGroup.min,
+        max: expressionGroup.max,
+      };
+    } else if (customGroup && customGroup.type === "custom") {
+      snap.filter = {
+        kind: "ids",
+        obsColumn: s.customGroupColumn ?? customGroup.column,
+        matchedCount: s.customGroupCommittedCount,
+      };
+    } else {
+      snap.filter = { kind: "spatial" };
+    }
+  }
+
+  return snap;
+}


### PR DESCRIPTION
## Summary

Chat client now sends a compact view-state snapshot with each turn request (`view_state` field on `POST /api/chat/<slug>/turns`). Lets the backend agent answer relative queries like "zoom in more" / "change to a different gene" / "now color by something else" without a separate tool round-trip — the snapshot rides along free.

## Design

- **Omit defaults.** Snapshot only includes fields that differ from the store defaults. Empty session → empty object. Typical busy session → 50–150 tokens.
- **Gene names as symbols.** Resolved through `geneLabelMap` before serializing — agent sees `"CD8A"` not `"ENSG00000176566"`.
- **Filter state is summarised.** kind + obs column + matched count for ID filters; gene + min/max for expression filters. No full ID lists.
- **`selectionDisplayMode`** only included if non-default (`hide`) AND a filter is active.
- **Field names** track AppConfig conventions so the agent's "current state" mental model maps onto "what would I emit to change it".

## Token cost

For a busy session (gene coloring + 3 pinned summary genes + 2 obs columns + filter + non-default opacity): ~120–150 tokens per turn. Empty session: ~0–30. At Claude Sonnet input pricing ($3/M), ~$0.0004 per turn extra.

## Out of scope

Backend wiring is a separate cell-explorer-py PR. Until that lands, the chat endpoint silently ignores the new field (Pydantic strips unknowns by default — verified, this is the existing chat schema's behavior).

## Test plan

- [x] 14 new tests in `viewStateSnapshot.test.ts` (field-by-field inclusion + omission rules, gene symbol resolution, filter snapshot variants).
- [x] 344 highperformer tests pass.

## Merge strategy

Use Create a merge commit.