### PR TITLE
fix(view): inset right-sidebar tab labels from the border

### DIFF
--- a/.changeset/chat-tabs-nav-padding.md
+++ b/.changeset/chat-tabs-nav-padding.md
@@ -1,0 +1,10 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Inset the right-sidebar tab labels ("Summary" / "Chat") from the Sider's
+left border so they don't sit flush against the edge.
+
+This is a tactical fix on the `<Tabs>` element. See #260 for the broader
+refactor that would move the gutter responsibility to the Sider container
+and let child panels drop their redundant edge padding.

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -959,6 +959,11 @@ function View() {
               size="small"
               defaultActiveKey="summary"
               className="chat-tabs"
+              // Inset the tab labels from the Sider's left border + drag
+              // handle so "Summary" / "Chat" don't sit flush against the
+              // edge. See cbioportal-cell-explorer issue for the broader
+              // sidebar-gutter refactor.
+              tabBarStyle={{ paddingLeft: 12, paddingRight: 8 }}
               items={[
                 {
                   key: 'summary',


### PR DESCRIPTION
## Summary

The "Summary" / "Chat" tab labels sat flush against the Sider's left border. Adds 12px left / 8px right padding to the tab nav via \`tabBarStyle\` on the \`<Tabs>\` element.

## Why a Tabs prop, not global CSS

The padding is a property of the \`<Tabs>\` element, not the panel as a whole. Living as a prop on the component it affects beats global CSS that future readers have to grep for.

## Follow-up

#260 tracks the broader refactor — give the Sider container its own inner gutter and drop per-child edge padding (including this workaround).

## Test plan

- [x] Manual: rebuilt dist, hard-refreshed, verified tab labels are inset.