### PR TITLE
feat(highperformer): bump default right sidebar to 400, add 700/800 snap points

### DIFF
--- a/.changeset/right-sidebar-breakpoints.md
+++ b/.changeset/right-sidebar-breakpoints.md
@@ -1,0 +1,7 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Right sidebar: default width bumped from 300 → 400; added 700 and 800
+as wider drag-snap points. Full snap list is now `[60, 300, 400, 550,
+700, 800]`. The chat panel benefits most from the extra width.

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -26,10 +26,10 @@ import { loadDatasets, saveDatasets } from '../utils/datasets'
 const { Sider, Content } = Layout
 
 const LEFT_SIDEBAR_WIDTH = 300
-const RIGHT_SIDEBAR_WIDTH = 300
+const RIGHT_SIDEBAR_WIDTH = 400
 const SIDEBAR_COLLAPSED_WIDTH = 60
 // Snap breakpoints for the right sidebar — drag releases snap to nearest
-const RIGHT_SNAP_POINTS = [SIDEBAR_COLLAPSED_WIDTH, RIGHT_SIDEBAR_WIDTH, 400, 550]
+const RIGHT_SNAP_POINTS = [SIDEBAR_COLLAPSED_WIDTH, 300, RIGHT_SIDEBAR_WIDTH, 550, 700, 800]
 
 function snapToNearest(value: number): number {
   let closest = RIGHT_SNAP_POINTS[0]


### PR DESCRIPTION
Default right-sidebar width bumped from 300 → 400 to give the chat panel more room out of the box. Adds 700 and 800 as wider drag-snap points so users with chat-heavy workflows can grow the panel without manual sizing.

Snap list is now `[60, 300, 400, 550, 700, 800]`.

## Test plan
- [x] 361 highperformer tests pass
- [ ] Manual: drag handle snaps to all 6 points; new datasets open with 400px sidebar