### PR TITLE
feat(chat): "Why" panel under assistant turns

### DIFF
--- a/.changeset/chat-why-panel.md
+++ b/.changeset/chat-why-panel.md
@@ -1,0 +1,18 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Add a "Why" panel under each assistant turn in the chat. The panel
+surfaces what the agent did — tool calls with their arguments and
+duration, UI actions, errors, and final token usage. Collapsed by
+default with a summary chip (`▼ Why · 2 tools · 3.2s`); auto-expands
+when the turn has an error (`⚠ Why · 2 tools (1 error) · 3.2s`).
+
+Internals: `ChatMessage` gained an optional `trace: TraceEntry[]` plus
+`usage`, `startedAt`, `endedAt`. The reducer appends to the trace as
+events arrive — `parts` still holds only the inline-rendered content.
+
+Implements cell-explorer-py#96 v1; depends on the matching backend PR
+that emits `args` on `tool_progress.started` and `duration_ms` on
+`tool_progress.ok` / `error`. Backend lands first; frontend is
+forward-compatible because the new fields are optional.

--- a/packages/highperformer/src/chat/ChatPanel.test.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.test.tsx
@@ -150,7 +150,9 @@ describe("ChatPanel", () => {
     await waitFor(() => expect(startMock).toHaveBeenCalled());
     dispatch!({ type: "text_delta", text: "partial " });
     dispatch!({ type: "error", message: "boom", retryable: false });
-    await waitFor(() => expect(screen.getByText(/boom/)).toBeDefined());
+    // The error appears both as the inline ErrorPart bubble and inside the
+    // WhyPanel trace (auto-expanded for errors), hence getAllByText.
+    await waitFor(() => expect(screen.getAllByText(/boom/).length).toBeGreaterThan(0));
     expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
 
     fireEvent.click(screen.getByRole("button", { name: /retry/i }));

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -8,6 +8,7 @@ import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
 import type { ChatEvent, ChatMessage, ContextResponse, MessagePart, WireMessage } from "./types";
 import { useChatTurn } from "./useChatTurn";
+import { WhyPanel } from "./WhyPanel";
 
 type Action =
   | { type: "AGENT_EVENT"; event: ChatEvent }
@@ -238,6 +239,7 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
                 {m.parts.map((p, j) => (
                   <MessagePartView key={j} part={p} />
                 ))}
+                {m.role === "assistant" && <WhyPanel message={m} />}
               </div>
             ))}
             {state.current && (
@@ -246,6 +248,7 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
                 {state.current.parts.map((p, j) => (
                   <MessagePartView key={j} part={p} />
                 ))}
+                <WhyPanel message={state.current} />
               </div>
             )}
             {hasError && (

--- a/packages/highperformer/src/chat/WhyPanel.test.tsx
+++ b/packages/highperformer/src/chat/WhyPanel.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { WhyPanel } from "./WhyPanel";
+import type { ChatMessage } from "./types";
+
+afterEach(() => cleanup());
+
+function msg(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    role: "assistant",
+    parts: [],
+    trace: [],
+    startedAt: 0,
+    endedAt: 3200,
+    ...overrides,
+  };
+}
+
+describe("WhyPanel", () => {
+  it("renders nothing when there is no trace or usage", () => {
+    const { container } = render(
+      <WhyPanel message={{ role: "assistant", parts: [] }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a collapsed chip with tool count and duration", () => {
+    render(
+      <WhyPanel
+        message={msg({
+          trace: [
+            { kind: "tool_start", tool: "get_dataset_schema", args: {} },
+            {
+              kind: "tool_end",
+              tool: "get_dataset_schema",
+              status: "ok",
+              duration_ms: 245,
+            },
+          ],
+        })}
+      />,
+    );
+    // Chip summary text — matched piecewise since icon + spans split the line
+    const chip = screen.getByRole("button");
+    expect(chip.textContent).toContain("Why");
+    expect(chip.textContent).toContain("1 tool");
+    expect(chip.textContent).toContain("3.2s");
+    // Collapsed by default — the trace row is not visible
+    expect(screen.queryByText(/get_dataset_schema\(\)/)).toBeNull();
+  });
+
+  it("expands to show trace rows when clicked", () => {
+    render(
+      <WhyPanel
+        message={msg({
+          trace: [
+            { kind: "tool_start", tool: "get_dataset_schema", args: {} },
+            {
+              kind: "tool_end",
+              tool: "get_dataset_schema",
+              status: "ok",
+              duration_ms: 245,
+            },
+          ],
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/get_dataset_schema\(\)/)).toBeDefined();
+    expect(screen.getByText(/245 ms/)).toBeDefined();
+  });
+
+  it("auto-expands when the trace contains an error", () => {
+    render(
+      <WhyPanel
+        message={msg({
+          trace: [
+            { kind: "tool_start", tool: "explode", args: { x: 1 } },
+            {
+              kind: "tool_end",
+              tool: "explode",
+              status: "error",
+              summary: "kaboom",
+              duration_ms: 12,
+            },
+          ],
+        })}
+      />,
+    );
+    // Already expanded — tool name visible without clicking
+    expect(screen.getByText(/explode/)).toBeDefined();
+    expect(screen.getByText(/kaboom/)).toBeDefined();
+    // Chip uses ⚠ variant and shows error count
+    const chip = screen.getByRole("button");
+    expect(chip.textContent).toContain("1 tool");
+    expect(chip.textContent).toContain("(1 error)");
+    expect(chip.textContent).toContain("3.2s");
+  });
+
+  it("renders pluralized tool count correctly", () => {
+    render(
+      <WhyPanel
+        message={msg({
+          trace: [
+            { kind: "tool_start", tool: "a" },
+            { kind: "tool_end", tool: "a", status: "ok", duration_ms: 5 },
+            { kind: "tool_start", tool: "b" },
+            { kind: "tool_end", tool: "b", status: "ok", duration_ms: 7 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText(/2 tools/)).toBeDefined();
+  });
+
+  it("shows usage summary when expanded", () => {
+    render(
+      <WhyPanel
+        message={msg({
+          trace: [
+            { kind: "tool_start", tool: "a" },
+            { kind: "tool_end", tool: "a", status: "ok", duration_ms: 5 },
+          ],
+          usage: { input_tokens: 1200, output_tokens: 80 },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/1280 tokens/)).toBeDefined();
+  });
+
+  it("shows UI action payload in the trace", () => {
+    render(
+      <WhyPanel
+        message={msg({
+          trace: [
+            { kind: "ui_action", payload: { colorBy: "gene", gene: "CD8A" } },
+          ],
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/"gene":"CD8A"/)).toBeDefined();
+  });
+});

--- a/packages/highperformer/src/chat/WhyPanel.tsx
+++ b/packages/highperformer/src/chat/WhyPanel.tsx
@@ -1,0 +1,164 @@
+/**
+ * Why panel — inline drop-down under an assistant turn that surfaces the
+ * agent's reasoning trace: tool calls (name + args + duration), UI actions,
+ * errors, and final usage. Spec: cell-explorer-py#96 design comment.
+ *
+ * v1 scope: inline placement under each assistant bubble, auto-expand on
+ * error, "Why" label, B+D chip variants. Reasoning text is not yet on the
+ * wire so no 💬 rows in v1.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { CaretDownOutlined, CaretRightOutlined, WarningOutlined } from "@ant-design/icons";
+import type { ChatMessage, TraceEntry } from "./types";
+
+type Stats = {
+  toolCount: number;
+  errorCount: number;
+  durationMs: number | null;
+  hasContent: boolean;
+};
+
+function computeStats(msg: ChatMessage): Stats {
+  const trace = msg.trace ?? [];
+  let toolCount = 0;
+  let errorCount = 0;
+  for (const e of trace) {
+    if (e.kind === "tool_end") toolCount++;
+    if (e.kind === "tool_end" && e.status === "error") errorCount++;
+    if (e.kind === "error") errorCount++;
+  }
+  const durationMs =
+    msg.startedAt != null && msg.endedAt != null
+      ? msg.endedAt - msg.startedAt
+      : null;
+  return {
+    toolCount,
+    errorCount,
+    durationMs,
+    hasContent: trace.length > 0 || !!msg.usage,
+  };
+}
+
+function fmtDuration(ms: number | null | undefined): string {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function fmtArgs(args: Record<string, unknown> | null | undefined): string {
+  if (!args || Object.keys(args).length === 0) return "()";
+  return JSON.stringify(args);
+}
+
+/** Compact JSON pretty-print with a max length; everything past the cap is replaced with "…". */
+function previewJson(value: unknown, max = 160): string {
+  const s = JSON.stringify(value);
+  if (!s) return "";
+  return s.length <= max ? s : s.slice(0, max) + "…";
+}
+
+export function WhyPanel({ message }: { message: ChatMessage }) {
+  const stats = useMemo(() => computeStats(message), [message]);
+  const hasError = stats.errorCount > 0;
+  const [open, setOpen] = useState(hasError);
+
+  // Auto-expand the first time an error appears mid-stream.
+  useEffect(() => {
+    if (hasError) setOpen(true);
+  }, [hasError]);
+
+  if (!stats.hasContent) return null;
+
+  const toolWord = stats.toolCount === 1 ? "tool" : "tools";
+  const summary = hasError
+    ? `${stats.toolCount} ${toolWord} (${stats.errorCount} error${stats.errorCount === 1 ? "" : "s"})`
+    : `${stats.toolCount} ${toolWord}`;
+
+  return (
+    <div style={{ marginTop: 4, fontSize: 12, color: "#666" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          color: hasError ? "#cf1322" : "#666",
+          cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          font: "inherit",
+        }}
+      >
+        {hasError ? (
+          <WarningOutlined />
+        ) : open ? (
+          <CaretDownOutlined />
+        ) : (
+          <CaretRightOutlined />
+        )}
+        <span>
+          Why · {summary} · {fmtDuration(stats.durationMs)}
+        </span>
+      </button>
+      {open && (
+        <div
+          style={{
+            marginTop: 6,
+            paddingLeft: 12,
+            borderLeft: "2px solid #eee",
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+          }}
+        >
+          {(message.trace ?? []).map((entry, i) => (
+            <TraceRow key={i} entry={entry} />
+          ))}
+          {message.usage && (
+            <div style={{ color: "#999", marginTop: 4 }}>
+              ✅ Done · {message.usage.input_tokens + message.usage.output_tokens} tokens
+              {" "}({message.usage.input_tokens} in / {message.usage.output_tokens} out)
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TraceRow({ entry }: { entry: TraceEntry }) {
+  switch (entry.kind) {
+    case "tool_start":
+      return (
+        <div>
+          🛠 <code>{entry.tool}{fmtArgs(entry.args)}</code>
+        </div>
+      );
+    case "tool_end": {
+      const icon = entry.status === "error" ? "❌" : "✓";
+      const color = entry.status === "error" ? "#cf1322" : "#52c41a";
+      return (
+        <div style={{ color, paddingLeft: 14 }}>
+          {icon} {fmtDuration(entry.duration_ms)}
+          {entry.summary && <span style={{ color: "#cf1322" }}> · {entry.summary}</span>}
+        </div>
+      );
+    }
+    case "ui_action":
+      return (
+        <div>
+          🎬 <code>{previewJson(entry.payload)}</code>
+        </div>
+      );
+    case "error":
+      return (
+        <div style={{ color: "#cf1322" }}>
+          ⚠ {entry.message}
+        </div>
+      );
+    default:
+      return null;
+  }
+}

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -31,17 +31,17 @@ describe("eventReducer.reduce", () => {
     expect(tools.map((t) => (t as { tool: string }).tool)).toEqual(["a", "b"]);
   });
 
-  it("ui_action calls applyConfig once with the payload, doesn't mutate state", () => {
+  it("ui_action calls applyConfig once with the payload and records a trace entry", () => {
     const apply = vi.fn();
     const before = initialState();
-    const after = reduce(
-      before,
-      { type: "ui_action", payload: { colorBy: "category", category: "T cells" } },
-      apply,
-    );
+    const payload = { colorBy: "category", category: "T cells" };
+    const after = reduce(before, { type: "ui_action", payload }, apply);
     expect(apply).toHaveBeenCalledTimes(1);
-    expect(apply).toHaveBeenCalledWith({ colorBy: "category", category: "T cells" });
-    expect(after).toBe(before); // no state mutation
+    expect(apply).toHaveBeenCalledWith(payload);
+    // Trace entry recorded for the Why panel; history/parts otherwise unchanged.
+    expect(after.history).toEqual(before.history);
+    expect(after.current?.parts ?? []).toEqual([]);
+    expect(after.current?.trace).toEqual([{ kind: "ui_action", payload }]);
   });
 
   it("ui_action: applyConfig callback may return a Promise (async-safe contract)", () => {

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -5,6 +5,7 @@ import type {
   TextPart,
   ToolPart,
   ErrorPart,
+  TraceEntry,
 } from "./types";
 
 export type State = {
@@ -18,7 +19,17 @@ export function initialState(): State {
 }
 
 function ensureCurrent(state: State): ChatMessage {
-  return state.current ?? { role: "assistant", parts: [] };
+  if (state.current) return state.current;
+  return {
+    role: "assistant",
+    parts: [],
+    trace: [],
+    startedAt: Date.now(),
+  };
+}
+
+function appendTrace(msg: ChatMessage, entry: TraceEntry): ChatMessage {
+  return { ...msg, trace: [...(msg.trace ?? []), entry] };
 }
 
 function mergeTextDelta(parts: MessagePart[], text: string): MessagePart[] {
@@ -32,16 +43,27 @@ function mergeTextDelta(parts: MessagePart[], text: string): MessagePart[] {
 
 function upsertToolPart(
   parts: MessagePart[],
-  ev: { tool: string; status: ToolPart["status"]; summary?: string },
+  ev: {
+    tool: string;
+    status: ToolPart["status"];
+    summary?: string;
+    args?: Record<string, unknown> | null;
+    duration_ms?: number | null;
+  },
 ): MessagePart[] {
   const idx = parts.findIndex(
     (p) => p.kind === "tool" && (p as ToolPart).tool === ev.tool,
   );
+  // Preserve args from the 'started' event when 'ok' / 'error' arrives
+  // without args. Preserve duration_ms from end event when later updates come.
+  const prev = idx === -1 ? undefined : (parts[idx] as ToolPart);
   const updated: ToolPart = {
     kind: "tool",
     tool: ev.tool,
     status: ev.status,
-    summary: ev.summary,
+    summary: ev.summary ?? prev?.summary,
+    args: ev.args ?? prev?.args,
+    duration_ms: ev.duration_ms ?? prev?.duration_ms,
   };
   if (idx === -1) return [...parts, updated];
   const next = parts.slice();
@@ -70,33 +92,52 @@ export function reduce(
     }
     case "tool_progress": {
       const cur = ensureCurrent(state);
+      const partsUpdated = upsertToolPart(cur.parts, {
+        tool: ev.tool,
+        status: ev.status,
+        summary: ev.summary,
+        args: ev.args,
+        duration_ms: ev.duration_ms,
+      });
+      const traceEntry: TraceEntry =
+        ev.status === "started"
+          ? { kind: "tool_start", tool: ev.tool, args: ev.args }
+          : {
+              kind: "tool_end",
+              tool: ev.tool,
+              status: ev.status,
+              summary: ev.summary,
+              duration_ms: ev.duration_ms,
+            };
       return {
         ...state,
-        current: {
-          ...cur,
-          parts: upsertToolPart(cur.parts, {
-            tool: ev.tool,
-            status: ev.status,
-            summary: ev.summary,
-          }),
-        },
+        current: appendTrace({ ...cur, parts: partsUpdated }, traceEntry),
         status: "streaming",
       };
     }
     case "ui_action": {
       applyConfig(ev.payload);
-      return state;
+      const cur = ensureCurrent(state);
+      return {
+        ...state,
+        current: appendTrace(cur, { kind: "ui_action", payload: ev.payload }),
+      };
     }
     case "error": {
       const cur = ensureCurrent(state);
       return {
         ...state,
-        current: { ...cur, parts: appendErrorPart(cur.parts, ev.message) },
+        current: appendTrace(
+          { ...cur, parts: appendErrorPart(cur.parts, ev.message) },
+          { kind: "error", message: ev.message },
+        ),
         status: "error",
       };
     }
     case "done": {
-      const cur = state.current;
+      const cur = state.current
+        ? { ...state.current, endedAt: Date.now(), usage: ev.usage }
+        : null;
       return {
         history: cur ? [...state.history, cur] : state.history,
         current: null,

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -75,6 +75,10 @@ export type ToolProgress = {
   tool: string;
   status: "started" | "ok" | "error";
   summary?: string;
+  /** Populated on the 'started' event — the tool's input arguments. */
+  args?: Record<string, unknown> | null;
+  /** Populated on the 'ok' / 'error' events — wall-clock since 'started'. */
+  duration_ms?: number | null;
 };
 export type UIAction     = { type: "ui_action"; payload: Record<string, unknown> };
 export type ErrorEvent   = { type: "error"; message: string; retryable: boolean };
@@ -104,13 +108,39 @@ export type ToolPart  = {
   tool: string;
   status: "started" | "ok" | "error";
   summary?: string;
+  args?: Record<string, unknown> | null;
+  duration_ms?: number | null;
 };
 export type ErrorPart = { kind: "error"; message: string };
 export type MessagePart = TextPart | ToolPart | ErrorPart;
 
+/**
+ * Per-turn event log used by the "Why" panel. Captures everything the agent
+ * did in chronological order (tool starts, tool ends, UI actions, errors).
+ * Distinct from `parts` — which holds only what renders inline in the chat
+ * bubble (text + tool widgets + errors).
+ */
+export type TraceEntry =
+  | { kind: "tool_start"; tool: string; args?: Record<string, unknown> | null }
+  | {
+      kind: "tool_end";
+      tool: string;
+      status: "ok" | "error";
+      summary?: string;
+      duration_ms?: number | null;
+    }
+  | { kind: "ui_action"; payload: Record<string, unknown> }
+  | { kind: "error"; message: string };
+
 export type ChatMessage = {
   role: "user" | "assistant";
   parts: MessagePart[];
+  /** Why-panel data — populated on assistant messages from the stream. */
+  trace?: TraceEntry[];
+  usage?: { input_tokens: number; output_tokens: number };
+  /** ms timestamps for computing total turn duration. */
+  startedAt?: number;
+  endedAt?: number;
 };
 
 // ---------- chip definitions ----------


### PR DESCRIPTION
Implements cell-explorer-py#96 v1 — surfaces what the agent did inline below each assistant message: tool calls with args + duration, UI actions, errors, and final token usage.

Collapsed by default with a one-line summary chip (`▼ Why · 2 tools · 3.2s`); auto-expands when the turn contains an error (`⚠ Why · 2 tools (1 error) · 3.2s`).

## What's new
- `ChatMessage` gains optional `trace: TraceEntry[]`, `usage`, `startedAt`, `endedAt`. `parts` still holds only the inline-rendered content.
- Reducer appends `tool_start` / `tool_end` / `ui_action` / `error` entries to `trace` as events arrive.
- `WhyPanel` renders the chip + expandable trace under each assistant bubble.
- `ToolProgress` wire type and `ToolPart` gain `args` and `duration_ms` (optional).

## Depends on
cell-explorer-py#104 (backend emits the new `args` / `duration_ms` fields). Fields are optional so this PR works even before the backend deploys — the chip just shows `—` for duration and `()` for empty args.

## Deferred from v1
- Reasoning (`💬`) rows — agent doesn't emit reasoning text on the wire yet
- Advanced toggle showing `view_state` + system prompt
- Tool-result rendering (would need backend to send results to client)
- Citation back-links (#97)
- Persistence on thread reload (#84 — backend stores messages, not trace)

## Test plan
- [x] 7 new WhyPanel tests cover chip rendering, expand/collapse, auto-expand-on-error, pluralization, usage summary, UI action rows
- [x] 1 reducer test updated for trace recording on ui_action
- [x] 376 highperformer tests pass total
- [x] Production build succeeds