### PR TITLE
feat: decouple cluster labels from color mode + expose to agent

### DIFF
--- a/.changeset/cluster-label-decouple.md
+++ b/.changeset/cluster-label-decouple.md
@@ -1,0 +1,12 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Decouple cluster-label rendering from color mode. Adds
+`categoryLabelsObsColumn` to the AppConfig schema and store so callers
+(postMessage, agent) can pick the obs column for cluster labels
+independent of color mode (e.g. label by `leiden` while coloring by
+gene expression). The ColorBySection toggle moves into its own
+subsection visible in both color modes, with a column picker beside
+it. The view-state snapshot now emits `showCategoryLabels` and
+`categoryLabelsObsColumn` so the agent can read current label state.

--- a/packages/highperformer/schema/app-config.schema.json
+++ b/packages/highperformer/schema/app-config.schema.json
@@ -226,6 +226,16 @@
     "showCategoryLabels": {
       "type": "boolean"
     },
+    "categoryLabelsObsColumn": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "showHeader": {
       "type": "boolean"
     },

--- a/packages/highperformer/src/chat/viewStateSnapshot.test.ts
+++ b/packages/highperformer/src/chat/viewStateSnapshot.test.ts
@@ -180,4 +180,29 @@ describe("buildViewStateSnapshot", () => {
     expect(snap.filter).toBeUndefined();
     expect(snap.selectionDisplayMode).toBeUndefined();
   });
+
+  it("omits showCategoryLabels when default (false)", () => {
+    useAppStore.setState({ showCategoryLabels: false } as any);
+    expect(buildViewStateSnapshot().showCategoryLabels).toBeUndefined();
+  });
+
+  it("includes showCategoryLabels when true", () => {
+    useAppStore.setState({ showCategoryLabels: true } as any);
+    expect(buildViewStateSnapshot().showCategoryLabels).toBe(true);
+  });
+
+  it("omits categoryLabelsObsColumn when null", () => {
+    useAppStore.setState({ categoryLabelsObsColumn: null } as any);
+    expect(buildViewStateSnapshot().categoryLabelsObsColumn).toBeUndefined();
+  });
+
+  it("includes categoryLabelsObsColumn when set", () => {
+    useAppStore.setState({
+      showCategoryLabels: true,
+      categoryLabelsObsColumn: "leiden",
+    } as any);
+    const snap = buildViewStateSnapshot();
+    expect(snap.showCategoryLabels).toBe(true);
+    expect(snap.categoryLabelsObsColumn).toBe("leiden");
+  });
 });

--- a/packages/highperformer/src/chat/viewStateSnapshot.ts
+++ b/packages/highperformer/src/chat/viewStateSnapshot.ts
@@ -32,6 +32,8 @@ export type ViewStateSnapshot = {
   summaryGenes?: string[];
   selectionDisplayMode?: "dim" | "hide";
   filter?: FilterSnapshot;
+  showCategoryLabels?: boolean;
+  categoryLabelsObsColumn?: string;
 };
 
 export function buildViewStateSnapshot(): ViewStateSnapshot {
@@ -73,6 +75,9 @@ export function buildViewStateSnapshot(): ViewStateSnapshot {
       (g) => s.geneLabelMap?.get(g) ?? g,
     );
   }
+
+  if (s.showCategoryLabels) snap.showCategoryLabels = true;
+  if (s.categoryLabelsObsColumn) snap.categoryLabelsObsColumn = s.categoryLabelsObsColumn;
 
   // Filter / selection state. Only include if there's a filter buffer
   // (something actually selected on the canvas).

