### PR TITLE
feat(chat): render citation markers as links into the WhyPanel

### DIFF
--- a/.changeset/chat-citations.md
+++ b/.changeset/chat-citations.md
@@ -1,0 +1,15 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Render `[t:<tool_use_id>]` citation markers in assistant chat turns as
+clickable superscript links. Clicking a citation opens the WhyPanel
+and flashes the matching tool row so users can see where a fact came
+from. Markers in the same turn are numbered in order of first
+appearance — repeated ids reuse their original number.
+
+The agent emits the markers (per cell-explorer-py#105's system prompt
+instruction) and `ToolProgress` events carry a `tool_call_id`
+(cell-explorer-py#106) — the frontend wires these into citations and
+the WhyPanel's row anchors. Unknown/stale ids render as inert citation
+labels rather than blocking the text.

--- a/.changeset/chat-citations.md
+++ b/.changeset/chat-citations.md
@@ -2,14 +2,17 @@
 "@cbioportal-cell-explorer/highperformer": minor
 ---
 
-Render `[t:<tool_use_id>]` citation markers in assistant chat turns as
-clickable superscript links. Clicking a citation opens the WhyPanel
-and flashes the matching tool row so users can see where a fact came
-from. Markers in the same turn are numbered in order of first
-appearance — repeated ids reuse their original number.
+Render citation markers in assistant chat turns as clickable
+superscript links. The agent (cell-explorer-py#107) emits `[t:N]`
+markers where N is the 1-based ordinal of the tool call within the
+current turn; the frontend resolves each ordinal to the Nth
+`tool_start` entry in the trace and renders a numbered link.
+Clicking opens the WhyPanel (if collapsed) and flashes the matching
+tool row so users can see where a fact came from.
 
-The agent emits the markers (per cell-explorer-py#105's system prompt
-instruction) and `ToolProgress` events carry a `tool_call_id`
-(cell-explorer-py#106) — the frontend wires these into citations and
-the WhyPanel's row anchors. Unknown/stale ids render as inert citation
-labels rather than blocking the text.
+Ordinals are used instead of raw `tool_use_id`s because models can't
+reliably reproduce 25-character random strings during free-form
+generation. Single-digit ordinals are within their working memory and
+the frontend's position-based lookup is deterministic — citations
+that appear always point to a real tool row. Out-of-range ordinals
+(if the model hallucinates one) render as inert grey labels.

--- a/packages/highperformer/src/chat/AssistantBubble.test.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.test.tsx
@@ -1,20 +1,20 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { AssistantBubble } from "./AssistantBubble";
 import type { ChatMessage } from "./types";
 
 afterEach(() => cleanup());
 
-function withCitation(text: string, toolId: string): ChatMessage {
+function withOneTool(text: string): ChatMessage {
   return {
     role: "assistant",
     parts: [{ kind: "text", text }],
     trace: [
-      { kind: "tool_start", tool: "compare_groups", tool_call_id: toolId, args: {} },
+      { kind: "tool_start", tool: "compare_groups", tool_call_id: "id_1", args: {} },
       {
         kind: "tool_end",
         tool: "compare_groups",
-        tool_call_id: toolId,
+        tool_call_id: "id_1",
         status: "ok",
         duration_ms: 245,
       },
@@ -35,14 +35,13 @@ describe("AssistantBubble", () => {
       />,
     );
     expect(screen.getByText(/no citations here/)).toBeDefined();
-    // No superscript link rendered
     expect(screen.queryByRole("link")).toBeNull();
   });
 
-  it("renders [t:<id>] as a clickable citation link", () => {
+  it("renders [t:N] as a clickable citation link", () => {
     render(
       <AssistantBubble
-        message={withCitation("Top gene is CD8A [t:toolu_abc] in cluster 3.", "toolu_abc")}
+        message={withOneTool("Top gene is CD8A [t:1] in cluster 3.")}
       />,
     );
     const link = screen.getByRole("link", { name: /citation 1/i });
@@ -50,39 +49,28 @@ describe("AssistantBubble", () => {
     expect(link.textContent).toBe("[1]");
   });
 
-  it("numbers multiple distinct tool ids in order of first appearance", () => {
+  it("renders out-of-range ordinals as inert grey labels (no link)", () => {
     render(
       <AssistantBubble
-        message={{
-          role: "assistant",
-          parts: [
-            {
-              kind: "text",
-              text: "First [t:b] then [t:a] then [t:b] again.",
-            },
-          ],
-          trace: [],
-        }}
+        message={withOneTool("Citing the second tool [t:2] (but only one ran).")}
       />,
     );
-    const links = screen.getAllByRole("link");
-    // 'b' was seen first → index 1. 'a' next → index 2. 'b' again → reuses 1.
-    expect(links.map((l) => l.textContent)).toEqual(["[1]", "[2]", "[1]"]);
+    // No link role for an invalid ordinal.
+    expect(screen.queryByRole("link")).toBeNull();
+    // The number still renders so the text doesn't show a raw [t:2] literal.
+    expect(screen.getByLabelText(/citation 2 \(no source\)/i)).toBeDefined();
   });
 
   it("clicking a citation opens the WhyPanel and shows the cited tool row", () => {
-    render(
-      <AssistantBubble
-        message={withCitation("CD8A [t:toolu_abc].", "toolu_abc")}
-      />,
-    );
+    render(<AssistantBubble message={withOneTool("CD8A [t:1].")} />);
     // Panel collapsed initially — tool row not visible
     expect(screen.queryByText(/compare_groups/)).toBeNull();
     fireEvent.click(screen.getByRole("link", { name: /citation 1/i }));
-    // Panel auto-expanded; tool row now visible and tagged with the id
-    const row = screen.getByText(/compare_groups/).closest("[data-tool-id]");
+    // Panel auto-expanded; tool row visible with the [1] label
+    const row = screen.getByText(/compare_groups/).closest("[data-cite-ordinal]");
     expect(row).not.toBeNull();
-    expect(row!.getAttribute("data-tool-id")).toBe("toolu_abc");
+    expect(row!.getAttribute("data-cite-ordinal")).toBe("1");
+    expect(row!.textContent).toContain("[1]");
   });
 
   it("renders tool tag pills inline (legacy ToolPart rendering preserved)", () => {

--- a/packages/highperformer/src/chat/AssistantBubble.test.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { AssistantBubble } from "./AssistantBubble";
+import type { ChatMessage } from "./types";
+
+afterEach(() => cleanup());
+
+function withCitation(text: string, toolId: string): ChatMessage {
+  return {
+    role: "assistant",
+    parts: [{ kind: "text", text }],
+    trace: [
+      { kind: "tool_start", tool: "compare_groups", tool_call_id: toolId, args: {} },
+      {
+        kind: "tool_end",
+        tool: "compare_groups",
+        tool_call_id: toolId,
+        status: "ok",
+        duration_ms: 245,
+      },
+    ],
+    startedAt: 0,
+    endedAt: 1000,
+  };
+}
+
+describe("AssistantBubble", () => {
+  it("renders text without citation markers as plain text", () => {
+    render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [{ kind: "text", text: "no citations here" }],
+        }}
+      />,
+    );
+    expect(screen.getByText(/no citations here/)).toBeDefined();
+    // No superscript link rendered
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders [t:<id>] as a clickable citation link", () => {
+    render(
+      <AssistantBubble
+        message={withCitation("Top gene is CD8A [t:toolu_abc] in cluster 3.", "toolu_abc")}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /citation 1/i });
+    expect(link).toBeDefined();
+    expect(link.textContent).toBe("[1]");
+  });
+
+  it("numbers multiple distinct tool ids in order of first appearance", () => {
+    render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [
+            {
+              kind: "text",
+              text: "First [t:b] then [t:a] then [t:b] again.",
+            },
+          ],
+          trace: [],
+        }}
+      />,
+    );
+    const links = screen.getAllByRole("link");
+    // 'b' was seen first → index 1. 'a' next → index 2. 'b' again → reuses 1.
+    expect(links.map((l) => l.textContent)).toEqual(["[1]", "[2]", "[1]"]);
+  });
+
+  it("clicking a citation opens the WhyPanel and shows the cited tool row", () => {
+    render(
+      <AssistantBubble
+        message={withCitation("CD8A [t:toolu_abc].", "toolu_abc")}
+      />,
+    );
+    // Panel collapsed initially — tool row not visible
+    expect(screen.queryByText(/compare_groups/)).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: /citation 1/i }));
+    // Panel auto-expanded; tool row now visible and tagged with the id
+    const row = screen.getByText(/compare_groups/).closest("[data-tool-id]");
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute("data-tool-id")).toBe("toolu_abc");
+  });
+
+  it("renders tool tag pills inline (legacy ToolPart rendering preserved)", () => {
+    render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [
+            { kind: "text", text: "Running it now: " },
+            { kind: "tool", tool: "compare_groups", status: "started" },
+          ],
+          trace: [],
+        }}
+      />,
+    );
+    expect(screen.getByText(/compare_groups/)).toBeDefined();
+  });
+});

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -1,0 +1,172 @@
+/**
+ * AssistantBubble — renders one assistant turn (text/tool/error parts + the
+ * WhyPanel below) and orchestrates the citation handshake:
+ *
+ *   1. Scan the message's text for [t:<id>] markers; assign each unique id a
+ *      1-based index (so the first cited tool is "[1]", the second "[2]", etc.)
+ *   2. Render text through ReactMarkdown with a components override that
+ *      replaces marker substrings with Citation link components
+ *   3. When a citation is clicked, open the WhyPanel and flash the matching
+ *      tool row (cleared after 2 seconds)
+ */
+import { useCallback, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Alert, Tag } from "antd";
+import { Citation } from "./Citation";
+import { parseCitations } from "./citations";
+import { WhyPanel } from "./WhyPanel";
+import type { ChatMessage, MessagePart, ToolPart } from "./types";
+
+const FLASH_MS = 2000;
+
+/** Walk through ReactMarkdown's children and replace [t:<id>] in text nodes. */
+function withCitations(
+  children: ReactNode,
+  citeIndex: Map<string, number>,
+  onCite: (id: string) => void,
+): ReactNode {
+  return walk(children, citeIndex, onCite);
+}
+
+function walk(
+  node: ReactNode,
+  citeIndex: Map<string, number>,
+  onCite: (id: string) => void,
+): ReactNode {
+  if (typeof node === "string") {
+    const segments = parseCitations(node);
+    if (segments.length === 1 && segments[0].kind === "text") return node;
+    return segments.map((seg, i) =>
+      seg.kind === "text" ? (
+        seg.text
+      ) : (
+        <Citation
+          key={`cite-${i}-${seg.toolId}`}
+          toolId={seg.toolId}
+          index={citeIndex.get(seg.toolId) ?? 0}
+          onCite={onCite}
+        />
+      ),
+    );
+  }
+  if (Array.isArray(node)) {
+    return node.map((child) => walk(child, citeIndex, onCite));
+  }
+  return node;
+}
+
+function buildCitationIndex(message: ChatMessage): Map<string, number> {
+  const index = new Map<string, number>();
+  let next = 1;
+  for (const p of message.parts) {
+    if (p.kind !== "text") continue;
+    for (const m of p.text.matchAll(/\[t:([A-Za-z0-9_-]+)\]/g)) {
+      const id = m[1];
+      if (!index.has(id)) {
+        index.set(id, next++);
+      }
+    }
+  }
+  return index;
+}
+
+function ToolPartTag({ part }: { part: ToolPart }) {
+  const sym = part.status === "started" ? "▶" : part.status === "ok" ? "✓" : "✗";
+  const color = part.status === "error" ? "red" : part.status === "ok" ? "green" : "blue";
+  return (
+    <Tag color={color}>
+      {sym} {part.tool}
+      {part.summary ? ` — ${part.summary}` : part.status === "started" ? "…" : ""}
+    </Tag>
+  );
+}
+
+export type AssistantBubbleProps = {
+  message: ChatMessage;
+  /** Inherited from the parent — controls antd-table layout etc. */
+  markdownComponents?: Components;
+};
+
+export function AssistantBubble({ message, markdownComponents }: AssistantBubbleProps) {
+  const [whyOpen, setWhyOpen] = useState(false);
+  const [flashToolId, setFlashToolId] = useState<string | null>(null);
+
+  const citeIndex = useMemo(() => buildCitationIndex(message), [message]);
+
+  const onCite = useCallback((toolId: string) => {
+    setWhyOpen(true);
+    setFlashToolId(toolId);
+    window.setTimeout(() => setFlashToolId(null), FLASH_MS);
+  }, []);
+
+  const componentsWithCitations: Components = useMemo(() => {
+    const base = markdownComponents ?? {};
+    // Wrap the components that commonly host text content so their text
+    // children get scanned for citation markers. Block-level tags only —
+    // citations land inside paragraphs, list items, table cells, and code.
+    const wrap = <T extends keyof JSX.IntrinsicElements>(
+      tag: T,
+      baseRenderer?: Components[T],
+    ) => {
+      const Wrapped = (props: { children?: ReactNode } & Record<string, unknown>) => {
+        const transformed = withCitations(props.children, citeIndex, onCite);
+        if (baseRenderer) {
+          const Renderer = baseRenderer as (p: typeof props) => ReactNode;
+          return <>{Renderer({ ...props, children: transformed })}</>;
+        }
+        const Tag = tag as keyof JSX.IntrinsicElements;
+        return <Tag {...(props as Record<string, unknown>)}>{transformed}</Tag>;
+      };
+      return Wrapped as Components[T];
+    };
+    return {
+      ...base,
+      p: wrap("p", base.p),
+      li: wrap("li", base.li),
+      td: wrap("td", base.td),
+      th: wrap("th", base.th),
+      strong: wrap("strong", base.strong),
+      em: wrap("em", base.em),
+    };
+  }, [markdownComponents, citeIndex, onCite]);
+
+  return (
+    <div>
+      {message.parts.map((p, i) => (
+        <PartView
+          key={i}
+          part={p}
+          markdownComponents={componentsWithCitations}
+        />
+      ))}
+      <WhyPanel
+        message={message}
+        open={whyOpen}
+        onOpenChange={setWhyOpen}
+        flashToolId={flashToolId}
+      />
+    </div>
+  );
+}
+
+function PartView({
+  part,
+  markdownComponents,
+}: {
+  part: MessagePart;
+  markdownComponents: Components;
+}) {
+  if (part.kind === "text") {
+    return (
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {part.text}
+      </ReactMarkdown>
+    );
+  }
+  if (part.kind === "tool") {
+    return <ToolPartTag part={part} />;
+  }
+  return <Alert type="error" message={part.message} showIcon style={{ marginTop: 8 }} />;
+}

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -1,13 +1,13 @@
 /**
  * AssistantBubble — renders one assistant turn (text/tool/error parts + the
- * WhyPanel below) and orchestrates the citation handshake:
+ * WhyPanel below) and orchestrates the citation handshake.
  *
- *   1. Scan the message's text for [t:<id>] markers; assign each unique id a
- *      1-based index (so the first cited tool is "[1]", the second "[2]", etc.)
- *   2. Render text through ReactMarkdown with a components override that
- *      replaces marker substrings with Citation link components
- *   3. When a citation is clicked, open the WhyPanel and flash the matching
- *      tool row (cleared after 2 seconds)
+ * Citations use ordinals (the model emits `[t:1]`, `[t:2]`, ...). The ordinal
+ * resolves to a tool by position in the trace — `[t:N]` → the Nth `tool_start`
+ * entry. Out-of-range ordinals render as inert grey labels.
+ *
+ * When a citation is clicked, the WhyPanel opens (if collapsed) and the
+ * corresponding tool row flashes; the flash clears after a short timeout.
  */
 import { useCallback, useMemo, useState } from "react";
 import type { ReactNode } from "react";
