### PR TITLE
fix(chat): chat input row clipped off-screen

### DIFF
--- a/.changeset/chat-conversation-flex-overflow.md
+++ b/.changeset/chat-conversation-flex-overflow.md
@@ -1,0 +1,12 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix chat input being pushed off-screen. `ConversationView`'s outer
+container used `height: 100%` while its parent `ChatPanel` was a flex
+column with a `ChatThreadHeader` sibling. The two children's heights
+summed to more than the parent's height, overflowing by the header's
+height and clipping the input row at the bottom. Switching the
+container to `flex: 1, minHeight: 0` makes it share space correctly
+with the header. Symptom became more obvious after the profiler bar
+close button (#258) made the chat container taller.

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -205,7 +205,7 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
   const hasError = state.status === "error";
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%", padding: 12 }}>
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, padding: 12 }}>
       <div
         ref={scrollContainerRef}
         onScroll={handleScroll}


### PR DESCRIPTION
ChatPanel is a flex column containing `ChatThreadHeader` (~32px) plus `ConversationView`. `ConversationView` used `height: 100%` which claims the parent's full height without participating in flex-share with the header — total content overflowed the parent by the header's height and clipped the input row at the bottom.

Symptom became visible after #258 enlarged the chat container by removing the profiler bar's reserved padding. The bug was actually present before; the input was just sitting near the clip line.

Switch to `flex: 1, minHeight: 0` so `ConversationView` correctly shares vertical space with the header.

## Test plan
- [x] 361/361 highperformer tests pass
- [x] Manual: input row visible whether profiler is shown or hidden