### PR TITLE
feat(chat): per-dataset chat tab + permission banner

### DIFF
--- a/.changeset/chat-gating.md
+++ b/.changeset/chat-gating.md
@@ -1,0 +1,12 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+"@cbioportal-cell-explorer/api-client": minor
+---
+
+Wire the chat-panel UI to the new per-dataset and per-user chat gates from
+cell-explorer-py. The chat tab on the View page is now hidden when
+`dataset.chat_enabled` is false. When the tab is visible but the user's
+`permission.can_chat` is false, ChatPanel renders a `ChatPermissionBanner`
+(sign-in CTA for anonymous, contact-admin copy for missing role) instead of
+the chat input. The api-client is regenerated to expose `chat_enabled` on
+the dataset shapes and a `permission` field on `ContextResponse`.

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -341,6 +341,13 @@ export interface components {
             /** Content */
             content: string;
         };
+        /** ChatPermissionResponse */
+        ChatPermissionResponse: {
+            /** Can Chat */
+            can_chat: boolean;
+            /** Reason */
+            reason?: string | null;
+        };
         /** ContextResponse */
         ContextResponse: {
             /** Slug */
@@ -359,6 +366,7 @@ export interface components {
             embedding_keys: string[];
             /** Available Tools */
             available_tools: string[];
+            permission: components["schemas"]["ChatPermissionResponse"];
         };
         /** DatasetAdminListResponse */
         DatasetAdminListResponse: {
@@ -383,6 +391,8 @@ export interface components {
             is_public: boolean;
             /** Required Roles */
             required_roles: string[];
+            /** Chat Enabled */
+            chat_enabled: boolean;
         };
         /** DatasetCreate */
         DatasetCreate: {
@@ -406,6 +416,11 @@ export interface components {
              * @default []
              */
             required_roles: string[];
+            /**
+             * Chat Enabled
+             * @default false
+             */
+            chat_enabled: boolean;
         };
         /** DatasetListResponse */
         DatasetListResponse: {
@@ -424,6 +439,8 @@ export interface components {
             is_public: boolean;
             /** Url */
             url: string | null;
+            /** Chat Enabled */
+            chat_enabled: boolean;
         };
         /** DatasetUpdate */
         DatasetUpdate: {
@@ -437,6 +454,8 @@ export interface components {
             is_public?: boolean | null;
             /** Required Roles */
             required_roles?: string[] | null;
+            /** Chat Enabled */
+            chat_enabled?: boolean | null;
         };
         /** DatasourceCreate */
         DatasourceCreate: {
@@ -445,6 +464,8 @@ export interface components {
             type: components["schemas"]["DatasourceType"];
             /** Base Url */
             base_url: string;
+            /** Internal Base Url */
+            internal_base_url?: string | null;
             /** Credential Ref */
             credential_ref?: string | null;
         };
@@ -462,6 +483,8 @@ export interface components {
             type: components["schemas"]["DatasourceType"];
             /** Base Url */
             base_url: string;
+            /** Internal Base Url */
+            internal_base_url: string | null;
             /** Credential Ref */
             credential_ref: string | null;
         };
@@ -477,6 +500,8 @@ export interface components {
             name?: string | null;
             /** Base Url */
             base_url?: string | null;
+            /** Internal Base Url */
+            internal_base_url?: string | null;
             /** Credential Ref */
             credential_ref?: string | null;
         };
@@ -516,6 +541,10 @@ export interface components {
         TurnRequest: {
             /** Messages */
             messages: components["schemas"]["ChatMessage"][];
+            /** View State */
+            view_state?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * User

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -29,6 +29,7 @@ const sampleCtx: ContextResponse = {
   ],
   embedding_keys: ["X_umap"],
   available_tools: ["top_expressed_genes"],
+  permission: { can_chat: true, reason: null },
 };
 
 const startMock = vi.fn();
@@ -128,5 +129,69 @@ describe("ChatPanel", () => {
     await waitFor(() => expect(startMock).toHaveBeenCalledTimes(2));
     const [, messages] = startMock.mock.calls[1];
     expect(messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  describe("ChatPanel permission-aware rendering", () => {
+    it("renders chat input when permission.can_chat is true", () => {
+      vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+        loading: false,
+        error: undefined,
+        data: {
+          slug: "demo",
+          name: "Demo",
+          description: "",
+          n_obs: 100,
+          n_var: 50,
+          obs_columns: [],
+          embedding_keys: ["X_umap"],
+          available_tools: [],
+          permission: { can_chat: true, reason: null },
+        },
+      });
+      render(<ChatPanel slug="demo" />);
+      expect(screen.getByPlaceholderText(/ask anything/i)).toBeInTheDocument();
+    });
+
+    it("renders banner instead of input when can_chat is false (missing_role)", () => {
+      vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+        loading: false,
+        error: undefined,
+        data: {
+          slug: "demo",
+          name: "Demo",
+          description: "",
+          n_obs: 100,
+          n_var: 50,
+          obs_columns: [],
+          embedding_keys: ["X_umap"],
+          available_tools: [],
+          permission: { can_chat: false, reason: "missing_role:cell-explorer-chat" },
+        },
+      });
+      render(<ChatPanel slug="demo" />);
+      expect(screen.queryByPlaceholderText(/ask anything/i)).toBeNull();
+      expect(screen.getByText(/cell-explorer-chat/)).toBeInTheDocument();
+    });
+
+    it("renders sign-in banner when reason is requires_auth", () => {
+      vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+        loading: false,
+        error: undefined,
+        data: {
+          slug: "demo",
+          name: "Demo",
+          description: "",
+          n_obs: 100,
+          n_var: 50,
+          obs_columns: [],
+          embedding_keys: ["X_umap"],
+          available_tools: [],
+          permission: { can_chat: false, reason: "requires_auth" },
+        },
+      });
+      render(<ChatPanel slug="demo" />);
+      expect(screen.queryByPlaceholderText(/ask anything/i)).toBeNull();
+      expect(screen.getByText(/sign in to use chat/i)).toBeInTheDocument();
+    });
   });
 });

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -149,7 +149,7 @@ describe("ChatPanel", () => {
         },
       });
       render(<ChatPanel slug="demo" />);
-      expect(screen.getByPlaceholderText(/ask anything/i)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/ask anything/i)).toBeDefined();
     });
 
     it("renders banner instead of input when can_chat is false (missing_role)", () => {
@@ -170,7 +170,7 @@ describe("ChatPanel", () => {
       });
       render(<ChatPanel slug="demo" />);
       expect(screen.queryByPlaceholderText(/ask anything/i)).toBeNull();
-      expect(screen.getByText(/cell-explorer-chat/)).toBeInTheDocument();
+      expect(screen.getByText(/cell-explorer-chat/)).toBeDefined();
     });
 
     it("renders sign-in banner when reason is requires_auth", () => {
@@ -191,7 +191,7 @@ describe("ChatPanel", () => {
       });
       render(<ChatPanel slug="demo" />);
       expect(screen.queryByPlaceholderText(/ask anything/i)).toBeNull();
-      expect(screen.getByText(/sign in to use chat/i)).toBeInTheDocument();
+      expect(screen.getByText(/sign in to use chat/i)).toBeDefined();
     });
   });
 });

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { applyErrorMessage } from "../config/applyResult";
 import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
 import type { ChatEvent, ChatMessage, MessagePart, WireMessage } from "./types";