--- a/packages/highperformer/src/components/ColorBySection.test.tsx
+++ b/packages/highperformer/src/components/ColorBySection.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+afterEach(() => cleanup())
+
+// Mock WorkerPool + worker (same pattern as other tests in this package).
+vi.mock('../pool/WorkerPool', () => ({
+  WorkerPool: class { dispatch = vi.fn().mockResolvedValue({}); clearQueue = vi.fn(); dispose() {} },
+}))
+vi.mock('../workers/universal.worker.ts?worker', () => ({ default: class {} }))
+
+const { default: useAppStore } = await import('../store/useAppStore')
+const { default: ColorBySection } = await import('./ColorBySection')
+
+describe('ColorBySection — cluster labels', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      obsColumnNames: ['cell_type', 'leiden'],
+      varNames: ['CD8A'],
+    } as any)
+  })
+
+  it('renders the Show cluster labels switch in category mode', () => {
+    useAppStore.setState({ colorMode: 'category' } as any)
+    render(<ColorBySection />)
+    expect(screen.getByText('Show cluster labels')).toBeDefined()
+  })
+
+  it('renders the Show cluster labels switch in gene mode (decoupled)', () => {
+    useAppStore.setState({ colorMode: 'gene' } as any)
+    render(<ColorBySection />)
+    expect(screen.getByText('Show cluster labels')).toBeDefined()
+  })
+
+  it('renders the Label by picker', () => {
+    useAppStore.setState({ colorMode: 'category', selectedObsColumn: 'cell_type' } as any)
+    render(<ColorBySection />)
+    expect(screen.getByText('Label by:')).toBeDefined()
+  })
+
+  it('shows the inline hint when switch is on AND no effective column resolves', () => {
+    useAppStore.setState({
+      colorMode: 'gene',
+      showCategoryLabels: true,
+      categoryLabelsObsColumn: null,
+    } as any)
+    render(<ColorBySection />)
+    expect(screen.getByText('Select a column to label by')).toBeDefined()
+  })
+
+  it('hides the inline hint when an effective column resolves', () => {
+    useAppStore.setState({
+      colorMode: 'category',
+      selectedObsColumn: 'cell_type',
+      showCategoryLabels: true,
+      categoryLabelsObsColumn: null,
+    } as any)
+    render(<ColorBySection />)
+    expect(screen.queryByText('Select a column to label by')).toBeNull()
+  })
+
+  it('hides the inline hint when the switch is off', () => {
+    useAppStore.setState({
+      colorMode: 'gene',
+      showCategoryLabels: false,
+      categoryLabelsObsColumn: null,
+    } as any)
+    render(<ColorBySection />)
+    expect(screen.queryByText('Select a column to label by')).toBeNull()
+  })
+
+  it('flipping the switch updates the store', () => {
+    useAppStore.setState({ colorMode: 'category', selectedObsColumn: 'cell_type' } as any)
+    render(<ColorBySection />)
+    const switchEl = screen.getByRole('switch', { name: /show cluster labels/i })
+    fireEvent.click(switchEl)
+    expect(useAppStore.getState().showCategoryLabels).toBe(true)
+  })
+})

--- a/packages/highperformer/src/components/ColorBySection.test.tsx
+++ b/packages/highperformer/src/components/ColorBySection.test.tsx
@@ -77,4 +77,18 @@ describe('ColorBySection — cluster labels', () => {
     fireEvent.click(switchEl)
     expect(useAppStore.getState().showCategoryLabels).toBe(true)
   })
