### PR TITLE
feat(chat): auto-submit suggestion chips

### DIFF
--- a/.changeset/chat-chip-autosubmit.md
+++ b/.changeset/chat-chip-autosubmit.md
@@ -1,0 +1,7 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Auto-submit suggestion chips in the chat empty state. Clicking a chip now
+sends the suggested prompt directly instead of populating the input field.
+Chips are disabled while a turn is streaming.

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -87,13 +87,16 @@ describe("ChatPanel", () => {
     expect(screen.getByPlaceholderText(/Ask anything/i)).toBeDefined();
   });
 
-  it("clicking a chip fills the input", async () => {
+  it("clicking a chip auto-submits the chip's prompt", async () => {
     render(<ChatPanel slug="spectrum" />);
     await enterNewMode();
     const chip = screen.getByText(/Top genes in T/);
     fireEvent.click(chip);
-    const input = screen.getByPlaceholderText(/Ask anything/i) as HTMLInputElement;
-    expect(input.value).toMatch(/Top genes in T/i);
+    await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+    const [, messages] = startMock.mock.calls[0];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].content).toMatch(/Top genes in T/i);
   });
 
   it("submitting calls useChatTurn.start with the user message appended", async () => {

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -222,7 +222,8 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
                 key={chip.label}
                 size="small"
                 style={{ margin: "4px 4px 4px 0" }}
-                onClick={() => setInput(chip.prompt)}
+                disabled={streaming}
+                onClick={() => submit(chip.prompt)}
               >
                 {chip.label}
               </Button>


### PR DESCRIPTION
## Summary

Clicking a suggestion chip on the empty-state landing now sends the chip's prompt directly instead of populating the input. Chips are disabled while a turn is streaming.

## Test plan

- [x] Existing test updated to assert the send call (was: input population).
- [x] 11 ChatPanel tests pass.
- [x] Manual: refreshed dist, clicked a chip, verified the question fires without a second click.