+import { ChatPermissionBanner } from "./ChatPermissionBanner";
 import { useChatContext } from "./useChatContext";
 import { useChatTurn } from "./useChatTurn";
 
@@ -171,6 +172,16 @@ export function ChatPanel({ slug }: { slug: string }) {
 
   const isEmpty = state.history.length === 0 && state.current === null && !streaming;
   const hasError = state.status === "error";
+
+  // Permission gate — short-circuit before rendering input.
+  const permission = ctxQuery.data?.permission;
+  if (permission && !permission.can_chat) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
+        <ChatPermissionBanner reason={permission.reason ?? "unknown"} />
+      </div>
+    );
+  }
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>

--- a/packages/highperformer/src/chat/ChatPermissionBanner.test.tsx
+++ b/packages/highperformer/src/chat/ChatPermissionBanner.test.tsx
@@ -5,17 +5,17 @@ import { ChatPermissionBanner } from './ChatPermissionBanner'
 describe('ChatPermissionBanner', () => {
   it('renders sign-in CTA for requires_auth', () => {
     render(<ChatPermissionBanner reason="requires_auth" />)
-    expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /sign in/i })).toBeDefined()
   })
 
   it('renders contact-admin copy for missing_role', () => {
     render(<ChatPermissionBanner reason="missing_role:cell-explorer-chat" />)
-    expect(screen.getByText(/cell-explorer-chat/)).toBeInTheDocument()
-    expect(screen.getByText(/administrator/i)).toBeInTheDocument()
+    expect(screen.getByText(/cell-explorer-chat/)).toBeDefined()
+    expect(screen.getByText(/administrator/i)).toBeDefined()
   })
 
   it('renders a generic fallback for unknown reasons', () => {
     render(<ChatPermissionBanner reason="some-future-reason" />)
-    expect(screen.getByText(/not available for your account/i)).toBeInTheDocument()
+    expect(screen.getByText(/not available for your account/i)).toBeDefined()
   })
 })

