### PR TITLE
feat(config): add showCategoryLabels to AppConfig schema

### DIFF
--- a/.changeset/show-category-labels-config.md
+++ b/.changeset/show-category-labels-config.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add `showCategoryLabels: boolean` to the AppConfig schema. Wires the
+cluster-label overlay toggle into the embeddable/postMessage config
+surface so callers (including the future agent tool) can flip it
+remotely. Applied in Phase 1 alongside the other UI toggles — does
+not block on dataset metadata.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -223,6 +223,9 @@
         "hide"
       ]
     },
+    "showCategoryLabels": {
+      "type": "boolean"
+    },
     "showHeader": {
       "type": "boolean"
     },

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -32,6 +32,7 @@ describe('applyConfig', () => {
       showLeftSidebar: true,
       showRightSidebar: false,
       showDatasetDropdown: false,
+      showCategoryLabels: true,
     }
 
     applyConfig(config)
@@ -41,6 +42,7 @@ describe('applyConfig', () => {
     expect(state.showLeftSidebar).toBe(true)
     expect(state.showRightSidebar).toBe(false)
     expect(state.showDatasetDropdown).toBe(false)
+    expect(state.showCategoryLabels).toBe(true)
   })
 
   it('calls openDataset with config url', () => {

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -61,6 +61,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     ...(config.showLeftSidebar !== undefined && { showLeftSidebar: config.showLeftSidebar }),
     ...(config.showRightSidebar !== undefined && { showRightSidebar: config.showRightSidebar }),
     ...(config.showDatasetDropdown !== undefined && { showDatasetDropdown: config.showDatasetDropdown }),
+    ...(config.showCategoryLabels !== undefined && { showCategoryLabels: config.showCategoryLabels }),
   })
 
   // Phase 2: Trigger dataset load if requested

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -77,6 +77,12 @@ export const AppConfigSchema = z.object({
   // default that ID-based filters set internally.
   selectionDisplayMode: z.enum(['dim', 'hide']).optional(),
 
+  // Cluster label overlay on the scatterplot. Affects render only when
+  // colorMode === 'category' and a category column is selected. Setting
+  // true while in gene mode is allowed but has no visible effect until
+  // the user switches to category mode.
+  showCategoryLabels: z.boolean().optional(),
+
   // UI chrome
   showHeader: z.boolean().optional(),
   showLeftSidebar: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds \`showCategoryLabels: boolean\` to the AppConfig schema, wiring the cluster-label overlay toggle (shipped in #264) into the embeddable/postMessage config surface. Applied in Phase 1 alongside the other UI toggles — no dataset-metadata dependency.

Regenerates the JSON Schema artifact (\`packages/highperformer/schema/app-config.schema.json\`) that cell-explorer-py consumes for its Pydantic codegen.

## Follow-up

The agent tool \`set_category_labels\` lands in cell-explorer-py after this PR merges (so the regenerated schema is in main for the Pydantic codegen to pick up).

## Test plan

- [x] Existing UI-toggles applyConfig test extended to assert the new field round-trips.
- [x] Full highperformer suite passes (369 tests).