### PR TITLE
feat(profiler): add close (X) button to hide the bar for the session

### DIFF
--- a/.changeset/profiler-close-button.md
+++ b/.changeset/profiler-close-button.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/profiler": minor
+---
+
+Add a close (X) button to the `ProfileBar` action group. Clicking it hides
+the bar for the current session — state is local to the component and
+resets on page reload, so the bar reappears automatically next time
+without a separate "show profiler" affordance. Helpful during dev when
+the bar overlaps UI controls.

--- a/packages/profiler/src/components/ProfileBar.tsx
+++ b/packages/profiler/src/components/ProfileBar.tsx
@@ -1,6 +1,6 @@
 import { useSyncExternalStore, useCallback, useRef, useEffect, useState, useMemo } from "react";
 import { Table, Tag, Space, Button, Typography, message, Collapse, Input } from "antd";
-import { DeleteOutlined, SaveOutlined, UpOutlined, DownOutlined, SearchOutlined, HistoryOutlined } from "@ant-design/icons";
+import { CloseOutlined, DeleteOutlined, SaveOutlined, UpOutlined, DownOutlined, SearchOutlined, HistoryOutlined } from "@ant-design/icons";
 import { Group } from "@visx/group";
 import { scaleLinear } from "@visx/scale";
 import { AxisBottom } from "@visx/axis";
@@ -327,6 +327,9 @@ const pulseStyle = `
 
 export default function ProfileBar({ profiler, onSave, renderLink }: ProfileBarProps) {
   const [expanded, setExpanded] = useState(false);
+  // Hide the bar during this session. Resets on page reload — intentional, so
+  // the bar reappears next time without a separate "show profiler" affordance.
+  const [hidden, setHidden] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const [barWidth, setBarWidth] = useState(0);
 
@@ -384,6 +387,8 @@ export default function ProfileBar({ profiler, onSave, renderLink }: ProfileBarP
 
   const currentHeight = expanded ? EXPANDED_HEIGHT : COLLAPSED_HEIGHT;
   const waterfallWidth = Math.max(barWidth - 48, 200);
+
+  if (hidden) return null;
 
   return (
     <div
@@ -472,6 +477,14 @@ export default function ProfileBar({ profiler, onSave, renderLink }: ProfileBarP
             Clear
           </Button>
           {expanded ? <DownOutlined /> : <UpOutlined />}
+          <Button
+            icon={<CloseOutlined />}
+            size="small"
+            type="text"
+            aria-label="Hide profiler"
+            title="Hide until next reload"
+            onClick={(e) => { e.stopPropagation(); setHidden(true); }}
+          />
         </Space>
       </div>
 


### PR DESCRIPTION
The profiler bar covers screen real estate near the bottom and sometimes overlaps UI controls during dev. Add a small \`X\` icon button in the action group that hides the bar for the current session — state is local and resets on page reload, so the bar comes back automatically next time without needing a separate show-profiler affordance.

## Test plan
- [x] All 39 profiler tests pass
- [x] Manual: click X, bar disappears; reload, bar back