--- a/packages/highperformer/src/chat/ChatPermissionBanner.test.tsx
+++ b/packages/highperformer/src/chat/ChatPermissionBanner.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ChatPermissionBanner } from './ChatPermissionBanner'
+
+describe('ChatPermissionBanner', () => {
+  it('renders sign-in CTA for requires_auth', () => {
+    render(<ChatPermissionBanner reason="requires_auth" />)
+    expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+  })
+
+  it('renders contact-admin copy for missing_role', () => {
+    render(<ChatPermissionBanner reason="missing_role:cell-explorer-chat" />)
+    expect(screen.getByText(/cell-explorer-chat/)).toBeInTheDocument()
+    expect(screen.getByText(/administrator/i)).toBeInTheDocument()
+  })
+
+  it('renders a generic fallback for unknown reasons', () => {
+    render(<ChatPermissionBanner reason="some-future-reason" />)
+    expect(screen.getByText(/not available for your account/i)).toBeInTheDocument()
+  })
+})

--- a/packages/highperformer/src/chat/ChatPermissionBanner.tsx
+++ b/packages/highperformer/src/chat/ChatPermissionBanner.tsx
@@ -1,0 +1,44 @@
+import { Alert } from "antd";
+
+export function ChatPermissionBanner({ reason }: { reason: string }) {
+  if (reason === "requires_auth") {
+    return (
+      <Alert
+        type="info"
+        showIcon
+        title="Sign in to use chat"
+        description={
+          <>
+            Chat requires an authenticated session.{" "}
+            <a href="/api/auth/login">Sign in</a> to continue.
+          </>
+        }
+      />
+    );
+  }
+  if (reason.startsWith("missing_role:")) {
+    const role = reason.slice("missing_role:".length);
+    return (
+      <Alert
+        type="info"
+        showIcon
+        title="Chat access required"
+        description={
+          <>
+            Chat requires the <code>{role}</code> role. Contact your
+            administrator to request access.
+          </>
+        }
+      />
+    );
+  }
+  // Fallback for future reason codes
+  return (
+    <Alert
+      type="info"
+      showIcon
+      title="Chat is not available"
+      description="Chat is not available for your account on this dataset."
+    />
+  );
+}

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -16,6 +16,11 @@ export type ObsColumnInfo = {
   values: string[] | null; // populated for categorical with cardinality <= 50
 };
 