@@ -21,19 +21,16 @@ import type { ChatMessage, MessagePart, ToolPart } from "./types";
 
 const FLASH_MS = 2000;
 
-/** Walk through ReactMarkdown's children and replace [t:<id>] in text nodes. */
-function withCitations(
-  children: ReactNode,
-  citeIndex: Map<string, number>,
-  onCite: (id: string) => void,
-): ReactNode {
-  return walk(children, citeIndex, onCite);
+/** Total number of `tool_start` entries in this message's trace. */
+function toolCount(message: ChatMessage): number {
+  return (message.trace ?? []).filter((e) => e.kind === "tool_start").length;
 }
 
+/** Walk through ReactMarkdown's children and replace [t:N] in text nodes. */
 function walk(
   node: ReactNode,
-  citeIndex: Map<string, number>,
-  onCite: (id: string) => void,
+  maxOrdinal: number,
+  onCite: (ordinal: number) => void,
 ): ReactNode {
   if (typeof node === "string") {
     const segments = parseCitations(node);
@@ -43,33 +40,18 @@ function walk(
         seg.text
       ) : (
         <Citation
-          key={`cite-${i}-${seg.toolId}`}
-          toolId={seg.toolId}
-          index={citeIndex.get(seg.toolId) ?? 0}
+          key={`cite-${i}-${seg.ordinal}`}
+          ordinal={seg.ordinal}
+          valid={seg.ordinal >= 1 && seg.ordinal <= maxOrdinal}
           onCite={onCite}
         />
       ),
     );
   }
   if (Array.isArray(node)) {
-    return node.map((child) => walk(child, citeIndex, onCite));
+    return node.map((child) => walk(child, maxOrdinal, onCite));
   }
   return node;
-}
-
-function buildCitationIndex(message: ChatMessage): Map<string, number> {
-  const index = new Map<string, number>();
-  let next = 1;
-  for (const p of message.parts) {
-    if (p.kind !== "text") continue;
-    for (const m of p.text.matchAll(/\[t:([A-Za-z0-9_-]+)\]/g)) {
-      const id = m[1];
-      if (!index.has(id)) {
-        index.set(id, next++);
-      }
-    }
-  }
-  return index;
 }
 
 function ToolPartTag({ part }: { part: ToolPart }) {
@@ -91,14 +73,14 @@ export type AssistantBubbleProps = {
 
 export function AssistantBubble({ message, markdownComponents }: AssistantBubbleProps) {
   const [whyOpen, setWhyOpen] = useState(false);
-  const [flashToolId, setFlashToolId] = useState<string | null>(null);
+  const [flashOrdinal, setFlashOrdinal] = useState<number | null>(null);
 
-  const citeIndex = useMemo(() => buildCitationIndex(message), [message]);
+  const maxOrdinal = useMemo(() => toolCount(message), [message]);
 
-  const onCite = useCallback((toolId: string) => {
+  const onCite = useCallback((ordinal: number) => {
     setWhyOpen(true);
-    setFlashToolId(toolId);
-    window.setTimeout(() => setFlashToolId(null), FLASH_MS);
+    setFlashOrdinal(ordinal);
+    window.setTimeout(() => setFlashOrdinal(null), FLASH_MS);
   }, []);
 
   const componentsWithCitations: Components = useMemo(() => {
@@ -111,7 +93,7 @@ export function AssistantBubble({ message, markdownComponents }: AssistantBubble
       baseRenderer?: Components[T],
     ) => {
       const Wrapped = (props: { children?: ReactNode } & Record<string, unknown>) => {
-        const transformed = withCitations(props.children, citeIndex, onCite);
+        const transformed = walk(props.children, maxOrdinal, onCite);
         if (baseRenderer) {
           const Renderer = baseRenderer as (p: typeof props) => ReactNode;
           return <>{Renderer({ ...props, children: transformed })}</>;
@@ -130,7 +112,7 @@ export function AssistantBubble({ message, markdownComponents }: AssistantBubble
       strong: wrap("strong", base.strong),
       em: wrap("em", base.em),
     };
-  }, [markdownComponents, citeIndex, onCite]);
+  }, [markdownComponents, maxOrdinal, onCite]);
 
   return (
     <div>
@@ -145,7 +127,7 @@ export function AssistantBubble({ message, markdownComponents }: AssistantBubble
         message={message}
         open={whyOpen}
         onOpenChange={setWhyOpen}
-        flashToolId={flashToolId}
+        flashOrdinal={flashOrdinal}
       />
     </div>
   );

--- a/packages/highperformer/src/chat/Citation.tsx
+++ b/packages/highperformer/src/chat/Citation.tsx
@@ -1,0 +1,38 @@
+/**
+ * Citation link — rendered in place of a [t:<id>] marker in assistant text.
+ * Clicking calls onCite, which (in the parent AssistantBubble) opens the
+ * WhyPanel and scroll/flashes the referenced tool row.
+ */
+import type { MouseEvent } from "react";
+
+export type CitationProps = {
+  toolId: string;
+  index: number; // 1-based; rendered as the superscript label
+  onCite: (toolId: string) => void;
+};
+
+export function Citation({ toolId, index, onCite }: CitationProps) {
+  const handleClick = (e: MouseEvent) => {
+    e.preventDefault();
+    onCite(toolId);
+  };
+  return (
+    <sup>
+      <a
+        href={`#tool-${toolId}`}
+        onClick={handleClick}
+        title={`Source: tool call ${toolId}`}
+        aria-label={`citation ${index}`}
+        style={{
+          color: "#1677ff",
+          textDecoration: "none",
+          fontSize: "0.75em",
+          padding: "0 2px",
+          cursor: "pointer",
+        }}
+      >
+        [{index}]
+      </a>
+    </sup>
+  );
+}

--- a/packages/highperformer/src/chat/Citation.tsx
+++ b/packages/highperformer/src/chat/Citation.tsx
@@ -1,37 +1,53 @@
 /**
- * Citation link — rendered in place of a [t:<id>] marker in assistant text.
- * Clicking calls onCite, which (in the parent AssistantBubble) opens the
- * WhyPanel and scroll/flashes the referenced tool row.
+ * Citation link — rendered in place of a [t:N] ordinal marker in assistant text.
+ * Clicking calls onCite(ordinal), which (in the parent AssistantBubble) opens
+ * the WhyPanel and scroll/flashes the matching tool row by position in the
+ * turn's trace.
+ *
+ * `valid=false` renders the same number with reduced affordance — no
+ * underline, not clickable — so out-of-range ordinals from a hallucinating
+ * model degrade gracefully instead of throwing the layout off.
  */
 import type { MouseEvent } from "react";
 
 export type CitationProps = {
-  toolId: string;
-  index: number; // 1-based; rendered as the superscript label
-  onCite: (toolId: string) => void;
+  ordinal: number;
+  valid: boolean;
+  onCite: (ordinal: number) => void;
 };
 
-export function Citation({ toolId, index, onCite }: CitationProps) {
+export function Citation({ ordinal, valid, onCite }: CitationProps) {
   const handleClick = (e: MouseEvent) => {
     e.preventDefault();
-    onCite(toolId);
+    if (valid) onCite(ordinal);
   };
+  const baseStyle = {
+    fontSize: "0.75em",
+    padding: "0 2px",
+  };
+  if (!valid) {
+    return (
+      <sup>
+        <span
+          title={`Source ${ordinal} (not in this turn)`}
+          aria-label={`citation ${ordinal} (no source)`}
+          style={{ ...baseStyle, color: "#999" }}
+        >
+          [{ordinal}]
+        </span>
+      </sup>
+    );
+  }
   return (
     <sup>
       <a
-        href={`#tool-${toolId}`}
+        href={`#cite-${ordinal}`}
         onClick={handleClick}
-        title={`Source: tool call ${toolId}`}
-        aria-label={`citation ${index}`}
-        style={{
-          color: "#1677ff",
-          textDecoration: "none",
-          fontSize: "0.75em",
-          padding: "0 2px",
-          cursor: "pointer",
-        }}
+        title={`Source: tool call #${ordinal}`}
+        aria-label={`citation ${ordinal}`}
+        style={{ ...baseStyle, color: "#1677ff", textDecoration: "none", cursor: "pointer" }}
       >
-        [{index}]
+        [{ordinal}]
       </a>
     </sup>
   );

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -8,7 +8,7 @@ import { initialState, reduce, type State } from "./eventReducer";
 import { deriveSuggestionChips } from "./suggestionChips";
 import type { ChatEvent, ChatMessage, ContextResponse, MessagePart, WireMessage } from "./types";
 import { useChatTurn } from "./useChatTurn";
-import { WhyPanel } from "./WhyPanel";
+import { AssistantBubble } from "./AssistantBubble";
 
 type Action =
   | { type: "AGENT_EVENT"; event: ChatEvent }
@@ -236,19 +236,23 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
             {state.history.map((m, i) => (
               <div key={i}>
                 <strong>{m.role === "user" ? "You: " : "Assistant: "}</strong>
-                {m.parts.map((p, j) => (
-                  <MessagePartView key={j} part={p} />
-                ))}
-                {m.role === "assistant" && <WhyPanel message={m} />}
+                {m.role === "assistant" ? (
+                  <AssistantBubble
+                    message={m}
+                    markdownComponents={markdownComponents}
+                  />
+                ) : (
+                  m.parts.map((p, j) => <MessagePartView key={j} part={p} />)
+                )}
               </div>
             ))}
             {state.current && (
               <div>
                 <strong>Assistant: </strong>
-                {state.current.parts.map((p, j) => (
-                  <MessagePartView key={j} part={p} />
-                ))}
-                <WhyPanel message={state.current} />
+                <AssistantBubble
+                  message={state.current}
+                  markdownComponents={markdownComponents}
+                />
               </div>
             )}
             {hasError && (

--- a/packages/highperformer/src/chat/WhyPanel.tsx
+++ b/packages/highperformer/src/chat/WhyPanel.tsx
@@ -7,7 +7,7 @@
  * error, "Why" label, B+D chip variants. Reasoning text is not yet on the
  * wire so no 💬 rows in v1.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CaretDownOutlined, CaretRightOutlined, WarningOutlined } from "@ant-design/icons";
 import type { ChatMessage, TraceEntry } from "./types";
 
@@ -57,15 +57,48 @@ function previewJson(value: unknown, max = 160): string {
   return s.length <= max ? s : s.slice(0, max) + "…";
 }
 
-export function WhyPanel({ message }: { message: ChatMessage }) {
+export type WhyPanelProps = {
+  message: ChatMessage;
+  /** Controlled-open flag. When undefined the component manages its own state. */
+  open?: boolean;
+  onOpenChange?: (next: boolean) => void;
+  /**
+   * When set, the row with matching tool_call_id renders with a flash effect
+   * (used to draw the eye after a citation click). Set back to null after
+   * a few seconds in the parent.
+   */
+  flashToolId?: string | null;
+};
+
+export function WhyPanel({ message, open: openProp, onOpenChange, flashToolId }: WhyPanelProps) {
   const stats = useMemo(() => computeStats(message), [message]);
   const hasError = stats.errorCount > 0;
-  const [open, setOpen] = useState(hasError);
+  const [openSelf, setOpenSelf] = useState(hasError);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp! : openSelf;
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setOpenSelf(next);
+    onOpenChange?.(next);
+  };
 
   // Auto-expand the first time an error appears mid-stream.
   useEffect(() => {
     if (hasError) setOpen(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasError]);
+
+  // Scroll the flashed tool row into view when a citation is clicked.
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!open || !flashToolId || !containerRef.current) return;
+    const row = containerRef.current.querySelector(
+      `[data-tool-id="${flashToolId}"]`,
+    );
+    if (row && row instanceof HTMLElement) {
+      // jsdom and some embedded webviews lack scrollIntoView — flash still works.
+      row.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
+    }
+  }, [open, flashToolId]);
 
   if (!stats.hasContent) return null;
 
@@ -104,6 +137,7 @@ export function WhyPanel({ message }: { message: ChatMessage }) {
       </button>
       {open && (
         <div
+          ref={containerRef}
           style={{
             marginTop: 6,
             paddingLeft: 12,
@@ -114,7 +148,7 @@ export function WhyPanel({ message }: { message: ChatMessage }) {
           }}
         >
           {(message.trace ?? []).map((entry, i) => (
-            <TraceRow key={i} entry={entry} />
+            <TraceRow key={i} entry={entry} flash={isFlashed(entry, flashToolId)} />
           ))}
           {message.usage && (
             <div style={{ color: "#999", marginTop: 4 }}>
@@ -128,11 +162,33 @@ export function WhyPanel({ message }: { message: ChatMessage }) {
   );
 }
 
-function TraceRow({ entry }: { entry: TraceEntry }) {
+function isFlashed(entry: TraceEntry, flashToolId?: string | null): boolean {
+  if (!flashToolId) return false;
+  return (
+    (entry.kind === "tool_start" || entry.kind === "tool_end") &&
+    entry.tool_call_id === flashToolId
+  );
+}
+
+function TraceRow({ entry, flash }: { entry: TraceEntry; flash: boolean }) {
+  const flashStyle: React.CSSProperties = flash
+    ? {
+        background: "#fff3bf",
+        transition: "background 1.2s ease-out",
+        borderRadius: 3,
+        padding: "1px 4px",
+        margin: "-1px -4px",
+      }
+    : {};
+
   switch (entry.kind) {
     case "tool_start":
       return (
-        <div>
+        <div
+          id={entry.tool_call_id ? `tool-${entry.tool_call_id}` : undefined}
+          data-tool-id={entry.tool_call_id ?? undefined}
+          style={flashStyle}
+        >
           🛠 <code>{entry.tool}{fmtArgs(entry.args)}</code>
         </div>
       );
@@ -140,7 +196,10 @@ function TraceRow({ entry }: { entry: TraceEntry }) {
       const icon = entry.status === "error" ? "❌" : "✓";
       const color = entry.status === "error" ? "#cf1322" : "#52c41a";
       return (
-        <div style={{ color, paddingLeft: 14 }}>
+        <div
+          data-tool-id={entry.tool_call_id ?? undefined}
+          style={{ color, paddingLeft: 14, ...flashStyle }}
+        >
           {icon} {fmtDuration(entry.duration_ms)}
           {entry.summary && <span style={{ color: "#cf1322" }}> · {entry.summary}</span>}
         </div>

--- a/packages/highperformer/src/chat/WhyPanel.tsx
+++ b/packages/highperformer/src/chat/WhyPanel.tsx
@@ -63,14 +63,18 @@ export type WhyPanelProps = {
   open?: boolean;
   onOpenChange?: (next: boolean) => void;
   /**
-   * When set, the row with matching tool_call_id renders with a flash effect
-   * (used to draw the eye after a citation click). Set back to null after
-   * a few seconds in the parent.
+   * 1-based ordinal of the tool row to flash (used after a citation click).
+   * Resolves to the Nth `tool_start` entry in the trace; null to clear.
    */
-  flashToolId?: string | null;
+  flashOrdinal?: number | null;
 };
 
-export function WhyPanel({ message, open: openProp, onOpenChange, flashToolId }: WhyPanelProps) {
+export function WhyPanel({
+  message,
+  open: openProp,
+  onOpenChange,
+  flashOrdinal,
+}: WhyPanelProps) {
   const stats = useMemo(() => computeStats(message), [message]);
   const hasError = stats.errorCount > 0;
   const [openSelf, setOpenSelf] = useState(hasError);
@@ -90,15 +94,15 @@ export function WhyPanel({ message, open: openProp, onOpenChange, flashToolId }:
   // Scroll the flashed tool row into view when a citation is clicked.
   const containerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (!open || !flashToolId || !containerRef.current) return;
+    if (!open || flashOrdinal == null || !containerRef.current) return;
     const row = containerRef.current.querySelector(
-      `[data-tool-id="${flashToolId}"]`,
+      `[data-cite-ordinal="${flashOrdinal}"]`,
     );
     if (row && row instanceof HTMLElement) {
       // jsdom and some embedded webviews lack scrollIntoView — flash still works.
       row.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
     }
-  }, [open, flashToolId]);
+  }, [open, flashOrdinal]);
 
   if (!stats.hasContent) return null;
 
@@ -147,9 +151,23 @@ export function WhyPanel({ message, open: openProp, onOpenChange, flashToolId }:
             gap: 4,
           }}
         >
-          {(message.trace ?? []).map((entry, i) => (
-            <TraceRow key={i} entry={entry} flash={isFlashed(entry, flashToolId)} />
-          ))}
+          {(() => {
+            // Assign each tool_start a 1-based ordinal matching the citation
+            // markers ([t:N]) emitted by the agent. The trace's tool_end and
+            // ui_action entries don't get ordinals — only tool_start.
+            let nextOrdinal = 1;
+            return (message.trace ?? []).map((entry, i) => {
+              const ord = entry.kind === "tool_start" ? nextOrdinal++ : null;
+              return (
+                <TraceRow
+                  key={i}
+                  entry={entry}
+                  ordinal={ord}
+                  flash={ord != null && ord === flashOrdinal}
+                />
+              );
+            });
+          })()}
           {message.usage && (
             <div style={{ color: "#999", marginTop: 4 }}>
               ✅ Done · {message.usage.input_tokens + message.usage.output_tokens} tokens
@@ -162,15 +180,16 @@ export function WhyPanel({ message, open: openProp, onOpenChange, flashToolId }:
   );
 }
 
-function isFlashed(entry: TraceEntry, flashToolId?: string | null): boolean {
-  if (!flashToolId) return false;
-  return (
-    (entry.kind === "tool_start" || entry.kind === "tool_end") &&
-    entry.tool_call_id === flashToolId
-  );
-}
-
-function TraceRow({ entry, flash }: { entry: TraceEntry; flash: boolean }) {
+function TraceRow({
+  entry,
+  ordinal,
+  flash,
+}: {
+  entry: TraceEntry;
+  /** 1-based ordinal for tool_start; null for non-tool rows. */
+  ordinal: number | null;
+  flash: boolean;
+}) {
   const flashStyle: React.CSSProperties = flash
     ? {
         background: "#fff3bf",
@@ -185,10 +204,15 @@ function TraceRow({ entry, flash }: { entry: TraceEntry; flash: boolean }) {
     case "tool_start":
       return (
         <div
-          id={entry.tool_call_id ? `tool-${entry.tool_call_id}` : undefined}
-          data-tool-id={entry.tool_call_id ?? undefined}
+          id={ordinal != null ? `cite-${ordinal}` : undefined}
+          data-cite-ordinal={ordinal ?? undefined}
           style={flashStyle}
         >
+          {ordinal != null && (
+            <span style={{ color: "#1677ff", fontWeight: 600, marginRight: 4 }}>
+              [{ordinal}]
+            </span>
+          )}
           🛠 <code>{entry.tool}{fmtArgs(entry.args)}</code>
         </div>
       );
@@ -196,10 +220,7 @@ function TraceRow({ entry, flash }: { entry: TraceEntry; flash: boolean }) {
       const icon = entry.status === "error" ? "❌" : "✓";
       const color = entry.status === "error" ? "#cf1322" : "#52c41a";
       return (
-        <div
-          data-tool-id={entry.tool_call_id ?? undefined}
-          style={{ color, paddingLeft: 14, ...flashStyle }}
-        >
+        <div style={{ color, paddingLeft: 14, ...flashStyle }}>
           {icon} {fmtDuration(entry.duration_ms)}
           {entry.summary && <span style={{ color: "#cf1322" }}> · {entry.summary}</span>}
         </div>

--- a/packages/highperformer/src/chat/citations.test.ts
+++ b/packages/highperformer/src/chat/citations.test.ts
@@ -8,19 +8,25 @@ describe("parseCitations", () => {
     ]);
   });
 
-  it("extracts a single marker between text segments", () => {
-    expect(parseCitations("The top gene is CD8A [t:toolu_abc] in cluster 3.")).toEqual([
+  it("extracts an ordinal marker between text segments", () => {
+    expect(parseCitations("The top gene is CD8A [t:1] in cluster 3.")).toEqual([
       { kind: "text", text: "The top gene is CD8A " },
-      { kind: "citation", toolId: "toolu_abc", raw: "[t:toolu_abc]" },
+      { kind: "citation", ordinal: 1, raw: "[t:1]" },
       { kind: "text", text: " in cluster 3." },
     ]);
   });
 
   it("handles back-to-back markers with no separator", () => {
-    expect(parseCitations("CD8A, GZMB [t:a][t:b]")).toEqual([
+    expect(parseCitations("CD8A, GZMB [t:1][t:2]")).toEqual([
       { kind: "text", text: "CD8A, GZMB " },
-      { kind: "citation", toolId: "a", raw: "[t:a]" },
-      { kind: "citation", toolId: "b", raw: "[t:b]" },
+      { kind: "citation", ordinal: 1, raw: "[t:1]" },
+      { kind: "citation", ordinal: 2, raw: "[t:2]" },
+    ]);
+  });
+
+  it("only matches digit ordinals — letter-shaped markers are plain text", () => {
+    expect(parseCitations("see [t:abc] not a citation")).toEqual([
+      { kind: "text", text: "see [t:abc] not a citation" },
     ]);
   });
 
@@ -30,17 +36,17 @@ describe("parseCitations", () => {
     ]);
   });
 
-  it("accepts hyphens and underscores in tool ids", () => {
-    expect(parseCitations("ok [t:my-tool_42]")).toEqual([
+  it("handles multi-digit ordinals", () => {
+    expect(parseCitations("ok [t:12]")).toEqual([
       { kind: "text", text: "ok " },
-      { kind: "citation", toolId: "my-tool_42", raw: "[t:my-tool_42]" },
+      { kind: "citation", ordinal: 12, raw: "[t:12]" },
     ]);
   });
 });
 
 describe("hasCitations", () => {
   it("detects a marker", () => {
-    expect(hasCitations("x [t:abc] y")).toBe(true);
+    expect(hasCitations("x [t:1] y")).toBe(true);
   });
 
   it("returns false for non-citation text", () => {
@@ -48,7 +54,7 @@ describe("hasCitations", () => {
   });
 
   it("is stateless across calls (regex lastIndex reset)", () => {
-    const s = "x [t:a] y";
+    const s = "x [t:1] y";
     expect(hasCitations(s)).toBe(true);
     expect(hasCitations(s)).toBe(true);
     expect(hasCitations(s)).toBe(true);

--- a/packages/highperformer/src/chat/citations.test.ts
+++ b/packages/highperformer/src/chat/citations.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { hasCitations, parseCitations } from "./citations";
+
+describe("parseCitations", () => {
+  it("returns the input as a single text segment when no markers present", () => {
+    expect(parseCitations("plain text")).toEqual([
+      { kind: "text", text: "plain text" },
+    ]);
+  });
+
+  it("extracts a single marker between text segments", () => {
+    expect(parseCitations("The top gene is CD8A [t:toolu_abc] in cluster 3.")).toEqual([
+      { kind: "text", text: "The top gene is CD8A " },
+      { kind: "citation", toolId: "toolu_abc", raw: "[t:toolu_abc]" },
+      { kind: "text", text: " in cluster 3." },
+    ]);
+  });
+
+  it("handles back-to-back markers with no separator", () => {
+    expect(parseCitations("CD8A, GZMB [t:a][t:b]")).toEqual([
+      { kind: "text", text: "CD8A, GZMB " },
+      { kind: "citation", toolId: "a", raw: "[t:a]" },
+      { kind: "citation", toolId: "b", raw: "[t:b]" },
+    ]);
+  });
+
+  it("ignores square-bracket text that isn't a t: marker", () => {
+    expect(parseCitations("see [Smith 2024] for context")).toEqual([
+      { kind: "text", text: "see [Smith 2024] for context" },
+    ]);
+  });
+
+  it("accepts hyphens and underscores in tool ids", () => {
+    expect(parseCitations("ok [t:my-tool_42]")).toEqual([
+      { kind: "text", text: "ok " },
+      { kind: "citation", toolId: "my-tool_42", raw: "[t:my-tool_42]" },
+    ]);
+  });
+});
+
+describe("hasCitations", () => {
+  it("detects a marker", () => {
+    expect(hasCitations("x [t:abc] y")).toBe(true);
+  });
+
+  it("returns false for non-citation text", () => {
+    expect(hasCitations("just some text [1] (Smith)")).toBe(false);
+  });
+
+  it("is stateless across calls (regex lastIndex reset)", () => {
+    const s = "x [t:a] y";
+    expect(hasCitations(s)).toBe(true);
+    expect(hasCitations(s)).toBe(true);
+    expect(hasCitations(s)).toBe(true);
+  });
+});

--- a/packages/highperformer/src/chat/citations.ts
+++ b/packages/highperformer/src/chat/citations.ts
@@ -1,0 +1,43 @@
+/**
+ * Citation marker handling.
+ *
+ * The agent (per the system prompt instruction landed in cell-explorer-py#105)
+ * emits `[t:<tool_use_id>]` markers in its assistant text immediately after
+ * data-derived facts. These markers point at the tool_use_id of the tool call
+ * whose result produced the fact, and are rendered by the frontend as clickable
+ * links that open the corresponding tool row in the WhyPanel.
+ *
+ * Tool ids are LLM-generated identifiers (Anthropic returns e.g. "toolu_01ab…")
+ * — alphanumeric plus underscore. The regex is intentionally permissive on the
+ * id chars so we can render whatever the model emits; an unknown id still
+ * renders as a non-functional citation rather than getting stuck in the text.
+ */
+
+export type CitationSegment =
+  | { kind: "text"; text: string }
+  | { kind: "citation"; toolId: string; raw: string };
+
+const CITATION_RE = /\[t:([A-Za-z0-9_-]+)\]/g;
+
+export function parseCitations(text: string): CitationSegment[] {
+  const segments: CitationSegment[] = [];
+  let lastIndex = 0;
+  for (const m of text.matchAll(CITATION_RE)) {
+    const start = m.index ?? 0;
+    if (start > lastIndex) {
+      segments.push({ kind: "text", text: text.slice(lastIndex, start) });
+    }
+    segments.push({ kind: "citation", toolId: m[1], raw: m[0] });
+    lastIndex = start + m[0].length;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ kind: "text", text: text.slice(lastIndex) });
+  }
+  return segments;
+}
+
+/** True when the string contains at least one citation marker. */
+export function hasCitations(text: string): boolean {
+  CITATION_RE.lastIndex = 0;
+  return CITATION_RE.test(text);
+}

--- a/packages/highperformer/src/chat/citations.ts
+++ b/packages/highperformer/src/chat/citations.ts
@@ -1,23 +1,23 @@
 /**
  * Citation marker handling.
  *
- * The agent (per the system prompt instruction landed in cell-explorer-py#105)
- * emits `[t:<tool_use_id>]` markers in its assistant text immediately after
- * data-derived facts. These markers point at the tool_use_id of the tool call
- * whose result produced the fact, and are rendered by the frontend as clickable
- * links that open the corresponding tool row in the WhyPanel.
+ * The agent (per cell-explorer-py#107) emits `[t:N]` markers in its assistant
+ * text immediately after data-derived facts, where N is the 1-based ordinal of
+ * the tool call within the current turn. The frontend resolves N → tool row by
+ * position in the trace, so the marker remains valid even though the model
+ * cannot reliably reproduce random tool_use_ids.
  *
- * Tool ids are LLM-generated identifiers (Anthropic returns e.g. "toolu_01ab…")
- * — alphanumeric plus underscore. The regex is intentionally permissive on the
- * id chars so we can render whatever the model emits; an unknown id still
- * renders as a non-functional citation rather than getting stuck in the text.
+ * Out-of-range ordinals (e.g. `[t:9]` when only two tools ran) are surfaced
+ * but rendered as inert text — the agent will sometimes emit one when it
+ * hallucinates an extra tool call. That's a graceful degradation: the user
+ * sees a number that goes nowhere rather than a stuck `[t:9]` literal.
  */
 
 export type CitationSegment =
   | { kind: "text"; text: string }
-  | { kind: "citation"; toolId: string; raw: string };
+  | { kind: "citation"; ordinal: number; raw: string };
 
-const CITATION_RE = /\[t:([A-Za-z0-9_-]+)\]/g;
+const CITATION_RE = /\[t:(\d+)\]/g;
 
 export function parseCitations(text: string): CitationSegment[] {
   const segments: CitationSegment[] = [];
@@ -27,7 +27,7 @@ export function parseCitations(text: string): CitationSegment[] {
     if (start > lastIndex) {
       segments.push({ kind: "text", text: text.slice(lastIndex, start) });
     }
-    segments.push({ kind: "citation", toolId: m[1], raw: m[0] });
+    segments.push({ kind: "citation", ordinal: Number(m[1]), raw: m[0] });
     lastIndex = start + m[0].length;
   }
   if (lastIndex < text.length) {

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -101,10 +101,16 @@ export function reduce(
       });
       const traceEntry: TraceEntry =
         ev.status === "started"
-          ? { kind: "tool_start", tool: ev.tool, args: ev.args }
+          ? {
+              kind: "tool_start",
+              tool: ev.tool,
+              tool_call_id: ev.tool_call_id,
+              args: ev.args,
+            }
           : {
               kind: "tool_end",
               tool: ev.tool,
+              tool_call_id: ev.tool_call_id,
               status: ev.status,
               summary: ev.summary,
               duration_ms: ev.duration_ms,

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -79,6 +79,8 @@ export type ToolProgress = {
   args?: Record<string, unknown> | null;
   /** Populated on the 'ok' / 'error' events — wall-clock since 'started'. */
   duration_ms?: number | null;
+  /** LLM-generated tool_use_id. Citation markers [t:<id>] reference this. */
+  tool_call_id?: string | null;
 };
 export type UIAction     = { type: "ui_action"; payload: Record<string, unknown> };
 export type ErrorEvent   = { type: "error"; message: string; retryable: boolean };
@@ -121,10 +123,16 @@ export type MessagePart = TextPart | ToolPart | ErrorPart;
  * bubble (text + tool widgets + errors).
  */
 export type TraceEntry =
-  | { kind: "tool_start"; tool: string; args?: Record<string, unknown> | null }
+  | {
+      kind: "tool_start";
+      tool: string;
+      tool_call_id?: string | null;
+      args?: Record<string, unknown> | null;
+    }
   | {
       kind: "tool_end";
       tool: string;
+      tool_call_id?: string | null;
       status: "ok" | "error";
       summary?: string;
       duration_ms?: number | null;


### PR DESCRIPTION
Closes #97. Frontend half — the backend already emits the markers (cell-explorer-py#105) and `tool_call_id` on `ToolProgress` (cell-explorer-py#106).

When the agent says *"The top markers are CD8A [t:toolu_abc], GZMB [t:toolu_abc]"*, the markers now render as small superscript links `[1]`. Clicking opens the WhyPanel (if collapsed) and flashes the matching tool row so the user can audit where a number came from.

- Citations in one turn are numbered in order of first appearance; repeated ids reuse their number
- Unknown/stale ids render as inert labels (no JS error, just a non-functional link)
- New `AssistantBubble` component encapsulates the per-turn citation handshake + WhyPanel state; `ConversationView` delegates to it
- `WhyPanel` gained controlled-open props + `flashToolId` for the highlight pulse

## Test plan
- [x] 8 new `citations` parser tests
- [x] 5 new `AssistantBubble` tests covering citation rendering, numbering, open-and-flash handshake, legacy tool tag rendering
- [x] 389 highperformer tests pass; production build succeeds