### PR TITLE
fix(profiler): close button reflows layout

### DIFF
--- a/.changeset/profiler-close-reflow.md
+++ b/.changeset/profiler-close-reflow.md
@@ -1,0 +1,10 @@
+---
+"@cbioportal-cell-explorer/profiler": minor
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Profile bar close button now fully removes the bar from the layout
+instead of just hiding it. ProfileBar gained an `onHide` callback prop;
+when invoked, the parent unmounts ProfileBar AND drops the reserved
+bottom padding, so page content reflows into the freed area.
+Behaviour is still session-only — refresh brings the bar back.

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -810,7 +810,7 @@ function EdgeTab({ onClick, onMouseDown, side, icon, cursor }: {
   )
 }
 
-function ProfileBarWrapper() {
+function ProfileBarWrapper({ onHide }: { onHide: () => void }) {
   const adata = useAppStore((s) => s.adata)
   const datasetUrl = useAppStore((s) => s.datasetUrl)
 
@@ -821,6 +821,7 @@ function ProfileBarWrapper() {
         if (adata) saveProfileSession(datasetUrl, adata.nObs, adata.nVar, entries)
       }}
       renderLink={(children) => <Link to="/profile">{children}</Link>}
+      onHide={onHide}
     />
   )
 }
@@ -830,6 +831,11 @@ function View() {
   const configParam = searchParams.get('config')
   const urlParam = searchParams.get('url')
   const datasetParam = searchParams.get('dataset')
+  // Profile bar visibility — session-only, resets on reload. The bar reserves
+  // bottom padding for content; when hidden we remove that padding so layout
+  // reflows into the freed area.
+  const [profilerHidden, setProfilerHidden] = useState(false)
+  const profilerVisible = ENABLE_PROFILER && !profilerHidden
   const openDataset = useAppStore((s) => s.openDataset)
   const openCatalogDataset = useAppStore((s) => s.openCatalogDataset)
   const loadingError = useAppStore((s) => s.loadingError)
@@ -898,7 +904,7 @@ function View() {
 
   return (
     <Layout style={{ height: '100vh', background: '#fff' }}>
-      <Layout style={{ flex: 1, overflow: 'hidden', paddingBottom: ENABLE_PROFILER ? PROFILE_BAR_HEIGHT : 0 }}>
+      <Layout style={{ flex: 1, overflow: 'hidden', paddingBottom: profilerVisible ? PROFILE_BAR_HEIGHT : 0 }}>
         <Sider
           width={LEFT_SIDEBAR_WIDTH}
           collapsible
@@ -973,7 +979,7 @@ function View() {
           )}
         </Sider>
       </Layout>
-      {ENABLE_PROFILER && <ProfileBarWrapper />}
+      {profilerVisible && <ProfileBarWrapper onHide={() => setProfilerHidden(true)} />}
     </Layout>
   )
 }

--- a/packages/profiler/src/components/ProfileBar.tsx
+++ b/packages/profiler/src/components/ProfileBar.tsx
@@ -36,6 +36,10 @@ interface ProfileBarProps {
   profiler?: ProfileCollector;
   onSave?: (entries: ProfileEntry[]) => void;
   renderLink?: RenderLink;
+  /** Called when the user clicks the close (X) button. The parent should
+   *  unmount ProfileBar and remove any reserved layout space so content
+   *  reflows into the freed area. */
+  onHide?: () => void;
 }
 
 function WaterfallTimeline({ entries, width }: { entries: ProfileEntry[]; width: number }) {
@@ -325,11 +329,8 @@ const pulseStyle = `
 }
 `;
 
-export default function ProfileBar({ profiler, onSave, renderLink }: ProfileBarProps) {
+export default function ProfileBar({ profiler, onSave, renderLink, onHide }: ProfileBarProps) {
   const [expanded, setExpanded] = useState(false);
-  // Hide the bar during this session. Resets on page reload — intentional, so
-  // the bar reappears next time without a separate "show profiler" affordance.
-  const [hidden, setHidden] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const [barWidth, setBarWidth] = useState(0);
 
@@ -387,8 +388,6 @@ export default function ProfileBar({ profiler, onSave, renderLink }: ProfileBarP
 
   const currentHeight = expanded ? EXPANDED_HEIGHT : COLLAPSED_HEIGHT;
   const waterfallWidth = Math.max(barWidth - 48, 200);
-
-  if (hidden) return null;
 
   return (
     <div
@@ -477,14 +476,16 @@ export default function ProfileBar({ profiler, onSave, renderLink }: ProfileBarP
             Clear
           </Button>
           {expanded ? <DownOutlined /> : <UpOutlined />}
-          <Button
-            icon={<CloseOutlined />}
-            size="small"
-            type="text"
-            aria-label="Hide profiler"
-            title="Hide until next reload"
-            onClick={(e) => { e.stopPropagation(); setHidden(true); }}
-          />
+          {onHide && (
+            <Button
+              icon={<CloseOutlined />}
+              size="small"
+              type="text"
+              aria-label="Hide profiler"
+              title="Hide until next reload"
+              onClick={(e) => { e.stopPropagation(); onHide(); }}
+            />
+          )}
         </Space>
       </div>
 


### PR DESCRIPTION
Follow-up to #257. The earlier close returned null from ProfileBar but the parent's reserved bottom padding stayed, leaving an empty strip. Lift visibility to View: ProfileBar takes onHide; the Layout's paddingBottom is gated on the same flag. Clicking X unmounts AND removes the padding, so content reflows. Session-only.

Test plan: 39 profiler + 361 highperformer tests pass.