+
+  it('picking an obs column from the picker calls setCategoryLabelsObsColumn', () => {
+    // antd Select's onChange does not fire via fireEvent.click in jsdom; call the store
+    // action directly and verify it round-trips through state correctly.
+    useAppStore.setState({ colorMode: 'gene', categoryLabelsObsColumn: null } as any)
+    render(<ColorBySection />)
+
+    // The Label by picker shows "Pick a column" placeholder in gene mode.
+    expect(screen.getByText('Pick a column')).toBeDefined()
+
+    // Drive the action directly and verify state is updated.
+    useAppStore.getState().setCategoryLabelsObsColumn('leiden')
+    expect(useAppStore.getState().categoryLabelsObsColumn).toBe('leiden')
+  })
 })

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -72,6 +72,14 @@ export default function ColorBySection() {
   const geneLabelMap = useAppStore((s) => s.geneLabelMap)
   const showCategoryLabels = useAppStore((s) => s.showCategoryLabels)
   const setShowCategoryLabels = useAppStore((s) => s.setShowCategoryLabels)
+  const categoryLabelsObsColumn = useAppStore((s) => s.categoryLabelsObsColumn)
+  const setCategoryLabelsObsColumn = useAppStore((s) => s.setCategoryLabelsObsColumn)
+
+  // Mirror View.tsx's effectiveLabelColumn so the hint logic stays in sync.
+  const effectiveLabelColumn =
+    !showCategoryLabels
+      ? null
+      : (categoryLabelsObsColumn ?? (colorMode === 'category' ? selectedObsColumn : null))
 
   const [categoryOpen, setCategoryOpen] = useState(false)
   const [geneSearchText, setGeneSearchText] = useState('')
@@ -142,15 +150,6 @@ export default function ColorBySection() {
             style={{ width: '100%' }}
             size="small"
           />
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
-            <Switch
-              size="small"
-              checked={showCategoryLabels}
-              onChange={setShowCategoryLabels}
-              disabled={!selectedObsColumn}
-            />
-            <span style={{ fontSize: 12, color: '#666' }}>Show cluster labels</span>
-          </div>
           {categoryWarning && (
             <Alert
               title={categoryWarning}
@@ -213,6 +212,42 @@ export default function ColorBySection() {
           </Space.Compact>
         </div>
       )}
+
+      <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid #f0f0f0' }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: '#888', textTransform: 'uppercase', marginBottom: 8 }}>
+          Labels
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Switch
+            size="small"
+            checked={showCategoryLabels}
+            onChange={setShowCategoryLabels}
+            aria-label="Show cluster labels"
+          />
+          <span style={{ fontSize: 12, color: '#666' }}>Show cluster labels</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
+            <span style={{ fontSize: 12, color: '#888' }}>Label by:</span>
+            <Select
+              value={categoryLabelsObsColumn ?? (colorMode === 'category' ? '__color_column__' : null)}
+              onChange={(v) => setCategoryLabelsObsColumn(v === '__color_column__' ? null : v)}
+              placeholder="Pick a column"
+              size="small"
+              style={{ minWidth: 120 }}
+              options={[
+                ...(colorMode === 'category'
+                  ? [{ value: '__color_column__', label: '(use color-by column)' }]
+                  : []),
+                ...obsColumnNames.map((name) => ({ value: name, label: name })),
+              ]}
+            />
+          </div>
+        </div>
+        {showCategoryLabels && !effectiveLabelColumn && (
+          <div style={{ fontSize: 12, color: '#999', marginTop: 6 }}>
+            Select a column to label by
+          </div>
+        )}
+      </div>
 
       {colorMode === 'category' && <CategoricalLegend />}
       {colorMode === 'gene' && <ContinuousLegend />}

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -7,6 +7,11 @@ import { COLOR_SCALES } from '../utils/colors'
 import CategoricalLegend from './CategoricalLegend'
 import ContinuousLegend from './ContinuousLegend'
 
+// Sentinel value used by the Labels "Label by" picker to represent
+// "fall back to the color-by column". Renamed to a vanishingly-unlikely
+// string so an obs column can't accidentally collide with it.
+const USE_COLOR_COLUMN_SENTINEL = '__CCE_use_color_by_column__'
+
 const scaleOptions = Object.keys(COLOR_SCALES).map((name) => ({
   value: name,
   label: name.charAt(0).toUpperCase() + name.slice(1),
@@ -228,14 +233,14 @@ export default function ColorBySection() {
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
             <span style={{ fontSize: 12, color: '#888' }}>Label by:</span>
             <Select
-              value={categoryLabelsObsColumn ?? (colorMode === 'category' ? '__color_column__' : null)}
-              onChange={(v) => setCategoryLabelsObsColumn(v === '__color_column__' ? null : v)}
+              value={categoryLabelsObsColumn ?? (colorMode === 'category' ? USE_COLOR_COLUMN_SENTINEL : undefined)}
+              onChange={(v) => setCategoryLabelsObsColumn(v === USE_COLOR_COLUMN_SENTINEL ? null : v)}
               placeholder="Pick a column"
               size="small"
               style={{ minWidth: 120 }}
               options={[
                 ...(colorMode === 'category'
-                  ? [{ value: '__color_column__', label: '(use color-by column)' }]
+                  ? [{ value: USE_COLOR_COLUMN_SENTINEL, label: '(use color-by column)' }]
                   : []),
                 ...obsColumnNames.map((name) => ({ value: name, label: name })),
               ]}

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -45,6 +45,30 @@ describe('applyConfig', () => {
     expect(state.showCategoryLabels).toBe(true)
   })
 
+  it('sets categoryLabelsObsColumn from config (Phase 1)', () => {
+    const config: AppConfig = {
+      url: 'https://example.com/data.zarr',
+      categoryLabelsObsColumn: 'leiden',
+    }
+
+    applyConfig(config)
+
+    expect(useAppStore.getState().categoryLabelsObsColumn).toBe('leiden')
+  })
+
+  it('clears categoryLabelsObsColumn when set to null', () => {
+    useAppStore.setState({ categoryLabelsObsColumn: 'leiden' } as any)
+
+    const config: AppConfig = {
+      url: 'https://example.com/data.zarr',
+      categoryLabelsObsColumn: null,
+    }
+
+    applyConfig(config)
+
+    expect(useAppStore.getState().categoryLabelsObsColumn).toBeNull()
+  })
+
   it('calls openDataset with config url', () => {
     const openDataset = vi.spyOn(useAppStore.getState(), 'openDataset').mockResolvedValue()
 

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -62,6 +62,7 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     ...(config.showRightSidebar !== undefined && { showRightSidebar: config.showRightSidebar }),
     ...(config.showDatasetDropdown !== undefined && { showDatasetDropdown: config.showDatasetDropdown }),
     ...(config.showCategoryLabels !== undefined && { showCategoryLabels: config.showCategoryLabels }),
+    ...(config.categoryLabelsObsColumn !== undefined && { categoryLabelsObsColumn: config.categoryLabelsObsColumn }),
   })
 
   // Phase 2: Trigger dataset load if requested

--- a/packages/highperformer/src/config/schema.test.ts
+++ b/packages/highperformer/src/config/schema.test.ts
@@ -42,4 +42,14 @@ describe('AppConfigSchema', () => {
     const result = AppConfigSchema.safeParse({ embedding: 'X_umap', futuristicField: 'x' })
     expect(result.success).toBe(true)
   })
+
+  it('accepts categoryLabelsObsColumn (string, null, or omitted)', () => {
+    expect(AppConfigSchema.safeParse({ categoryLabelsObsColumn: 'leiden' }).success).toBe(true)
+    expect(AppConfigSchema.safeParse({ categoryLabelsObsColumn: null }).success).toBe(true)
+    expect(AppConfigSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('rejects non-string non-null categoryLabelsObsColumn', () => {
+    expect(AppConfigSchema.safeParse({ categoryLabelsObsColumn: 42 }).success).toBe(false)
+  })
 })

--- a/packages/highperformer/src/config/schema.ts
+++ b/packages/highperformer/src/config/schema.ts
@@ -83,6 +83,11 @@ export const AppConfigSchema = z.object({
   // the user switches to category mode.
   showCategoryLabels: z.boolean().optional(),
 
+  // Explicit obs column for cluster labels. Pairs with showCategoryLabels.
+  // null = fall back to selectedObsColumn when in category color mode;
+  // string = label by that column independent of color mode.
+  categoryLabelsObsColumn: z.string().nullable().optional(),
+
   // UI chrome
   showHeader: z.boolean().optional(),
   showLeftSidebar: z.boolean().optional(),

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -582,6 +582,12 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     effectiveLabelColumn ? s.summaryObsData.get(effectiveLabelColumn) : undefined,
   )
 
+  // True when labels and the color buffer share an obs column. Used to
+  // decide which categoryMap to use for label text/color AND whether
+  // category highlights apply to label filtering.
+  const labelMatchesColorColumn =
+    colorMode === 'category' && selectedObsColumn === effectiveLabelColumn
+
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Derive initial view state from data bounds + container size.
@@ -718,8 +724,6 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     // already loaded for the color buffer. When labeling by a DIFFERENT column,
     // pull labels + colors from summaryObsData (populated by addSummaryObsColumn
     // which the setter calls).
-    const labelMatchesColorColumn =
-      colorMode === 'category' && selectedObsColumn === effectiveLabelColumn
     const labelMap = labelMatchesColorColumn
       ? categoryMap
       : (labelColumnObsData?.categoryMap ?? [])
@@ -760,8 +764,7 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     })
   }, [
     effectiveLabelColumn,
-    colorMode,
-    selectedObsColumn,
+    labelMatchesColorColumn,
     selectedEmbedding,
     categoryCentroids,
     highlightedCategories,

--- a/packages/highperformer/src/pages/View.tsx
+++ b/packages/highperformer/src/pages/View.tsx
@@ -562,6 +562,26 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
   const selectedEmbedding = useAppStore((s) => s.selectedEmbedding)
   const colorMode = useAppStore((s) => s.colorMode)
   const selectedObsColumn = useAppStore((s) => s.selectedObsColumn)
+  const categoryLabelsObsColumn = useAppStore((s) => s.categoryLabelsObsColumn)
+
+  // The column we render labels for. Decoupled from color mode: explicit
+  // override wins; null falls back to selectedObsColumn but only when the
+  // user is actually coloring by a category. In gene mode without an
+  // explicit override, no labels render — the ColorBySection hint guides
+  // the user to pick a column.
+  const effectiveLabelColumn =
+    !showCategoryLabels
+      ? null
+      : (categoryLabelsObsColumn ?? (colorMode === 'category' ? selectedObsColumn : null))
+
+  // Subscribe to the label column's obs data so the centroid-dispatch effect
+  // re-fires once it lands (addSummaryObsColumn / selectObsColumn populate
+  // summaryObsData async; without this dep, the centroid dispatch misses
+  // the first-load window for a new column).
+  const labelColumnObsData = useAppStore((s) =>
+    effectiveLabelColumn ? s.summaryObsData.get(effectiveLabelColumn) : undefined,
+  )
+
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Derive initial view state from data bounds + container size.
@@ -690,22 +710,34 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
   }, [embeddingData, colorBuffer, radiusBuffer, selectionFilterBuffer, selectionDisplayMode])
 
   const categoryLabelLayer = useMemo(() => {
-    if (!showCategoryLabels || colorMode !== 'category' || !selectedObsColumn) return null
-    const cache = categoryCentroids.get(`${selectedEmbedding}::${selectedObsColumn}`)
+    if (!effectiveLabelColumn) return null
+    const cache = categoryCentroids.get(`${selectedEmbedding}::${effectiveLabelColumn}`)
     if (!cache) return null
 
-    // Highlight-aware: when the highlight set is non-empty, only render labels
-    // for those codes; otherwise render labels for all categories with data.
-    const visibleCodes = highlightedCategories.size > 0
-      ? Array.from(highlightedCategories)
-      : categoryMap.map((_, i) => i)
+    // When labeling by the SAME column we're coloring by, use the categoryMap
+    // already loaded for the color buffer. When labeling by a DIFFERENT column,
+    // pull labels + colors from summaryObsData (populated by addSummaryObsColumn
+    // which the setter calls).
+    const labelMatchesColorColumn =
+      colorMode === 'category' && selectedObsColumn === effectiveLabelColumn
+    const labelMap = labelMatchesColorColumn
+      ? categoryMap
+      : (labelColumnObsData?.categoryMap ?? [])
+    if (labelMap.length === 0) return null
+
+    // Highlights only apply when labeling by the column we're coloring by —
+    // the highlightedCategories codes refer to the color column's categoryMap.
+    const visibleCodes =
+      labelMatchesColorColumn && highlightedCategories.size > 0
+        ? Array.from(highlightedCategories)
+        : labelMap.map((_, i) => i)
 
     const labels = visibleCodes
       .filter((code) => cache.counts[code] > 0)
       .map((code) => ({
-        text: categoryMap[code]?.label ?? '',
+        text: labelMap[code]?.label ?? '',
         position: [cache.positions[2 * code], cache.positions[2 * code + 1]] as [number, number],
-        color: categoryMap[code]?.color ?? ([255, 255, 255] as [number, number, number]),
+        color: labelMap[code]?.color ?? ([255, 255, 255] as [number, number, number]),
       }))
 
     if (labels.length === 0) return null
@@ -727,13 +759,14 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
       outlineWidth: 0,
     })
   }, [
-    showCategoryLabels,
+    effectiveLabelColumn,
     colorMode,
     selectedObsColumn,
     selectedEmbedding,
     categoryCentroids,
     highlightedCategories,
     categoryMap,
+    labelColumnObsData,
   ])
 
   const layers = useMemo(() => {
@@ -804,31 +837,15 @@ function Visualization({ deckRef }: { deckRef: React.RefObject<DeckGL | null> })
     didMountRef.current = false
   }, [deckKey])
 
-  // Subscribe to the active column's obs data so the effect below re-fires
-  // once it lands (selectObsColumn populates summaryObsData async; without
-  // this dep, the centroid dispatch misses the first-load window for a new
-  // column and the user has to toggle off+on to recover).
-  const currentObsData = useAppStore((s) =>
-    s.selectedObsColumn ? s.summaryObsData.get(s.selectedObsColumn) : undefined,
-  )
-
   useEffect(() => {
-    if (
-      showCategoryLabels &&
-      colorMode === 'category' &&
-      selectedObsColumn &&
-      embeddingData &&
-      currentObsData
-    ) {
-      ensureCategoryCentroids(selectedEmbedding, selectedObsColumn)
+    if (effectiveLabelColumn && embeddingData && labelColumnObsData && selectedEmbedding) {
+      ensureCategoryCentroids(selectedEmbedding, effectiveLabelColumn)
     }
   }, [
-    showCategoryLabels,
-    colorMode,
-    selectedObsColumn,
+    effectiveLabelColumn,
     selectedEmbedding,
     embeddingData,
-    currentObsData,
+    labelColumnObsData,
     ensureCategoryCentroids,
   ])
 

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -1354,5 +1354,25 @@ describe('useAppStore', () => {
       await useAppStore.getState().ensureCategoryCentroids("X_umap", "cell_type");
       expect(useAppStore.getState().categoryCentroids.get("X_umap::cell_type")).toBe(firstCache);
     });
+
+    it("starts with categoryLabelsObsColumn=null", () => {
+      expect(useAppStore.getState().categoryLabelsObsColumn).toBeNull();
+    });
+
+    it("setCategoryLabelsObsColumn updates the field", () => {
+      useAppStore.getState().setCategoryLabelsObsColumn("leiden");
+      expect(useAppStore.getState().categoryLabelsObsColumn).toBe("leiden");
+      useAppStore.getState().setCategoryLabelsObsColumn(null);
+      expect(useAppStore.getState().categoryLabelsObsColumn).toBeNull();
+    });
+
+    it("categoryLabelsObsColumn is preserved across setShowCategoryLabels(false)+(true)", () => {
+      useAppStore.getState().setCategoryLabelsObsColumn("leiden");
+      useAppStore.getState().setShowCategoryLabels(true);
+      useAppStore.getState().setShowCategoryLabels(false);
+      expect(useAppStore.getState().categoryLabelsObsColumn).toBe("leiden");
+      useAppStore.getState().setShowCategoryLabels(true);
+      expect(useAppStore.getState().categoryLabelsObsColumn).toBe("leiden");
+    });
   });
 })

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -1140,7 +1140,6 @@ const useAppStore = create<AppState>((set, get) => ({
       summaryGeneData: new Map(), summaryGeneRanges: new Map(),
       summaryCache: new Map(),
       categoryCentroids: new Map(),
-      categoryLabelsObsColumn: null,
     })
     try {
       const adata = await AnnDataStore.open(url, overrides)

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -126,13 +126,17 @@ export interface AppState {
   highlightedCategories: Set<number>
   radiusBuffer: Float32Array | null
 
-  // Cluster label overlay (see docs/superpowers/specs/2026-05-13-category-label-layer-design.md)
+  // Cluster label overlay (see docs/superpowers/specs/2026-05-13-cluster-label-toggle-redesign-design.md)
   showCategoryLabels: boolean
+  // Explicit obs column to label by. null = fall back to selectedObsColumn when
+  // in category color mode; explicit string = label independent of color mode.
+  categoryLabelsObsColumn: string | null
   categoryCentroids: Map<string, {
     positions: Float32Array
     counts: Uint32Array
   }>
   setShowCategoryLabels: (value: boolean) => void
+  setCategoryLabelsObsColumn: (name: string | null) => void
   ensureCategoryCentroids: (embeddingKey: string, obsColumn: string) => Promise<void>
 
   // Selection
@@ -366,6 +370,16 @@ const useAppStore = create<AppState>((set, get) => ({
 
   setShowCategoryLabels: (value) => set({ showCategoryLabels: value }),
 
+  setCategoryLabelsObsColumn: (name) => {
+    set({ categoryLabelsObsColumn: name })
+    // Loading the codes/categoryMap for the label column happens lazily.
+    // If the column isn't already in summaryObsData (because the user picked
+    // a column they're not coloring by), addSummaryObsColumn fetches it.
+    // This auto-pins to the summary panel — acceptable for v1 (matches
+    // selectObsColumn's behavior).
+    if (name) get().addSummaryObsColumn(name)
+  },
+
   ensureCategoryCentroids: async (embeddingKey, obsColumn) => {
     const cacheKey = `${embeddingKey}::${obsColumn}`
     const state = get()
@@ -409,6 +423,7 @@ const useAppStore = create<AppState>((set, get) => ({
 
   // Cluster label overlay
   showCategoryLabels: false,
+  categoryLabelsObsColumn: null,
   categoryCentroids: new Map(),
 
   // Color By state
@@ -1125,6 +1140,7 @@ const useAppStore = create<AppState>((set, get) => ({
       summaryGeneData: new Map(), summaryGeneRanges: new Map(),
       summaryCache: new Map(),
       categoryCentroids: new Map(),
+      categoryLabelsObsColumn: null,
     })
     try {
       const adata = await AnnDataStore.open(url, overrides)


### PR DESCRIPTION
## Summary

- Adds `categoryLabelsObsColumn` to AppConfig + store. Labels can now be rendered independent of color mode (e.g. label by `leiden` while coloring by gene expression).
- ColorBySection: switch moves out of the category-only block into its own Labels subsection, with a column picker beside it. Inline hint shows when no column resolves.
- View-state snapshot: emits `showCategoryLabels` and `categoryLabelsObsColumn` so the agent can read current label state.

The follow-up cell-explorer-py PR will extend the `set_category_labels` tool to accept `obs_column` once this lands and the JSON Schema artifact regenerates.

## Test plan

- [x] highperformer unit suite passes (409 tests)
- [ ] manual: gene mode + label-by-leiden renders labels
- [ ] manual: switch off+on preserves column override
- [ ] manual: changing color obs column with labels on updates labels immediately