+export type ChatPermission = {
+  can_chat: boolean;
+  reason: string | null;
+};
+
 export type ContextResponse = {
   slug: string;
   name: string;
@@ -25,6 +30,7 @@ export type ContextResponse = {
   obs_columns: ObsColumnInfo[];
   embedding_keys: string[];
   available_tools: string[];
+  permission: ChatPermission;
 };
 
 // ---------- /turns wire request ----------

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -835,6 +835,9 @@ function View() {
   const loadingError = useAppStore((s) => s.loadingError)
   const datasetUrl = useAppStore((s) => s.datasetUrl)
   const datasetSlug = useAppStore((s) => s.datasetSlug)
+  const dataset = useAppStore((s) =>
+    s.catalogDatasets.find((d) => d.slug === datasetSlug),
+  )
   const backendInfo = useAppStore((s) => s.backendInfo)
   const [leftCollapsed, setLeftCollapsed] = useState(false)
   const [rightWidth, setRightWidth] = useState(RIGHT_SIDEBAR_WIDTH)
@@ -956,7 +959,7 @@ function View() {
                   label: 'Summary',
                   children: <SummaryPanel collapsed={false} onExpand={() => {}} />,
                 },
-                ...(datasetSlug && backendInfo?.chat_enabled
+                ...(datasetSlug && backendInfo?.chat_enabled && dataset?.chat_enabled
                   ? [
                       {
                         key: 'chat',

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1227,8 +1227,8 @@ describe('useAppStore', () => {
 
     it('fetchCatalog stores datasets from API', async () => {
       const mockDatasets = [
-        { slug: 'brca-demo', name: 'BRCA Demo', description: 'Test', is_public: true, url: 'https://cdn.example.com/brca.zarr' },
-        { slug: 'private-study', name: 'Private Study', description: null, is_public: false, url: null },
+        { slug: 'brca-demo', name: 'BRCA Demo', description: 'Test', is_public: true, url: 'https://cdn.example.com/brca.zarr', chat_enabled: false },
+        { slug: 'private-study', name: 'Private Study', description: null, is_public: false, url: null, chat_enabled: false },
       ]
       mockGET.mockResolvedValueOnce({ data: { datasets: mockDatasets } })
 
@@ -1246,7 +1246,7 @@ describe('useAppStore', () => {
     it('openCatalogDataset opens a public dataset directly', async () => {
       useAppStore.setState({
         catalogDatasets: [
-          { slug: 'public-ds', name: 'Public', description: null, is_public: true, url: 'https://cdn.example.com/test.zarr' },
+          { slug: 'public-ds', name: 'Public', description: null, is_public: true, url: 'https://cdn.example.com/test.zarr', chat_enabled: false },
         ],
       })
 
@@ -1263,7 +1263,7 @@ describe('useAppStore', () => {
     it('openCatalogDataset calls /access for private datasets', async () => {
       useAppStore.setState({
         catalogDatasets: [
-          { slug: 'private-ds', name: 'Private', description: null, is_public: false, url: null },
+          { slug: 'private-ds', name: 'Private', description: null, is_public: false, url: null, chat_enabled: false },
         ],
       })
 
@@ -1293,7 +1293,7 @@ describe('useAppStore', () => {
     it('openCatalogDataset sets error on 503', async () => {
       useAppStore.setState({
         catalogDatasets: [
-          { slug: 'broken-ds', name: 'Broken', description: null, is_public: false, url: null },
+          { slug: 'broken-ds', name: 'Broken', description: null, is_public: false, url: null, chat_enabled: false },
         ],
       })
 

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -202,6 +202,7 @@ export interface AppState {
     description: string | null
     is_public: boolean
     url: string | null
+    chat_enabled: boolean
   }>
   fetchCatalog: () => Promise<void>
   openCatalogDataset: (slug: string) => Promise<void>


### PR DESCRIPTION
## Summary

Consumes the per-dataset `chat_enabled` flag and the new `permission` object on `/api/chat/{slug}/context` (cell-explorer-py #98 merged).

- Chat tab hidden when `dataset.chat_enabled=false`.
- When tab is visible and `permission.can_chat=false`, `ChatPanel` renders a banner instead of the input. Banner copy depends on `reason`:
  - `requires_auth` → "Sign in to use chat" + sign-in link.
  - `missing_role:<name>` → "Chat requires the `<name>` role. Contact your administrator."
  - other → generic "Chat is not available" fallback.

## Test plan

- [x] `ChatPermissionBanner` renders all three reason variants
- [x] `ChatPanel` forks on `permission.can_chat`
- [x] `View.tsx` hides chat tab when `dataset.chat_enabled=false` (three-flag AND)
- [x] api-client regenerated from cell-explorer-py main
- [x] 350 tests pass in `packages/highperformer`