### PR TITLE
fix(config): load label column data in applyConfig

### DIFF
--- a/.changeset/apply-config-label-column-load.md
+++ b/.changeset/apply-config-label-column-load.md
@@ -1,0 +1,13 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix: `applyConfig` now loads the label column's obs data via
+`addSummaryObsColumn` when `categoryLabelsObsColumn` is set to a
+non-null string. Previously the Phase 1 spread set the field via
+`setState`, bypassing the store setter's side effect, so labels
+dispatched through `applyConfig` (e.g. the chat agent calling
+`set_category_labels(value=True, obs_column="leiden")`) silently
+failed to render because `summaryObsData.get(labelColumn)` was
+undefined. Adds a `field_value_invalid` error path when the column
+is missing from `obsColumnNames`.

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -69,6 +69,55 @@ describe('applyConfig', () => {
     expect(useAppStore.getState().categoryLabelsObsColumn).toBeNull()
   })
 
+  it('calls addSummaryObsColumn to load data for the label column', async () => {
+    const addSummaryObsColumn = vi.spyOn(useAppStore.getState(), 'addSummaryObsColumn').mockImplementation(() => {})
+
+    const config: AppConfig = {
+      url: 'https://example.com/data.zarr',
+      categoryLabelsObsColumn: 'leiden',
+    }
+
+    const promise = applyConfig(config)
+    useAppStore.setState({ obsColumnNames: ['cell_type', 'leiden'], obsmKeys: [], varNames: [], varColumns: [] })
+    await promise
+
+    expect(addSummaryObsColumn).toHaveBeenCalledWith('leiden')
+    addSummaryObsColumn.mockRestore()
+  })
+
+  it('returns field_value_invalid when categoryLabelsObsColumn is not in the dataset', async () => {
+    const config: AppConfig = {
+      url: 'https://example.com/data.zarr',
+      categoryLabelsObsColumn: 'nonexistent',
+    }
+
+    const promise = applyConfig(config)
+    useAppStore.setState({ obsColumnNames: ['cell_type'], obsmKeys: [], varNames: [], varColumns: [] })
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.reason.kind === 'field_value_invalid') {
+      expect(result.reason.field).toBe('categoryLabelsObsColumn')
+      expect(result.reason.value).toBe('nonexistent')
+    } else {
+      throw new Error('expected field_value_invalid error')
+    }
+  })
+
+  it('does not call addSummaryObsColumn when categoryLabelsObsColumn is null', () => {
+    const addSummaryObsColumn = vi.spyOn(useAppStore.getState(), 'addSummaryObsColumn').mockImplementation(() => {})
+
+    const config: AppConfig = {
+      url: 'https://example.com/data.zarr',
+      categoryLabelsObsColumn: null,
+    }
+
+    applyConfig(config)
+
+    expect(addSummaryObsColumn).not.toHaveBeenCalled()
+    addSummaryObsColumn.mockRestore()
+  })
+
   it('calls openDataset with config url', () => {
     const openDataset = vi.spyOn(useAppStore.getState(), 'openDataset').mockResolvedValue()
 

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -90,7 +90,11 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     config.pointSize !== undefined ||  // null is a valid clear sentinel
     config.opacity !== undefined ||  // null is a valid clear sentinel
     config.summaryContext ||
-    config.selectionDisplayMode
+    config.selectionDisplayMode ||
+    // A non-null categoryLabelsObsColumn needs post-load handling to fetch
+    // the column's codes/categoryMap. Plain null is a Phase 1 clear — no
+    // post-load work needed.
+    !!config.categoryLabelsObsColumn
 
   if (!hasPostLoadConfig) return ok()
 
@@ -213,6 +217,23 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   // color buffer only if currently in gene mode (no-op otherwise).
   if (config.colorScaleName) {
     store.getState().setColorScaleName(config.colorScaleName)
+  }
+
+  // Load the data for the cluster-label obs column when set to a non-null
+  // string. Phase 1's setState updated the field but bypassed the store
+  // setter's side effect (addSummaryObsColumn). Without this, View.tsx's
+  // labelColumnObsData selector returns undefined and labels never render.
+  if (config.categoryLabelsObsColumn) {
+    const { obsColumnNames } = store.getState()
+    if (!obsColumnNames.includes(config.categoryLabelsObsColumn)) {
+      return err({
+        kind: 'field_value_invalid',
+        field: 'categoryLabelsObsColumn',
+        value: config.categoryLabelsObsColumn,
+        reason: 'not found in dataset',
+      })
+    }
+    store.getState().addSummaryObsColumn(config.categoryLabelsObsColumn)
   }
 
   // 3d: Summary panel.


### PR DESCRIPTION
## Summary

Follow-up to #269. The chat agent's `set_category_labels(value=True, obs_column='leiden')` call dispatched through `applyConfig` was silently failing — labels never rendered because Phase 1's `setState` bypassed the store setter's `addSummaryObsColumn` side effect, leaving `summaryObsData.get('leiden')` undefined.

Adds a post-load handler that validates the column and loads its data. Manual UI path was unaffected (the picker's `onChange` calls the setter directly).

## Test plan

- [x] 412 highperformer tests pass (3 new applyConfig tests)
- [ ] manual: agent "label by leiden" actually renders leiden labels