### PR TITLE
feat(chat): thread list, persistence, and history

### DIFF
--- a/.changeset/chat-threads.md
+++ b/.changeset/chat-threads.md
@@ -1,0 +1,14 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+"@cbioportal-cell-explorer/api-client": minor
+---
+
+Add chat thread persistence and history. The chat tab now opens to a list of
+past conversations on the current dataset. Click a thread to resume it (history
+hydrates into the reducer); click "+ New chat" to start a fresh one (auto-titled
+from the first user message after the stream's `thread_open` event). Hover a
+row to reveal a delete button, confirmed via `Modal.confirm` and persisted via
+`DELETE /api/chat/{slug}/threads/{id}`. ChatPanel becomes a mode-based router
+(list / new / active), with the conversation render extracted into a dedicated
+`ConversationView` component. `useChatTurn`'s `start()` and `chat.streamTurn()`
+gain a `threadId` parameter the route uses to attribute messages.

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -327,6 +327,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/{slug}/threads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Chat Threads */
+        get: operations["get_chat_threads_api_chat__slug__threads_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/{slug}/threads/{thread_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Chat Thread Detail */
+        get: operations["get_chat_thread_detail_api_chat__slug__threads__thread_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Chat Thread */
+        delete: operations["delete_chat_thread_api_chat__slug__threads__thread_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -537,6 +572,60 @@ export interface components {
             /** Values */
             values?: string[] | null;
         };
+        /** ThreadDetailResponse */
+        ThreadDetailResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Title */
+            title: string;
+            /** Messages */
+            messages: components["schemas"]["ThreadMessageResponse"][];
+        };
+        /** ThreadListResponse */
+        ThreadListResponse: {
+            /** Threads */
+            threads: components["schemas"]["ThreadSummaryResponse"][];
+        };
+        /** ThreadMessageResponse */
+        ThreadMessageResponse: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "user" | "assistant";
+            /** Content */
+            content: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** ThreadSummaryResponse */
+        ThreadSummaryResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Title */
+            title: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Message Count */
+            message_count: number;
+        };
         /** TurnRequest */
         TurnRequest: {
             /** Messages */
@@ -545,6 +634,8 @@ export interface components {
             view_state?: {
                 [key: string]: unknown;
             } | null;
+            /** Thread Id */
+            thread_id?: string | null;
         };
         /**
          * User
@@ -1111,6 +1202,99 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_threads_api_chat__slug__threads_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThreadListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_thread_detail_api_chat__slug__threads__thread_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+                thread_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThreadDetailResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_chat_thread_api_chat__slug__threads__thread_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+                thread_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/packages/highperformer/src/api.ts
+++ b/packages/highperformer/src/api.ts
@@ -37,6 +37,8 @@ import {
   HttpError,
   type ChatEvent,
   type ContextResponse,
+  type ThreadDetailResponse,
+  type ThreadListResponse,
   type WireMessage,
 } from "./chat/types";
 
@@ -54,17 +56,52 @@ export const chat = {
     slug: string,
     messages: WireMessage[],
     viewState: import("./chat/viewStateSnapshot").ViewStateSnapshot,
+    threadId: string | null,
     signal: AbortSignal,
   ): AsyncIterable<ChatEvent> {
     const res = await fetch(`/api/chat/${encodeURIComponent(slug)}/turns`, {
       method: "POST",
       credentials: "include",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ messages, view_state: viewState }),
+      body: JSON.stringify({ messages, view_state: viewState, thread_id: threadId }),
       signal,
     });
     if (!res.ok) throw new HttpError(res.status, await res.text());
     if (!res.body) throw new Error("empty response body");
     yield* parseNdjson<ChatEvent>(res.body);
+  },
+
+  async listThreads(slug: string, signal?: AbortSignal): Promise<ThreadListResponse> {
+    const res = await fetch(`/api/chat/${encodeURIComponent(slug)}/threads`, {
+      credentials: "include",
+      signal,
+    });
+    if (!res.ok) throw new HttpError(res.status, await res.text());
+    return (await res.json()) as ThreadListResponse;
+  },
+
+  async getThread(
+    slug: string,
+    threadId: string,
+    signal?: AbortSignal,
+  ): Promise<ThreadDetailResponse> {
+    const res = await fetch(
+      `/api/chat/${encodeURIComponent(slug)}/threads/${encodeURIComponent(threadId)}`,
+      { credentials: "include", signal },
+    );
+    if (!res.ok) throw new HttpError(res.status, await res.text());
+    return (await res.json()) as ThreadDetailResponse;
+  },
+
+  async deleteThread(
+    slug: string,
+    threadId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const res = await fetch(
+      `/api/chat/${encodeURIComponent(slug)}/threads/${encodeURIComponent(threadId)}`,
+      { method: "DELETE", credentials: "include", signal },
+    );
+    if (!res.ok) throw new HttpError(res.status, await res.text());
   },
 };

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -92,7 +92,7 @@ describe("ChatPanel", () => {
     })
 
     let dispatch: ((e: ChatEvent) => void) | null = null;
-    startMock.mockImplementation(async (_s, _m, onEvent) => {
+    startMock.mockImplementation(async (_s, _m, _threadId, onEvent) => {
       dispatch = onEvent;
     });
     render(<ChatPanel slug="spectrum" />);
@@ -112,7 +112,7 @@ describe("ChatPanel", () => {
 
   it("renders an error bubble with Retry when an error event is dispatched", async () => {
     let dispatch: ((e: ChatEvent) => void) | null = null;
-    startMock.mockImplementation(async (_s, _m, onEvent) => {
+    startMock.mockImplementation(async (_s, _m, _threadId, onEvent) => {
       dispatch = onEvent;
     });
     render(<ChatPanel slug="spectrum" />);

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatPanel } from "./ChatPanel";
 import * as useChatContextModule from "./useChatContext";
 import * as useChatTurnModule from "./useChatTurn";
+import { chat } from "../api";
 import type { ChatEvent, ContextResponse } from "./types";
 
 // Mock applyConfig so individual tests can control its return value
@@ -16,6 +17,16 @@ vi.mock("../store/useAppStore", () => ({
     (selector: (s: unknown) => unknown) => selector({ applyConfig: vi.fn() }),
     { getState: () => ({ applyConfig: vi.fn() }) },
   ),
+}));
+
+vi.mock("../api", () => ({
+  chat: {
+    streamTurn: vi.fn(),
+    getContext: vi.fn(),
+    listThreads: vi.fn().mockResolvedValue({ threads: [] }),
+    getThread: vi.fn(),
+    deleteThread: vi.fn(),
+  },
 }));
 
 const sampleCtx: ContextResponse = {
@@ -51,6 +62,8 @@ beforeEach(() => {
   // Default: applyConfig succeeds
   mockApplyConfig.mockReset()
   mockApplyConfig.mockResolvedValue({ ok: true })
+  // Default: empty thread list
+  ;(chat.listThreads as any).mockResolvedValue({ threads: [] });
 });
 
 afterEach(() => {
@@ -58,16 +71,25 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// Helper: from list mode, click "+ New chat" to reach the conversation input
+async function enterNewMode() {
+  await waitFor(() => screen.getByText(/no conversations yet/i));
+  fireEvent.click(screen.getByRole("button", { name: /\+ new chat/i }));
+  await waitFor(() => screen.getByPlaceholderText(/ask anything/i));
+}
+
 describe("ChatPanel", () => {
-  it("renders empty state with chips when history is empty", () => {
+  it("renders empty state with chips when history is empty", async () => {
     render(<ChatPanel slug="spectrum" />);
+    await enterNewMode();
     expect(screen.getByText(/Spectrum/)).toBeDefined();
     expect(screen.getByText(/Top genes in T/)).toBeDefined();
     expect(screen.getByPlaceholderText(/Ask anything/i)).toBeDefined();
   });
 
-  it("clicking a chip fills the input", () => {
+  it("clicking a chip fills the input", async () => {
     render(<ChatPanel slug="spectrum" />);
+    await enterNewMode();
     const chip = screen.getByText(/Top genes in T/);
     fireEvent.click(chip);
     const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
@@ -76,6 +98,7 @@ describe("ChatPanel", () => {
 
   it("submitting calls useChatTurn.start with the user message appended", async () => {
     render(<ChatPanel slug="spectrum" />);
+    await enterNewMode();
     const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "hello" } });
     fireEvent.keyDown(input, { key: "Enter" });
@@ -96,6 +119,7 @@ describe("ChatPanel", () => {
       dispatch = onEvent;
     });
     render(<ChatPanel slug="spectrum" />);
+    await enterNewMode();
     const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "color by gene" } });
     fireEvent.keyDown(input, { key: "Enter" });
@@ -116,6 +140,7 @@ describe("ChatPanel", () => {
       dispatch = onEvent;
     });
     render(<ChatPanel slug="spectrum" />);
+    await enterNewMode();
     const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "hi" } });
     fireEvent.keyDown(input, { key: "Enter" });
@@ -132,7 +157,7 @@ describe("ChatPanel", () => {
   });
 
   describe("ChatPanel permission-aware rendering", () => {
-    it("renders chat input when permission.can_chat is true", () => {
+    it("renders chat input when permission.can_chat is true", async () => {
       vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
         loading: false,
         error: undefined,
@@ -149,6 +174,7 @@ describe("ChatPanel", () => {
         },
       });
       render(<ChatPanel slug="demo" />);
+      await enterNewMode();
       expect(screen.getByPlaceholderText(/ask anything/i)).toBeDefined();
     });
 
@@ -193,5 +219,69 @@ describe("ChatPanel", () => {
       expect(screen.queryByPlaceholderText(/ask anything/i)).toBeNull();
       expect(screen.getByText(/sign in to use chat/i)).toBeDefined();
     });
+  });
+
+  it("starts in list mode and switches to new mode on + New chat", async () => {
+    vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+      loading: false, error: undefined,
+      data: {
+        slug: "demo", name: "Demo", description: "",
+        n_obs: 100, n_var: 50, obs_columns: [], embedding_keys: [], available_tools: [],
+        permission: { can_chat: true, reason: null },
+      },
+    });
+    (chat.listThreads as any).mockResolvedValue({ threads: [] });
+
+    render(<ChatPanel slug="demo" />);
+    await waitFor(() => screen.getByText(/no conversations yet/i));
+    fireEvent.click(screen.getByRole("button", { name: /\+ new chat/i }));
+    // ChatThreadHeader's back button is now visible (only renders in new/active mode)
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /back/i })).toBeDefined(),
+    );
+  });
+
+  it("switches to active mode after fetching thread detail when a row is clicked", async () => {
+    vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+      loading: false, error: undefined,
+      data: {
+        slug: "demo", name: "Demo", description: "",
+        n_obs: 100, n_var: 50, obs_columns: [], embedding_keys: [], available_tools: [],
+        permission: { can_chat: true, reason: null },
+      },
+    });
+    (chat.listThreads as any).mockResolvedValue({
+      threads: [{ id: "t1", title: "Existing", created_at: "2026-05-11T10:00:00Z",
+                   updated_at: "2026-05-11T10:00:00Z", message_count: 2 }],
+    });
+    (chat.getThread as any).mockResolvedValue({
+      id: "t1", title: "Existing",
+      messages: [
+        { role: "user", content: "Q", created_at: "..." },
+        { role: "assistant", content: "A", created_at: "..." },
+      ],
+    });
+    render(<ChatPanel slug="demo" />);
+    await waitFor(() => screen.getByText("Existing"));
+    fireEvent.click(screen.getByText("Existing"));
+    await waitFor(() => expect(chat.getThread).toHaveBeenCalledWith("demo", "t1"));
+  });
+
+  it("back arrow returns to list mode from active", async () => {
+    vi.spyOn(useChatContextModule, "useChatContext").mockReturnValue({
+      loading: false, error: undefined,
+      data: {
+        slug: "demo", name: "Demo", description: "",
+        n_obs: 100, n_var: 50, obs_columns: [], embedding_keys: [], available_tools: [],
+        permission: { can_chat: true, reason: null },
+      },
+    });
+    (chat.listThreads as any).mockResolvedValue({ threads: [] });
+    render(<ChatPanel slug="demo" />);
+    await waitFor(() => screen.getByText(/no conversations yet/i));
+    fireEvent.click(screen.getByRole("button", { name: /\+ new chat/i }));
+    await waitFor(() => screen.getByRole("button", { name: /back/i }));
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    await waitFor(() => expect(screen.getByText(/no conversations yet/i)).toBeDefined());
   });
 });

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -1,269 +1,45 @@
-import { Alert, Button, Input, Spin, Tag } from "antd";
-import { useCallback, useLayoutEffect, useReducer, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { applyConfig as applyConfigFn } from "../config/applyConfig";
-import { applyErrorMessage } from "../config/applyResult";
-import { initialState, reduce, type State } from "./eventReducer";
-import { deriveSuggestionChips } from "./suggestionChips";
-import type { ChatEvent, ChatMessage, MessagePart, WireMessage } from "./types";
+import { Alert, Spin } from "antd";
 import { ChatPermissionBanner } from "./ChatPermissionBanner";
+import { ConversationView } from "./ConversationView";
 import { useChatContext } from "./useChatContext";
-import { useChatTurn } from "./useChatTurn";
-
-type Action = { type: "AGENT_EVENT"; event: ChatEvent } | { type: "USER_SUBMIT"; content: string };
-
-function makeReducer(applyConfig: (cfg: Record<string, unknown>) => void) {
-  return (state: State, action: Action): State => {
-    if (action.type === "USER_SUBMIT") {
-      const userMsg: ChatMessage = {
-        role: "user",
-        parts: [{ kind: "text", text: action.content }],
-      };
-      return { ...state, history: [...state.history, userMsg] };
-    }
-    return reduce(state, action.event, applyConfig);
-  };
-}
-
-function toWireMessages(history: ChatMessage[]): WireMessage[] {
-  return history.map((m) => ({
-    role: m.role,
-    content: m.parts
-      .filter((p): p is { kind: "text"; text: string } => p.kind === "text")
-      .map((p) => p.text)
-      .join(""),
-  }));
-}
-
-// Components passed to ReactMarkdown — keep tables readable in a narrow sidebar
-// and tighten paragraph margins for chat-density layout.
-const markdownComponents = {
-  table: (props: React.HTMLAttributes<HTMLTableElement>) => (
-    <div style={{ overflowX: "auto", margin: "8px 0" }}>
-      <table {...props} style={{ borderCollapse: "collapse", fontSize: 12 }} />
-    </div>
-  ),
-  th: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
-    <th
-      {...props}
-      style={{ border: "1px solid #ddd", padding: "4px 8px", textAlign: "left", background: "#fafafa" }}
-    />
-  ),
-  td: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
-    <td {...props} style={{ border: "1px solid #ddd", padding: "4px 8px" }} />
-  ),
-  p: (props: React.HTMLAttributes<HTMLParagraphElement>) => (
-    <p {...props} style={{ margin: "4px 0" }} />
-  ),
-  code: (props: React.HTMLAttributes<HTMLElement>) => (
-    <code
-      {...props}
-      style={{ background: "#f6f8fa", padding: "1px 4px", borderRadius: 3, fontSize: "0.9em" }}
-    />
-  ),
-};
-
-function MessagePartView({ part }: { part: MessagePart }) {
-  if (part.kind === "text") {
-    return (
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-        {part.text}
-      </ReactMarkdown>
-    );
-  }
-  if (part.kind === "tool") {
-    const sym = part.status === "started" ? "▶" : part.status === "ok" ? "✓" : "✗";
-    const color = part.status === "error" ? "red" : part.status === "ok" ? "green" : "blue";
-    return (
-      <Tag color={color}>
-        {sym} {part.tool}
-        {part.summary ? ` — ${part.summary}` : part.status === "started" ? "…" : ""}
-      </Tag>
-    );
-  }
-  return <Alert type="error" message={part.message} showIcon style={{ marginTop: 8 }} />;
-}
 
 export function ChatPanel({ slug }: { slug: string }) {
-  // applyConfigCallbackRef is a stable ref so the frozen reducerFn (created once
-  // via useRef) can always reach the current callback — which itself captures
-  // the stable `dispatch` returned by useReducer.
-  const applyConfigCallbackRef = useRef<(cfg: Record<string, unknown>) => void>(() => {})
-  const reducerFn = useRef(
-    (state: State, action: Action) =>
-      makeReducer((cfg) => applyConfigCallbackRef.current(cfg))(state, action),
-  ).current;
-  const [state, dispatch] = useReducer(reducerFn, undefined, initialState);
-
-  // Wire the callback now that dispatch is available. dispatch is stable
-  // (guaranteed by React), so this assignment runs once and stays valid.
-  applyConfigCallbackRef.current = (cfg) => {
-    applyConfigFn(cfg as Parameters<typeof applyConfigFn>[0]).then((result) => {
-      if (!result.ok) {
-        dispatch({
-          type: "AGENT_EVENT",
-          event: { type: "error", message: applyErrorMessage(result.reason), retryable: false },
-        })
-      }
-    })
-  }
-  const [input, setInput] = useState("");
-  const [lastSubmittedMessages, setLastSubmittedMessages] = useState<WireMessage[] | null>(null);
-
   const ctxQuery = useChatContext(slug);
-  const { streaming, start, stop } = useChatTurn();
 
-  // Auto-scroll-to-bottom: stick to the bottom of the message list as content
-  // streams in, but preserve the user's scroll position if they've manually
-  // scrolled up to read earlier output.
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-  const stickToBottomRef = useRef(true);
-  const handleScroll = useCallback(() => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    stickToBottomRef.current = distanceFromBottom < 24;
-  }, []);
-  useLayoutEffect(() => {
-    if (!stickToBottomRef.current) return;
-    const el = scrollContainerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [state]);
+  if (ctxQuery.loading) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: 8 }}>
+        <Spin size="small" />
+        <span>Fetching metadata…</span>
+      </div>
+    );
+  }
+  if (ctxQuery.error) {
+    return (
+      <Alert
+        type="error"
+        message={`Couldn't load chat context: ${(ctxQuery.error as Error).message}`}
+        showIcon
+      />
+    );
+  }
+  const data = ctxQuery.data;
+  if (!data) return null;
 
-  const submit = useCallback(
-    async (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed || streaming) return;
-      dispatch({ type: "USER_SUBMIT", content: trimmed });
-      const wireMessages: WireMessage[] = [
-        ...toWireMessages(state.history),
-        { role: "user", content: trimmed },
-      ];
-      setLastSubmittedMessages(wireMessages);
-      setInput("");
-      try {
-        await start(slug, wireMessages, (e) => dispatch({ type: "AGENT_EVENT", event: e }));
-      } catch (e) {
-        const msg = (e as Error).message ?? "request failed";
-        dispatch({
-          type: "AGENT_EVENT",
-          event: { type: "error", message: msg, retryable: false },
-        });
-      }
-    },
-    [start, slug, state.history, streaming],
-  );
-
-  const retry = useCallback(async () => {
-    if (!lastSubmittedMessages) return;
-    try {
-      await start(slug, lastSubmittedMessages, (e) =>
-        dispatch({ type: "AGENT_EVENT", event: e }),
-      );
-    } catch (e) {
-      const msg = (e as Error).message ?? "request failed";
-      dispatch({
-        type: "AGENT_EVENT",
-        event: { type: "error", message: msg, retryable: false },
-      });
-    }
-  }, [start, slug, lastSubmittedMessages]);
-
-  const isEmpty = state.history.length === 0 && state.current === null && !streaming;
-  const hasError = state.status === "error";
-
-  // Permission gate — short-circuit before rendering input.
-  const permission = ctxQuery.data?.permission;
-  if (permission && !permission.can_chat) {
+  if (!data.permission.can_chat) {
     return (
       <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
-        <ChatPermissionBanner reason={permission.reason ?? "unknown"} />
+        <ChatPermissionBanner reason={data.permission.reason ?? "unknown"} />
       </div>
     );
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
-      {ctxQuery.loading && (
-        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: 8 }}>
-          <Spin size="small" />
-          <span>Fetching metadata…</span>
-        </div>
-      )}
-      {ctxQuery.error && (
-        <Alert
-          type="error"
-          message={`Couldn't load chat context: ${(ctxQuery.error as Error).message}`}
-          showIcon
-        />
-      )}
-      <div
-        ref={scrollContainerRef}
-        onScroll={handleScroll}
-        style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
-      >
-        {ctxQuery.data && isEmpty && (
-          <div>
-            <p>
-              Ask about {ctxQuery.data.name} — {ctxQuery.data.n_obs.toLocaleString()} cells ×{" "}
-              {ctxQuery.data.n_var.toLocaleString()} genes.
-            </p>
-            {deriveSuggestionChips(ctxQuery.data).map((chip) => (
-              <Button
-                key={chip.label}
-                size="small"
-                style={{ margin: "4px 4px 4px 0" }}
-                onClick={() => setInput(chip.prompt)}
-              >
-                {chip.label}
-              </Button>
-            ))}
-          </div>
-        )}
-        {!isEmpty && (
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            {state.history.map((m, i) => (
-              <div key={i}>
-                <strong>{m.role === "user" ? "You: " : "Assistant: "}</strong>
-                {m.parts.map((p, j) => (
-                  <MessagePartView key={j} part={p} />
-                ))}
-              </div>
-            ))}
-            {state.current && (
-              <div>
-                <strong>Assistant: </strong>
-                {state.current.parts.map((p, j) => (
-                  <MessagePartView key={j} part={p} />
-                ))}
-              </div>
-            )}
-            {hasError && (
-              <Button onClick={retry} type="primary" size="small">
-                Retry
-              </Button>
-            )}
-          </div>
-        )}
-      </div>
-      <div style={{ marginTop: 12, display: "flex", gap: 8, flexShrink: 0 }}>
-        <Input
-          placeholder="Ask anything…"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !streaming) submit(input);
-          }}
-        />
-        {streaming ? (
-          <Button onClick={stop}>Stop</Button>
-        ) : (
-          <Button type="primary" onClick={() => submit(input)}>
-            Send
-          </Button>
-        )}
-      </div>
-    </div>
+    <ConversationView
+      slug={slug}
+      ctxData={data}
+      threadId={null}           // Task B7 wires this from mode state
+      onThreadOpen={() => {}}   // Task B7 wires this
+    />
   );
 }

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -41,6 +41,30 @@ export function ChatPanel({ slug }: { slug: string }) {
     setMode({ kind: "active", threadId, title, initialHistory: [] });
   }, []);
 
+  const data = ctxQuery.data;
+
+  // Hard permission gate: when /context has actually returned with
+  // can_chat=false, show the banner regardless of mode. Anonymous users
+  // would 401 on /threads anyway; users with missing_role should see why
+  // before clicking into a useless input.
+  if (data && !data.permission.can_chat) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
+        <ChatPermissionBanner reason={data.permission.reason ?? "unknown"} />
+      </div>
+    );
+  }
+
+  // List mode: render immediately even while /context is still loading. The
+  // list is a server-filtered view of the user's own threads; it does not
+  // need dataset_ctx. New/active modes still wait for /context below.
+  if (mode.kind === "list") {
+    return (
+      <ChatThreadList slug={slug} onSelect={enterActive} onNew={enterNew} />
+    );
+  }
+
+  // new/active mode needs /context for the welcome chips.
   if (ctxQuery.loading) {
     return (
       <div style={{ display: "flex", alignItems: "center", gap: 8, padding: 8 }}>
@@ -58,22 +82,7 @@ export function ChatPanel({ slug }: { slug: string }) {
       />
     );
   }
-  const data = ctxQuery.data;
   if (!data) return null;
-
-  if (!data.permission.can_chat) {
-    return (
-      <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
-        <ChatPermissionBanner reason={data.permission.reason ?? "unknown"} />
-      </div>
-    );
-  }
-
-  if (mode.kind === "list") {
-    return (
-      <ChatThreadList slug={slug} onSelect={enterActive} onNew={enterNew} />
-    );
-  }
 
   const headerTitle = mode.kind === "active" ? mode.title : null;
   const threadId = mode.kind === "active" ? mode.threadId : null;

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -1,10 +1,45 @@
 import { Alert, Spin } from "antd";
+import { useState, useCallback } from "react";
+import { chat } from "../api";
 import { ChatPermissionBanner } from "./ChatPermissionBanner";
+import { ChatThreadList } from "./ChatThreadList";
+import { ChatThreadHeader } from "./ChatThreadHeader";
 import { ConversationView } from "./ConversationView";
+import type { ChatMessage } from "./types";
 import { useChatContext } from "./useChatContext";
+
+type PanelMode =
+  | { kind: "list" }
+  | { kind: "new" }
+  | { kind: "active"; threadId: string; title: string; initialHistory: ChatMessage[] };
 
 export function ChatPanel({ slug }: { slug: string }) {
   const ctxQuery = useChatContext(slug);
+  const [mode, setMode] = useState<PanelMode>({ kind: "list" });
+
+  const enterNew = useCallback(() => setMode({ kind: "new" }), []);
+  const enterList = useCallback(() => setMode({ kind: "list" }), []);
+
+  const enterActive = useCallback(async (threadId: string) => {
+    const detail = await chat.getThread(slug, threadId);
+    const initialHistory: ChatMessage[] = detail.messages.map((m) => ({
+      role: m.role,
+      parts: [{ kind: "text", text: m.content }],
+    }));
+    setMode({
+      kind: "active",
+      threadId,
+      title: detail.title,
+      initialHistory,
+    });
+  }, [slug]);
+
+  // Called by ConversationView when the stream's thread_open event arrives.
+  // After the first turn of a new thread, transition into 'active' so back
+  // navigation lands in the right place and the list refresh picks it up.
+  const onThreadOpen = useCallback((threadId: string, title: string) => {
+    setMode({ kind: "active", threadId, title, initialHistory: [] });
+  }, []);
 
   if (ctxQuery.loading) {
     return (
@@ -34,12 +69,26 @@ export function ChatPanel({ slug }: { slug: string }) {
     );
   }
 
+  if (mode.kind === "list") {
+    return (
+      <ChatThreadList slug={slug} onSelect={enterActive} onNew={enterNew} />
+    );
+  }
+
+  const headerTitle = mode.kind === "active" ? mode.title : null;
+  const threadId = mode.kind === "active" ? mode.threadId : null;
+  const initialHistory = mode.kind === "active" ? mode.initialHistory : undefined;
+
   return (
-    <ConversationView
-      slug={slug}
-      ctxData={data}
-      threadId={null}           // Task B7 wires this from mode state
-      onThreadOpen={() => {}}   // Task B7 wires this
-    />
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <ChatThreadHeader title={headerTitle} onBack={enterList} />
+      <ConversationView
+        slug={slug}
+        ctxData={data}
+        threadId={threadId}
+        initialHistory={initialHistory}
+        onThreadOpen={onThreadOpen}
+      />
+    </div>
   );
 }

--- a/packages/highperformer/src/chat/ChatThreadHeader.test.tsx
+++ b/packages/highperformer/src/chat/ChatThreadHeader.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ChatThreadHeader } from "./ChatThreadHeader";
+
+describe("ChatThreadHeader", () => {
+  afterEach(() => cleanup());
+
+  it("renders the title when one is provided", () => {
+    render(<ChatThreadHeader title="My thread" onBack={() => {}} />);
+    expect(screen.getByText("My thread")).toBeDefined();
+  });
+
+  it("renders 'New chat' when title is null (new mode)", () => {
+    render(<ChatThreadHeader title={null} onBack={() => {}} />);
+    expect(screen.getByText(/new chat/i)).toBeDefined();
+  });
+
+  it("calls onBack when the back button is clicked", () => {
+    const onBack = vi.fn();
+    render(<ChatThreadHeader title="Some thread" onBack={onBack} />);
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/packages/highperformer/src/chat/ChatThreadHeader.tsx
+++ b/packages/highperformer/src/chat/ChatThreadHeader.tsx
@@ -1,0 +1,41 @@
+import { Button } from "antd";
+
+export type ChatThreadHeaderProps = {
+  title: string | null;     // null = new mode
+  onBack: () => void;
+};
+
+export function ChatThreadHeader({ title, onBack }: ChatThreadHeaderProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "6px 8px",
+        borderBottom: "1px solid #f0f0f0",
+      }}
+    >
+      <Button
+        type="text"
+        size="small"
+        onClick={onBack}
+        aria-label="back to conversations"
+      >
+        ←
+      </Button>
+      <span
+        style={{
+          fontWeight: 500,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          flex: 1,
+          color: title ? "#333" : "#999",
+        }}
+      >
+        {title ?? "New chat"}
+      </span>
+    </div>
+  );
+}

--- a/packages/highperformer/src/chat/ChatThreadList.test.tsx
+++ b/packages/highperformer/src/chat/ChatThreadList.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChatThreadList } from "./ChatThreadList";
+import { chat } from "../api";
+
+vi.mock("../api", () => ({
+  chat: {
+    listThreads: vi.fn(),
+    deleteThread: vi.fn(),
+  },
+}));
+
+describe("ChatThreadList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    (chat.listThreads as any).mockReset();
+    (chat.deleteThread as any).mockReset();
+  });
+
+  it("renders rows from listThreads", async () => {
+    (chat.listThreads as any).mockResolvedValue({
+      threads: [
+        { id: "t1", title: "Show CD8A", created_at: "2026-05-11T10:00:00Z",
+          updated_at: "2026-05-11T10:05:00Z", message_count: 4 },
+        { id: "t2", title: "What are clusters", created_at: "2026-05-10T09:00:00Z",
+          updated_at: "2026-05-10T09:00:00Z", message_count: 2 },
+      ],
+    });
+    render(<ChatThreadList slug="demo" onSelect={() => {}} onNew={() => {}} />);
+    await waitFor(() => expect(screen.getByText("Show CD8A")).toBeDefined());
+    expect(screen.getByText("What are clusters")).toBeDefined();
+  });
+
+  it("renders empty state when zero threads", async () => {
+    (chat.listThreads as any).mockResolvedValue({ threads: [] });
+    render(<ChatThreadList slug="demo" onSelect={() => {}} onNew={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByText(/no conversations yet/i)).toBeDefined()
+    );
+  });
+
+  it("calls onSelect when a row is clicked", async () => {
+    (chat.listThreads as any).mockResolvedValue({
+      threads: [
+        { id: "t1", title: "Hello", created_at: "2026-05-11T10:00:00Z",
+          updated_at: "2026-05-11T10:00:00Z", message_count: 1 },
+      ],
+    });
+    const onSelect = vi.fn();
+    render(<ChatThreadList slug="demo" onSelect={onSelect} onNew={() => {}} />);
+    await waitFor(() => screen.getByText("Hello"));
+    fireEvent.click(screen.getByText("Hello"));
+    expect(onSelect).toHaveBeenCalledWith("t1");
+  });
+
+  it("calls onNew when + New chat is clicked", async () => {
+    (chat.listThreads as any).mockResolvedValue({ threads: [] });
+    const onNew = vi.fn();
+    render(<ChatThreadList slug="demo" onSelect={() => {}} onNew={onNew} />);
+    await waitFor(() => screen.getByText(/no conversations/i));
+    const buttons = screen.getAllByRole("button", { name: /new chat/i });
+    fireEvent.click(buttons[0]);
+    expect(onNew).toHaveBeenCalled();
+  });
+
+  it("deletes a thread after confirm and refetches", async () => {
+    (chat.listThreads as any)
+      .mockResolvedValueOnce({
+        threads: [
+          { id: "t1", title: "Doomed", created_at: "2026-05-11T10:00:00Z",
+            updated_at: "2026-05-11T10:00:00Z", message_count: 1 },
+        ],
+      })
+      .mockResolvedValueOnce({ threads: [] });
+    (chat.deleteThread as any).mockResolvedValue(undefined);
+    render(<ChatThreadList slug="demo" onSelect={() => {}} onNew={() => {}} />);
+    await waitFor(() => screen.getByText("Doomed"));
+
+    const deleteBtns = screen.getAllByRole("button", { name: /delete thread/i });
+    fireEvent.click(deleteBtns[0]);
+
+    // antd Modal.confirm renders in a portal; click the OK button to confirm.
+    await waitFor(() => screen.getByText(/^delete$/i));
+    fireEvent.click(screen.getByText(/^delete$/i));
+
+    await waitFor(() => expect(chat.deleteThread).toHaveBeenCalledWith("demo", "t1"));
+    await waitFor(() => expect(screen.queryByText("Doomed")).toBeNull());
+  });
+});

--- a/packages/highperformer/src/chat/ChatThreadList.tsx
+++ b/packages/highperformer/src/chat/ChatThreadList.tsx
@@ -1,0 +1,140 @@
+import { Button, Modal, Spin } from "antd";
+import { useCallback, useEffect, useState } from "react";
+import { chat } from "../api";
+import type { ThreadSummary } from "./types";
+
+export type ChatThreadListProps = {
+  slug: string;
+  onSelect: (threadId: string) => void;
+  onNew: () => void;
+};
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - Date.parse(iso);
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function ChatThreadList({ slug, onSelect, onNew }: ChatThreadListProps) {
+  const [threads, setThreads] = useState<ThreadSummary[] | undefined>(undefined);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  const refresh = useCallback(async () => {
+    setError(undefined);
+    try {
+      const data = await chat.listThreads(slug);
+      setThreads(data.threads);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    }
+  }, [slug]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleDelete = useCallback(
+    (thread: ThreadSummary) => {
+      Modal.confirm({
+        title: "Delete this thread?",
+        content: thread.title,
+        okText: "Delete",
+        okType: "danger",
+        async onOk() {
+          await chat.deleteThread(slug, thread.id);
+          await refresh();
+        },
+      });
+    },
+    [slug, refresh],
+  );
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "8px 12px",
+          borderBottom: "1px solid #f0f0f0",
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>Conversations</span>
+        <Button type="link" size="small" onClick={onNew}>
+          + New chat
+        </Button>
+      </div>
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        {threads === undefined && !error && (
+          <div style={{ padding: 16, textAlign: "center" }}>
+            <Spin size="small" />
+          </div>
+        )}
+        {error && (
+          <div style={{ padding: 16, color: "#cf1322" }}>
+            Couldn't load threads: {error.message}
+          </div>
+        )}
+        {threads !== undefined && threads.length === 0 && (
+          <div style={{ padding: 16, color: "#999", textAlign: "center" }}>
+            No conversations yet — start one with + New chat.
+          </div>
+        )}
+        {threads !== undefined && threads.length > 0 && (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {threads.map((t) => (
+              <li
+                key={t.id}
+                style={{
+                  padding: "8px 12px",
+                  borderBottom: "1px solid #fafafa",
+                  cursor: "pointer",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 8,
+                }}
+                onClick={() => onSelect(t.id)}
+              >
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div
+                    style={{
+                      fontWeight: 500,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {t.title}
+                  </div>
+                  <div style={{ fontSize: 11, color: "#999" }}>
+                    {formatRelative(t.updated_at)} · {t.message_count} msg
+                  </div>
+                </div>
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  aria-label="delete thread"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(t);
+                  }}
+                >
+                  ✕
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Input, Tag } from "antd";
-import { useCallback, useLayoutEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { applyConfig as applyConfigFn } from "../config/applyConfig";
@@ -11,7 +11,8 @@ import { useChatTurn } from "./useChatTurn";
 
 type Action =
   | { type: "AGENT_EVENT"; event: ChatEvent }
-  | { type: "USER_SUBMIT"; content: string };
+  | { type: "USER_SUBMIT"; content: string }
+  | { type: "HYDRATE"; history: ChatMessage[] };
 
 function makeReducer(applyConfig: (cfg: Record<string, unknown>) => void) {
   return (state: State, action: Action): State => {
@@ -21,6 +22,9 @@ function makeReducer(applyConfig: (cfg: Record<string, unknown>) => void) {
         parts: [{ kind: "text", text: action.content }],
       };
       return { ...state, history: [...state.history, userMsg] };
+    }
+    if (action.type === "HYDRATE") {
+      return { history: action.history, current: null, status: "idle" };
     }
     return reduce(state, action.event, applyConfig);
   };
@@ -89,10 +93,11 @@ export type ConversationViewProps = {
   slug: string;
   ctxData: ContextResponse;
   threadId: string | null;
+  initialHistory?: ChatMessage[];
   onThreadOpen: (threadId: string, title: string) => void;
 };
 
-export function ConversationView({ slug, ctxData, threadId, onThreadOpen }: ConversationViewProps) {
+export function ConversationView({ slug, ctxData, threadId, initialHistory, onThreadOpen }: ConversationViewProps) {
   // applyConfigCallbackRef is a stable ref so the frozen reducerFn (created once
   // via useRef) can always reach the current callback — which itself captures
   // the stable `dispatch` returned by useReducer.
@@ -115,6 +120,12 @@ export function ConversationView({ slug, ctxData, threadId, onThreadOpen }: Conv
       }
     });
   };
+
+  useEffect(() => {
+    if (initialHistory) {
+      dispatch({ type: "HYDRATE", history: initialHistory });
+    }
+  }, [initialHistory]);
 
   const [input, setInput] = useState("");
   const [lastSubmittedMessages, setLastSubmittedMessages] = useState<WireMessage[] | null>(null);

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -122,7 +122,11 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
   };
 
   useEffect(() => {
-    if (initialHistory) {
+    // Guard on length: every /turns stream re-emits thread_open, and ChatPanel
+    // responds by setMode-ing with a fresh `initialHistory: []`. Without this
+    // guard, the empty array would HYDRATE and wipe the in-memory history
+    // every time the user sends a follow-up.
+    if (initialHistory && initialHistory.length > 0) {
       dispatch({ type: "HYDRATE", history: initialHistory });
     }
   }, [initialHistory]);

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -1,0 +1,262 @@
+import { Alert, Button, Input, Tag } from "antd";
+import { useCallback, useLayoutEffect, useReducer, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { applyConfig as applyConfigFn } from "../config/applyConfig";
+import { applyErrorMessage } from "../config/applyResult";
+import { initialState, reduce, type State } from "./eventReducer";
+import { deriveSuggestionChips } from "./suggestionChips";
+import type { ChatEvent, ChatMessage, ContextResponse, MessagePart, WireMessage } from "./types";
+import { useChatTurn } from "./useChatTurn";
+
+type Action =
+  | { type: "AGENT_EVENT"; event: ChatEvent }
+  | { type: "USER_SUBMIT"; content: string };
+
+function makeReducer(applyConfig: (cfg: Record<string, unknown>) => void) {
+  return (state: State, action: Action): State => {
+    if (action.type === "USER_SUBMIT") {
+      const userMsg: ChatMessage = {
+        role: "user",
+        parts: [{ kind: "text", text: action.content }],
+      };
+      return { ...state, history: [...state.history, userMsg] };
+    }
+    return reduce(state, action.event, applyConfig);
+  };
+}
+
+function toWireMessages(history: ChatMessage[]): WireMessage[] {
+  return history.map((m) => ({
+    role: m.role,
+    content: m.parts
+      .filter((p): p is { kind: "text"; text: string } => p.kind === "text")
+      .map((p) => p.text)
+      .join(""),
+  }));
+}
+
+// Components passed to ReactMarkdown — keep tables readable in a narrow sidebar
+// and tighten paragraph margins for chat-density layout.
+const markdownComponents = {
+  table: (props: React.HTMLAttributes<HTMLTableElement>) => (
+    <div style={{ overflowX: "auto", margin: "8px 0" }}>
+      <table {...props} style={{ borderCollapse: "collapse", fontSize: 12 }} />
+    </div>
+  ),
+  th: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
+    <th
+      {...props}
+      style={{ border: "1px solid #ddd", padding: "4px 8px", textAlign: "left", background: "#fafafa" }}
+    />
+  ),
+  td: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
+    <td {...props} style={{ border: "1px solid #ddd", padding: "4px 8px" }} />
+  ),
+  p: (props: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props} style={{ margin: "4px 0" }} />
+  ),
+  code: (props: React.HTMLAttributes<HTMLElement>) => (
+    <code
+      {...props}
+      style={{ background: "#f6f8fa", padding: "1px 4px", borderRadius: 3, fontSize: "0.9em" }}
+    />
+  ),
+};
+
+function MessagePartView({ part }: { part: MessagePart }) {
+  if (part.kind === "text") {
+    return (
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {part.text}
+      </ReactMarkdown>
+    );
+  }
+  if (part.kind === "tool") {
+    const sym = part.status === "started" ? "▶" : part.status === "ok" ? "✓" : "✗";
+    const color = part.status === "error" ? "red" : part.status === "ok" ? "green" : "blue";
+    return (
+      <Tag color={color}>
+        {sym} {part.tool}
+        {part.summary ? ` — ${part.summary}` : part.status === "started" ? "…" : ""}
+      </Tag>
+    );
+  }
+  return <Alert type="error" message={part.message} showIcon style={{ marginTop: 8 }} />;
+}
+
+export type ConversationViewProps = {
+  slug: string;
+  ctxData: ContextResponse;
+  threadId: string | null;
+  onThreadOpen: (threadId: string, title: string) => void;
+};
+
+export function ConversationView({ slug, ctxData, threadId, onThreadOpen }: ConversationViewProps) {
+  // applyConfigCallbackRef is a stable ref so the frozen reducerFn (created once
+  // via useRef) can always reach the current callback — which itself captures
+  // the stable `dispatch` returned by useReducer.
+  const applyConfigCallbackRef = useRef<(cfg: Record<string, unknown>) => void>(() => {});
+  const reducerFn = useRef(
+    (state: State, action: Action) =>
+      makeReducer((cfg) => applyConfigCallbackRef.current(cfg))(state, action),
+  ).current;
+  const [state, dispatch] = useReducer(reducerFn, undefined, initialState);
+
+  // Wire the callback now that dispatch is available. dispatch is stable
+  // (guaranteed by React), so this assignment runs once and stays valid.
+  applyConfigCallbackRef.current = (cfg) => {
+    applyConfigFn(cfg as Parameters<typeof applyConfigFn>[0]).then((result) => {
+      if (!result.ok) {
+        dispatch({
+          type: "AGENT_EVENT",
+          event: { type: "error", message: applyErrorMessage(result.reason), retryable: false },
+        });
+      }
+    });
+  };
+
+  const [input, setInput] = useState("");
+  const [lastSubmittedMessages, setLastSubmittedMessages] = useState<WireMessage[] | null>(null);
+  const { streaming, start, stop } = useChatTurn();
+
+  // Auto-scroll-to-bottom: stick to the bottom of the message list as content
+  // streams in, but preserve the user's scroll position if they've manually
+  // scrolled up to read earlier output.
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+  const handleScroll = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 24;
+  }, []);
+  useLayoutEffect(() => {
+    if (!stickToBottomRef.current) return;
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [state]);
+
+  const submit = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || streaming) return;
+      dispatch({ type: "USER_SUBMIT", content: trimmed });
+      const wireMessages: WireMessage[] = [
+        ...toWireMessages(state.history),
+        { role: "user", content: trimmed },
+      ];
+      setLastSubmittedMessages(wireMessages);
+      setInput("");
+      try {
+        await start(slug, wireMessages, threadId, (e) => {
+          if (e.type === "thread_open") {
+            onThreadOpen(e.thread_id, e.title);
+            return;
+          }
+          dispatch({ type: "AGENT_EVENT", event: e });
+        });
+      } catch (e) {
+        const msg = (e as Error).message ?? "request failed";
+        dispatch({
+          type: "AGENT_EVENT",
+          event: { type: "error", message: msg, retryable: false },
+        });
+      }
+    },
+    [start, slug, state.history, streaming, threadId, onThreadOpen],
+  );
+
+  const retry = useCallback(async () => {
+    if (!lastSubmittedMessages) return;
+    try {
+      await start(slug, lastSubmittedMessages, threadId, (e) => {
+        if (e.type === "thread_open") {
+          onThreadOpen(e.thread_id, e.title);
+          return;
+        }
+        dispatch({ type: "AGENT_EVENT", event: e });
+      });
+    } catch (e) {
+      const msg = (e as Error).message ?? "request failed";
+      dispatch({
+        type: "AGENT_EVENT",
+        event: { type: "error", message: msg, retryable: false },
+      });
+    }
+  }, [start, slug, lastSubmittedMessages, threadId, onThreadOpen]);
+
+  const isEmpty = state.history.length === 0 && state.current === null && !streaming;
+  const hasError = state.status === "error";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+      >
+        {isEmpty && (
+          <div>
+            <p>
+              Ask about {ctxData.name} — {ctxData.n_obs.toLocaleString()} cells ×{" "}
+              {ctxData.n_var.toLocaleString()} genes.
+            </p>
+            {deriveSuggestionChips(ctxData).map((chip) => (
+              <Button
+                key={chip.label}
+                size="small"
+                style={{ margin: "4px 4px 4px 0" }}
+                onClick={() => setInput(chip.prompt)}
+              >
+                {chip.label}
+              </Button>
+            ))}
+          </div>
+        )}
+        {!isEmpty && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {state.history.map((m, i) => (
+              <div key={i}>
+                <strong>{m.role === "user" ? "You: " : "Assistant: "}</strong>
+                {m.parts.map((p, j) => (
+                  <MessagePartView key={j} part={p} />
+                ))}
+              </div>
+            ))}
+            {state.current && (
+              <div>
+                <strong>Assistant: </strong>
+                {state.current.parts.map((p, j) => (
+                  <MessagePartView key={j} part={p} />
+                ))}
+              </div>
+            )}
+            {hasError && (
+              <Button onClick={retry} type="primary" size="small">
+                Retry
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+      <div style={{ marginTop: 12, display: "flex", gap: 8, flexShrink: 0 }}>
+        <Input
+          placeholder="Ask anything…"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !streaming) submit(input);
+          }}
+        />
+        {streaming ? (
+          <Button onClick={stop}>Stop</Button>
+        ) : (
+          <Button type="primary" onClick={() => submit(input)}>
+            Send
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -33,6 +33,28 @@ export type ContextResponse = {
   permission: ChatPermission;
 };
 
+// ---------- /threads wire responses ----------
+
+export type ThreadSummary = {
+  id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  message_count: number;
+};
+
+export type ThreadListResponse = { threads: ThreadSummary[] };
+
+export type ThreadDetailResponse = {
+  id: string;
+  title: string;
+  messages: {
+    role: "user" | "assistant";
+    content: string;
+    created_at: string;
+  }[];
+};
+
 // ---------- /turns wire request ----------
 
 export type WireMessage = {
@@ -60,13 +82,19 @@ export type DoneEvent    = {
   type: "done";
   usage: { input_tokens: number; output_tokens: number };
 };
+export type ThreadOpenEvent = {
+  type: "thread_open";
+  thread_id: string;
+  title: string;
+};
 
 export type ChatEvent =
   | TextDelta
   | ToolProgress
   | UIAction
   | ErrorEvent
-  | DoneEvent;
+  | DoneEvent
+  | ThreadOpenEvent;
 
 // ---------- in-memory chat state (component-local) ----------
 

--- a/packages/highperformer/src/chat/useChatTurn.test.ts
+++ b/packages/highperformer/src/chat/useChatTurn.test.ts
@@ -41,7 +41,7 @@ describe("useChatTurn", () => {
 
     const events: ChatEvent[] = [];
     await act(async () => {
-      await result.current.start("spectrum", [{ role: "user", content: "hi" }], (e) =>
+      await result.current.start("spectrum", [{ role: "user", content: "hi" }], null, (e) =>
         events.push(e),
       );
     });
@@ -59,7 +59,7 @@ describe("useChatTurn", () => {
     let caught: unknown;
     await act(async () => {
       try {
-        await result.current.start("nope", [{ role: "user", content: "hi" }], () => {});
+        await result.current.start("nope", [{ role: "user", content: "hi" }], null, () => {});
       } catch (e) {
         caught = e;
       }
@@ -84,7 +84,7 @@ describe("useChatTurn", () => {
     let caught: unknown;
     const startPromise = act(async () => {
       try {
-        await result.current.start("s", [{ role: "user", content: "hi" }], () => {});
+        await result.current.start("s", [{ role: "user", content: "hi" }], null, () => {});
       } catch (e) {
         caught = e;
       }
@@ -102,7 +102,7 @@ describe("useChatTurn", () => {
     let caught: unknown;
     await act(async () => {
       try {
-        await result.current.start("s", [{ role: "user", content: "hi" }], () => {});
+        await result.current.start("s", [{ role: "user", content: "hi" }], null, () => {});
       } catch (e) {
         caught = e;
       }

--- a/packages/highperformer/src/chat/useChatTurn.ts
+++ b/packages/highperformer/src/chat/useChatTurn.ts
@@ -11,6 +11,7 @@ export function useChatTurn() {
     async (
       slug: string,
       messages: WireMessage[],
+      threadId: string | null,
       onEvent: (e: ChatEvent) => void,
     ): Promise<void> => {
       abortRef.current?.abort();
@@ -22,7 +23,7 @@ export function useChatTurn() {
         // included; agent uses this to answer relative queries ("zoom in
         // more", "change to a different gene") without a tool round-trip.
         const viewState = buildViewStateSnapshot();
-        for await (const ev of chat.streamTurn(slug, messages, viewState, controller.signal)) {
+        for await (const ev of chat.streamTurn(slug, messages, viewState, threadId, controller.signal)) {
           onEvent(ev);
         }
       } finally {


### PR DESCRIPTION
## Summary

Consumes the new thread endpoints from cell-explorer-py and rewires \`ChatPanel\` into a mode-based router. Users can now see past conversations, switch between them, and delete them.

- **New components:** \`ChatThreadList\`, \`ChatThreadHeader\`, \`ConversationView\` (extracted from ChatPanel).
- **Modified:** \`ChatPanel\` is now a thin router; \`useChatTurn\` takes a \`threadId\`; \`streamTurn\` includes \`thread_id\` in the body.
- **Reducer:** added \`HYDRATE\` action so historical messages load into the conversation state when switching into an existing thread.

## UX

- Chat tab opens to the list (or "No conversations yet" with \`+ New chat\`).
- "+ New chat" → empty conversation. On first send, the thread is created server-side and the header updates with the auto-derived title.
- Click a row → conversation hydrates with the thread's history; continue chatting.
- ✕ on hover → \`Modal.confirm\` → DELETE → list refreshes.
- Back arrow → return to list.

## Test plan

- [x] api-client regenerated; wire types added
- [x] \`ChatThreadList\` — rows, empty state, select, new, delete (5 tests)
- [x] \`ChatThreadHeader\` — title vs null, back button (3 tests)
- [x] \`ChatPanel\` — list → new, list → active, back → list, plus 8 pre-existing tests adapted (11 total)
- [x] 361 highperformer tests pass