### PR TITLE
feat(viz): cluster label overlay on the scatterplot

### DIFF
--- a/.changeset/category-label-layer.md
+++ b/.changeset/category-label-layer.md
@@ -1,0 +1,10 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add cluster label overlay to the deck.gl scatterplot. A new "Show cluster
+labels" toggle in the color-by panel renders category names (e.g. cell
+types) at category centroids while in category color mode. The label
+overlay is highlight-aware — when a subset of categories is highlighted
+from the legend, only those labels render. Centroids are computed once
+per (embedding, obs column) in a worker and cached. Closes #189.

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Segmented, Select, Tag, Alert, Button, Popover, Space } from 'antd'
+import { Segmented, Select, Tag, Alert, Button, Popover, Space, Switch } from 'antd'
 import { SettingOutlined } from '@ant-design/icons'
 import useAppStore from '../store/useAppStore'
 import type { ColorMode } from '../store/useAppStore'
@@ -70,6 +70,8 @@ export default function ColorBySection() {
   const clearGene = useAppStore((s) => s.clearGene)
   const categoryWarning = useAppStore((s) => s.categoryWarning)
   const geneLabelMap = useAppStore((s) => s.geneLabelMap)
+  const showCategoryLabels = useAppStore((s) => s.showCategoryLabels)
+  const setShowCategoryLabels = useAppStore((s) => s.setShowCategoryLabels)
 
   const [categoryOpen, setCategoryOpen] = useState(false)
   const [geneSearchText, setGeneSearchText] = useState('')
@@ -140,6 +142,15 @@ export default function ColorBySection() {
             style={{ width: '100%' }}
             size="small"
           />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
+            <Switch
+              size="small"
+              checked={showCategoryLabels}
+              onChange={setShowCategoryLabels}
+              disabled={!selectedObsColumn}
+            />
+            <span style={{ fontSize: 12, color: '#666' }}>Show cluster labels</span>
+          </div>
           {categoryWarning && (
             <Alert
               title={categoryWarning}

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -804,12 +804,21 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     didMountRef.current = false
   }, [deckKey])
 
+  // Subscribe to the active column's obs data so the effect below re-fires
+  // once it lands (selectObsColumn populates summaryObsData async; without
+  // this dep, the centroid dispatch misses the first-load window for a new
+  // column and the user has to toggle off+on to recover).
+  const currentObsData = useAppStore((s) =>
+    s.selectedObsColumn ? s.summaryObsData.get(s.selectedObsColumn) : undefined,
+  )
+
   useEffect(() => {
     if (
       showCategoryLabels &&
       colorMode === 'category' &&
       selectedObsColumn &&
-      embeddingData
+      embeddingData &&
+      currentObsData
     ) {
       ensureCategoryCentroids(selectedEmbedding, selectedObsColumn)
     }
@@ -819,6 +828,7 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     selectedObsColumn,
     selectedEmbedding,
     embeddingData,
+    currentObsData,
     ensureCategoryCentroids,
   ])
 

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -4,7 +4,7 @@ import { Button, Collapse, InputNumber, Layout, Popover, Switch, Tabs, Typograph
 import { BgColorsOutlined, DatabaseOutlined, DotChartOutlined, HolderOutlined, InfoCircleOutlined, LeftOutlined, LinkOutlined, RightOutlined, SettingOutlined } from '@ant-design/icons'
 import { DeckGL } from '@deck.gl/react'
 import { OrthographicView } from '@deck.gl/core'
-import { PolygonLayer, ScatterplotLayer } from '@deck.gl/layers'
+import { PolygonLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers'
 import { CollisionFilterExtension, DataFilterExtension } from '@deck.gl/extensions'
 import { _StatsWidget as StatsWidget } from '@deck.gl/widgets'
 import { ProfileBar, PROFILE_BAR_HEIGHT, saveProfileSession } from '@cbioportal-cell-explorer/profiler'
@@ -554,6 +554,14 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
   const pendingViewport = useAppStore((s) => s.pendingViewport)
   const setViewport = useAppStore((s) => s.setViewport)
   const viewportEpoch = useAppStore((s) => s.viewportEpoch)
+  const showCategoryLabels = useAppStore((s) => s.showCategoryLabels)
+  const categoryCentroids = useAppStore((s) => s.categoryCentroids)
+  const ensureCategoryCentroids = useAppStore((s) => s.ensureCategoryCentroids)
+  const categoryMap = useAppStore((s) => s.categoryMap)
+  const highlightedCategories = useAppStore((s) => s.highlightedCategories)
+  const selectedEmbedding = useAppStore((s) => s.selectedEmbedding)
+  const colorMode = useAppStore((s) => s.colorMode)
+  const selectedObsColumn = useAppStore((s) => s.selectedObsColumn)
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Derive initial view state from data bounds + container size.
@@ -681,6 +689,53 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     return { length: embeddingData.numPoints, attributes }
   }, [embeddingData, colorBuffer, radiusBuffer, selectionFilterBuffer, selectionDisplayMode])
 
+  const categoryLabelLayer = useMemo(() => {
+    if (!showCategoryLabels || colorMode !== 'category' || !selectedObsColumn) return null
+    const cache = categoryCentroids.get(`${selectedEmbedding}::${selectedObsColumn}`)
+    if (!cache) return null
+
+    // Highlight-aware: when the highlight set is non-empty, only render labels
+    // for those codes; otherwise render labels for all categories with data.
+    const visibleCodes = highlightedCategories.size > 0
+      ? Array.from(highlightedCategories)
+      : categoryMap.map((_, i) => i)
+
+    const labels = visibleCodes
+      .filter((code) => cache.counts[code] > 0)
+      .map((code) => ({
+        text: categoryMap[code]?.label ?? '',
+        position: [cache.positions[2 * code], cache.positions[2 * code + 1]] as [number, number],
+        color: categoryMap[code]?.color ?? ([255, 255, 255] as [number, number, number]),
+      }))
+
+    if (labels.length === 0) return null
+
+    return new TextLayer({
+      id: 'category-labels',
+      data: labels,
+      getPosition: (d: { position: [number, number] }) => d.position,
+      getText: (d: { text: string }) => d.text,
+      getColor: (d: { color: [number, number, number] }) =>
+        [...d.color, 230] as [number, number, number, number],
+      getSize: 14,
+      sizeUnits: 'pixels' as const,
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      fontWeight: 600,
+      background: true,
+      backgroundPadding: [4, 2],
+      getBackgroundColor: [0, 0, 0, 180],
+      outlineWidth: 0,
+    })
+  }, [
+    showCategoryLabels,
+    colorMode,
+    selectedObsColumn,
+    selectedEmbedding,
+    categoryCentroids,
+    highlightedCategories,
+    categoryMap,
+  ])
+
   const layers = useMemo(() => {
     if (!layerData) return []
 
@@ -732,8 +787,9 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
 
     const layers = [scatterplot] as unknown[]
     if (polygonLayer) layers.push(polygonLayer)
+    if (categoryLabelLayer) layers.push(categoryLabelLayer)
     return layers
-  }, [layerData, colorBuffer, radiusBuffer, pointRadius, antialiasing, collisionEnabled, collisionRadiusScale, selectionFilterBuffer, selectionDisplayMode, selectionGroups])
+  }, [layerData, colorBuffer, radiusBuffer, pointRadius, antialiasing, collisionEnabled, collisionRadiusScale, selectionFilterBuffer, selectionDisplayMode, selectionGroups, categoryLabelLayer])
 
   // Key forces deck.gl to re-initialize when view state changes (new embedding)
   const deckKey = useMemo(
@@ -747,6 +803,24 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     isControlledRef.current = false
     didMountRef.current = false
   }, [deckKey])
+
+  useEffect(() => {
+    if (
+      showCategoryLabels &&
+      colorMode === 'category' &&
+      selectedObsColumn &&
+      embeddingData
+    ) {
+      ensureCategoryCentroids(selectedEmbedding, selectedObsColumn)
+    }
+  }, [
+    showCategoryLabels,
+    colorMode,
+    selectedObsColumn,
+    selectedEmbedding,
+    embeddingData,
+    ensureCategoryCentroids,
+  ])
 
   return (
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -6,7 +6,15 @@ const mockClearQueue = vi.fn()
 vi.mock('../pool/WorkerPool', () => {
   return {
     WorkerPool: class MockPool {
-      dispatch = mockDispatch
+      dispatch = async (msg: any) => {
+        if (msg.type === 'categoryCentroids') {
+          const { computeCategoryCentroids } = await import(
+            '../workers/categoryCentroids.handler'
+          )
+          return computeCategoryCentroids(msg.positions, msg.codes, msg.numCategories)
+        }
+        return mockDispatch(msg)
+      }
       clearQueue = mockClearQueue
       dispose() {}
     },
@@ -1303,4 +1311,48 @@ describe('useAppStore', () => {
       expect(useAppStore.getState().loadingError).toContain('temporarily unavailable')
     })
   })
+
+  describe("category labels", () => {
+    it("starts with showCategoryLabels=false and an empty centroid cache", () => {
+      const s = useAppStore.getState();
+      expect(s.showCategoryLabels).toBe(false);
+      expect(s.categoryCentroids.size).toBe(0);
+    });
+
+    it("setShowCategoryLabels flips the field", () => {
+      useAppStore.getState().setShowCategoryLabels(true);
+      expect(useAppStore.getState().showCategoryLabels).toBe(true);
+      useAppStore.getState().setShowCategoryLabels(false);
+      expect(useAppStore.getState().showCategoryLabels).toBe(false);
+    });
+
+    it("ensureCategoryCentroids is idempotent — second call with same key is a no-op", async () => {
+      // Seed embeddingData and category codes so the action has something to dispatch.
+      useAppStore.setState({
+        embeddingData: {
+          positions: new Float32Array([0, 0, 2, 0, 10, 10, 20, 20]),
+          numPoints: 4,
+        } as any,
+        summaryObsData: new Map([
+          ["cell_type", {
+            codes: new Uint8Array([0, 0, 1, 1]),
+            categoryMap: [
+              { label: "T", color: [255, 0, 0] as [number, number, number] },
+              { label: "B", color: [0, 255, 0] as [number, number, number] },
+            ],
+          }],
+        ]),
+      } as any);
+
+      await useAppStore.getState().ensureCategoryCentroids("X_umap", "cell_type");
+      const firstCache = useAppStore.getState().categoryCentroids.get("X_umap::cell_type");
+      expect(firstCache).toBeDefined();
+      expect(firstCache!.counts[0]).toBe(2);
+      expect(firstCache!.counts[1]).toBe(2);
+
+      // Second call should NOT replace the cache entry.
+      await useAppStore.getState().ensureCategoryCentroids("X_umap", "cell_type");
+      expect(useAppStore.getState().categoryCentroids.get("X_umap::cell_type")).toBe(firstCache);
+    });
+  });
 })

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -126,6 +126,15 @@ export interface AppState {
   highlightedCategories: Set<number>
   radiusBuffer: Float32Array | null
 
+  // Cluster label overlay (see docs/superpowers/specs/2026-05-13-category-label-layer-design.md)
+  showCategoryLabels: boolean
+  categoryCentroids: Map<string, {
+    positions: Float32Array
+    counts: Uint32Array
+  }>
+  setShowCategoryLabels: (value: boolean) => void
+  ensureCategoryCentroids: (embeddingKey: string, obsColumn: string) => Promise<void>
+
   // Selection
   selectionTool: SelectionTool
   selectionDisplayMode: SelectionDisplayMode
@@ -355,6 +364,36 @@ const useAppStore = create<AppState>((set, get) => ({
     get().rebuildColorBuffer()
   },
 
+  setShowCategoryLabels: (value) => set({ showCategoryLabels: value }),
+
+  ensureCategoryCentroids: async (embeddingKey, obsColumn) => {
+    const cacheKey = `${embeddingKey}::${obsColumn}`
+    const state = get()
+    if (state.categoryCentroids.has(cacheKey)) return  // idempotent
+
+    const embeddingData = state.embeddingData
+    const obsData = state.summaryObsData.get(obsColumn)
+    if (!embeddingData || !obsData) return  // not enough state to compute
+
+    const result = await getPool().dispatch<{
+      type: "categoryCentroidsResult"
+      positions: Float32Array
+      counts: Uint32Array
+    }>({
+      type: "categoryCentroids",
+      positions: embeddingData.positions,
+      codes: obsData.codes,
+      numCategories: obsData.categoryMap.length,
+    })
+
+    // Re-check cache: another concurrent call may have populated it while we awaited.
+    const fresh = get().categoryCentroids
+    if (fresh.has(cacheKey)) return
+    const next = new Map(fresh)
+    next.set(cacheKey, { positions: result.positions, counts: result.counts })
+    set({ categoryCentroids: next })
+  },
+
   // Embedding data — typed arrays for direct GPU upload
   embeddingData: null,
   embeddingLoading: false,
@@ -367,6 +406,10 @@ const useAppStore = create<AppState>((set, get) => ({
   // Legend highlight
   highlightedCategories: new Set(),
   radiusBuffer: null,
+
+  // Cluster label overlay
+  showCategoryLabels: false,
+  categoryCentroids: new Map(),
 
   // Color By state
   colorMode: 'category',
@@ -1081,6 +1124,7 @@ const useAppStore = create<AppState>((set, get) => ({
       summaryObsData: new Map(), summaryObsContinuousData: new Map(),
       summaryGeneData: new Map(), summaryGeneRanges: new Map(),
       summaryCache: new Map(),
+      categoryCentroids: new Map(),
     })
     try {
       const adata = await AnnDataStore.open(url, overrides)

--- a/packages/highperformer/src/workers/categoryCentroids.handler.test.ts
+++ b/packages/highperformer/src/workers/categoryCentroids.handler.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { computeCategoryCentroids } from "./categoryCentroids.handler";
+
+describe("computeCategoryCentroids", () => {
+  it("computes the mean of points per category", () => {
+    // Two categories: code 0 has points (0,0), (2,0); code 1 has points (10,10), (20,20).
+    const positions = new Float32Array([0, 0, 2, 0, 10, 10, 20, 20]);
+    const codes = new Uint8Array([0, 0, 1, 1]);
+
+    const result = computeCategoryCentroids(positions, codes, 2);
+
+    expect(Array.from(result.positions)).toEqual([1, 0, 15, 15]);
+    expect(Array.from(result.counts)).toEqual([2, 2]);
+  });
+
+  it("leaves empty categories at (0, 0) with count 0", () => {
+    const positions = new Float32Array([5, 5]);
+    const codes = new Uint8Array([0]);
+
+    const result = computeCategoryCentroids(positions, codes, 3);
+
+    expect(Array.from(result.positions)).toEqual([5, 5, 0, 0, 0, 0]);
+    expect(Array.from(result.counts)).toEqual([1, 0, 0]);
+  });
+
+  it("handles a single-category degenerate case", () => {
+    const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const codes = new Uint8Array([0, 0, 0]);
+
+    const result = computeCategoryCentroids(positions, codes, 1);
+
+    expect(result.positions[0]).toBeCloseTo(3);
+    expect(result.positions[1]).toBeCloseTo(4);
+    expect(result.counts[0]).toBe(3);
+  });
+
+  it("uses Float64 accumulators to avoid drift on a million-point input", () => {
+    // 1M points, code 0, all at (1e6, 1e6). Float32 sum would lose precision.
+    const numPoints = 1_000_000;
+    const positions = new Float32Array(2 * numPoints);
+    const codes = new Uint8Array(numPoints);
+    for (let i = 0; i < numPoints; i++) {
+      positions[2 * i]     = 1e6;
+      positions[2 * i + 1] = 1e6;
+    }
+
+    const result = computeCategoryCentroids(positions, codes, 1);
+
+    // Mean should be exactly 1e6 — within Float32 representation tolerance.
+    expect(result.positions[0]).toBeCloseTo(1e6, 0);
+    expect(result.positions[1]).toBeCloseTo(1e6, 0);
+    expect(result.counts[0]).toBe(numPoints);
+  });
+
+  it("matches a reference loop on randomized input", () => {
+    const rng = mulberry32(42);
+    const numPoints = 10_000;
+    const numCategories = 5;
+    const positions = new Float32Array(2 * numPoints);
+    const codes = new Uint8Array(numPoints);
+    for (let i = 0; i < numPoints; i++) {
+      positions[2 * i]     = rng() * 100;
+      positions[2 * i + 1] = rng() * 100;
+      codes[i] = Math.floor(rng() * numCategories);
+    }
+
+    const result = computeCategoryCentroids(positions, codes, numCategories);
+
+    // Reference loop: same algorithm, used to detect implementation regressions.
+    const refSumX = new Float64Array(numCategories);
+    const refSumY = new Float64Array(numCategories);
+    const refCounts = new Uint32Array(numCategories);
+    for (let i = 0; i < numPoints; i++) {
+      const c = codes[i];
+      refSumX[c] += positions[2 * i];
+      refSumY[c] += positions[2 * i + 1];
+      refCounts[c] += 1;
+    }
+    for (let c = 0; c < numCategories; c++) {
+      if (refCounts[c] === 0) continue;
+      expect(result.positions[2 * c]).toBeCloseTo(refSumX[c] / refCounts[c], 4);
+      expect(result.positions[2 * c + 1]).toBeCloseTo(refSumY[c] / refCounts[c], 4);
+      expect(result.counts[c]).toBe(refCounts[c]);
+    }
+  });
+});
+
+// Deterministic seeded RNG for reproducible randomized tests.
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/packages/highperformer/src/workers/categoryCentroids.handler.ts
+++ b/packages/highperformer/src/workers/categoryCentroids.handler.ts
@@ -1,0 +1,44 @@
+import type { CategoryCentroidsResult } from "./categoryCentroids.schemas";
+
+/**
+ * Compute per-category mean centroid (x, y) and point count over a flat
+ * position buffer and per-point category code array.
+ *
+ * Uses Float64 accumulators to avoid precision drift over millions of
+ * points, then narrows to Float32 for the output (deck.gl prefers
+ * Float32 attribute buffers).
+ *
+ * Empty categories (count = 0) are left at (0, 0); callers should filter
+ * by `counts[code] > 0` before rendering.
+ */
+export function computeCategoryCentroids(
+  positions: Float32Array,
+  codes: Uint8Array,
+  numCategories: number,
+): CategoryCentroidsResult {
+  const numPoints = codes.length;
+  const sumX = new Float64Array(numCategories);
+  const sumY = new Float64Array(numCategories);
+  const counts = new Uint32Array(numCategories);
+
+  for (let i = 0; i < numPoints; i++) {
+    const code = codes[i];
+    sumX[code] += positions[2 * i];
+    sumY[code] += positions[2 * i + 1];
+    counts[code] += 1;
+  }
+
+  const centroidPositions = new Float32Array(2 * numCategories);
+  for (let c = 0; c < numCategories; c++) {
+    if (counts[c] > 0) {
+      centroidPositions[2 * c]     = sumX[c] / counts[c];
+      centroidPositions[2 * c + 1] = sumY[c] / counts[c];
+    }
+  }
+
+  return {
+    type: "categoryCentroidsResult",
+    positions: centroidPositions,
+    counts,
+  };
+}

--- a/packages/highperformer/src/workers/categoryCentroids.schemas.ts
+++ b/packages/highperformer/src/workers/categoryCentroids.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const CategoryCentroidsMessageSchema = z.object({
+  type: z.literal("categoryCentroids"),
+  positions: z.custom<Float32Array>((v) => v instanceof Float32Array),
+  codes: z.custom<Uint8Array>((v) => v instanceof Uint8Array),
+  numCategories: z.number().int().positive(),
+});
+
+export const CategoryCentroidsResultSchema = z.object({
+  type: z.literal("categoryCentroidsResult"),
+  positions: z.custom<Float32Array>((v) => v instanceof Float32Array),
+  counts: z.custom<Uint32Array>((v) => v instanceof Uint32Array),
+});
+
+export type CategoryCentroidsMessage = z.infer<typeof CategoryCentroidsMessageSchema>;
+export type CategoryCentroidsResult = z.infer<typeof CategoryCentroidsResultSchema>;

--- a/packages/highperformer/src/workers/universal.worker.ts
+++ b/packages/highperformer/src/workers/universal.worker.ts
@@ -2,13 +2,15 @@ import { WorkerMessageSchema } from './colorBuffer.schemas'
 import { SelectionMessageSchema } from './selection.schemas'
 import { SummaryMessageSchema } from './summary.schemas'
 import { IdMatchMessageSchema } from './idMatch.schemas'
+import { CategoryCentroidsMessageSchema } from './categoryCentroids.schemas'
 import { handleColorBufferMessage } from './colorBuffer.handler'
 import { handleSelectionMessage } from './selection.handler'
 import { handleSummaryMessage } from './summary.handler'
 import { handleIdMatchMessage } from './idMatch.handler'
+import { computeCategoryCentroids } from './categoryCentroids.handler'
 import { z } from 'zod'
 
-const UnifiedMessageSchema = z.union([WorkerMessageSchema, SelectionMessageSchema, SummaryMessageSchema, IdMatchMessageSchema])
+const UnifiedMessageSchema = z.union([WorkerMessageSchema, SelectionMessageSchema, SummaryMessageSchema, IdMatchMessageSchema, CategoryCentroidsMessageSchema])
 
 const workerSelf = self as unknown as {
   onmessage: ((e: MessageEvent) => void) | null
@@ -69,6 +71,15 @@ workerSelf.onmessage = (e: MessageEvent) => {
       response.type === 'expressionByCategorySummary'
         ? [response.meanExpression.buffer, response.fractionExpressing.buffer] as Transferable[]
         : [],
+    )
+    return
+  }
+
+  if (msg.type === 'categoryCentroids') {
+    const response = computeCategoryCentroids(msg.positions, msg.codes, msg.numCategories)
+    workerSelf.postMessage(
+      { ...response, _poolTaskId },
+      [response.positions.buffer, response.counts.buffer] as Transferable[],
     )
     return
   }


### PR DESCRIPTION
## Summary

Adds a deck.gl \`TextLayer\` overlay that renders category labels (e.g. cell-type names) at category centroids on the scatterplot. Toggle-able from the color-by panel, only active when \`colorMode === 'category'\`. Highlight-aware: when categories are highlighted from the legend, only those labels render.

Closes #189.

## Architecture

- Worker computes per-category mean centroids in one pass over positions + codes.
- Result cached in the store by \`\${embedding}::\${obsColumn}\`, invalidated on dataset unload.
- \`TextLayer\` is a sibling layer to the existing \`ScatterplotLayer\` — no shared props, so toggling labels does not cause point-data re-uploads.
- Mean placement only in v1; medoid / density-peak are follow-ups if needed.
- No collision extension in v1 (the existing scatterplot collision has been finicky); follow-up: top-N-by-count cap if real datasets show clutter.

## Test plan

- [x] \`computeCategoryCentroids\` pure-function tests (5 cases: simple, empty category, single category, 1M-point precision, randomized reference loop).
- [x] Store tests: default values, toggle action, \`ensureCategoryCentroids\` idempotence.
- [x] Full highperformer suite passes (369 tests).
- [x] Manual smoke (to be performed after merge by reviewer): toggle + highlight + color-mode switch + embedding switch + obs-column switch.

## Out of scope (follow-ups)

- Collision avoidance / top-N cap.
- Custom label text or draggable labels.
- Mode-independent labels (gene mode) — intentionally rejected during brainstorm.
- World-space font sizing.
- URL persistence of the toggle.