### PR TITLE
feat(chat): per-turn thumbs feedback on assistant turns

### DIFF
--- a/.changeset/chat-feedback.md
+++ b/.changeset/chat-feedback.md
@@ -1,0 +1,11 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Per-turn thumbs up/down on assistant chat messages. The strip lives
+next to the existing WhyPanel chip on each assistant bubble. Thumbs-up
+fires immediately with no follow-up; thumbs-down reveals an inline
+optional comment textarea. State is toggleable (click an active thumb
+to clear) and persists server-side via the new cell-explorer-py
+PUT/DELETE feedback endpoints. Reloading a thread shows each assistant
+message with the user's previous rating already applied.

--- a/packages/highperformer/src/api.ts
+++ b/packages/highperformer/src/api.ts
@@ -37,6 +37,7 @@ import {
   HttpError,
   type ChatEvent,
   type ContextResponse,
+  type MessageFeedback,
   type ThreadDetailResponse,
   type ThreadListResponse,
   type WireMessage,
@@ -100,6 +101,38 @@ export const chat = {
   ): Promise<void> {
     const res = await fetch(
       `/api/chat/${encodeURIComponent(slug)}/threads/${encodeURIComponent(threadId)}`,
+      { method: "DELETE", credentials: "include", signal },
+    );
+    if (!res.ok) throw new HttpError(res.status, await res.text());
+  },
+
+  async putFeedback(
+    slug: string,
+    messageId: string,
+    body: { rating: "up" | "down"; comment?: string | null },
+    signal?: AbortSignal,
+  ): Promise<MessageFeedback> {
+    const res = await fetch(
+      `/api/chat/${encodeURIComponent(slug)}/messages/${encodeURIComponent(messageId)}/feedback`,
+      {
+        method: "PUT",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal,
+      },
+    );
+    if (!res.ok) throw new HttpError(res.status, await res.text());
+    return (await res.json()) as MessageFeedback;
+  },
+
+  async deleteFeedback(
+    slug: string,
+    messageId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const res = await fetch(
+      `/api/chat/${encodeURIComponent(slug)}/messages/${encodeURIComponent(messageId)}/feedback`,
       { method: "DELETE", credentials: "include", signal },
     );
     if (!res.ok) throw new HttpError(res.status, await res.text());

--- a/packages/highperformer/src/chat/AssistantBubble.test.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.test.tsx
@@ -1,7 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { AssistantBubble } from "./AssistantBubble";
-import { chat as chatClient } from "../api";
 import type { ChatMessage } from "./types";
 
 afterEach(() => cleanup());
@@ -97,10 +96,6 @@ describe("AssistantBubble", () => {
   });
 
   it("renders FeedbackThumbs when message.id is present", () => {
-    vi.spyOn(chatClient, "putFeedback").mockResolvedValue({
-      rating: "up",
-      comment: null,
-    });
     render(
       <AssistantBubble
         message={{

--- a/packages/highperformer/src/chat/AssistantBubble.test.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.test.tsx
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { AssistantBubble } from "./AssistantBubble";
+import { chat as chatClient } from "../api";
 import type { ChatMessage } from "./types";
 
 afterEach(() => cleanup());
@@ -32,6 +33,7 @@ describe("AssistantBubble", () => {
           role: "assistant",
           parts: [{ kind: "text", text: "no citations here" }],
         }}
+        slug="public-atlas"
       />,
     );
     expect(screen.getByText(/no citations here/)).toBeDefined();
@@ -42,6 +44,7 @@ describe("AssistantBubble", () => {
     render(
       <AssistantBubble
         message={withOneTool("Top gene is CD8A [t:1] in cluster 3.")}
+        slug="public-atlas"
       />,
     );
     const link = screen.getByRole("link", { name: /citation 1/i });
@@ -53,6 +56,7 @@ describe("AssistantBubble", () => {
     render(
       <AssistantBubble
         message={withOneTool("Citing the second tool [t:2] (but only one ran).")}
+        slug="public-atlas"
       />,
     );
     // No link role for an invalid ordinal.
@@ -62,7 +66,9 @@ describe("AssistantBubble", () => {
   });
 
   it("clicking a citation opens the WhyPanel and shows the cited tool row", () => {
-    render(<AssistantBubble message={withOneTool("CD8A [t:1].")} />);
+    render(
+      <AssistantBubble message={withOneTool("CD8A [t:1].")} slug="public-atlas" />,
+    );
     // Panel collapsed initially — tool row not visible
     expect(screen.queryByText(/compare_groups/)).toBeNull();
     fireEvent.click(screen.getByRole("link", { name: /citation 1/i }));
@@ -84,8 +90,38 @@ describe("AssistantBubble", () => {
           ],
           trace: [],
         }}
+        slug="public-atlas"
       />,
     );
     expect(screen.getByText(/compare_groups/)).toBeDefined();
+  });
+
+  it("renders FeedbackThumbs when message.id is present", () => {
+    vi.spyOn(chatClient, "putFeedback").mockResolvedValue({
+      rating: "up",
+      comment: null,
+    });
+    render(
+      <AssistantBubble
+        message={{
+          ...withOneTool("Some answer."),
+          id: "msg-1",
+          feedback: { rating: "up", comment: null },
+        }}
+        slug="public-atlas"
+      />,
+    );
+    // Thumb-up should render in the filled state.
+    expect(screen.getByRole("button", { name: /thumbs up/i })).toBeDefined();
+  });
+
+  it("does not render FeedbackThumbs on a streaming message (no id)", () => {
+    render(
+      <AssistantBubble
+        message={withOneTool("Mid-stream answer.")}
+        slug="public-atlas"
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /thumbs up/i })).toBeNull();
   });
 });

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -16,8 +16,10 @@ import remarkGfm from "remark-gfm";
 import { Alert, Tag } from "antd";
 import { Citation } from "./Citation";
 import { parseCitations } from "./citations";
+import { FeedbackThumbs } from "./FeedbackThumbs";
+import { useChatFeedback } from "./useChatFeedback";
 import { WhyPanel } from "./WhyPanel";
-import type { ChatMessage, MessagePart, ToolPart } from "./types";
+import type { ChatMessage, MessageFeedback, MessagePart, ToolPart } from "./types";
 
 const FLASH_MS = 2000;
 
@@ -67,11 +69,13 @@ function ToolPartTag({ part }: { part: ToolPart }) {
 
 export type AssistantBubbleProps = {
   message: ChatMessage;
+  /** Dataset slug — required to scope feedback writes to the right thread. */
+  slug: string;
   /** Inherited from the parent — controls antd-table layout etc. */
   markdownComponents?: Components;
 };
 
-export function AssistantBubble({ message, markdownComponents }: AssistantBubbleProps) {
+export function AssistantBubble({ message, slug, markdownComponents }: AssistantBubbleProps) {
   const [whyOpen, setWhyOpen] = useState(false);
   const [flashOrdinal, setFlashOrdinal] = useState<number | null>(null);
 
@@ -123,13 +127,50 @@ export function AssistantBubble({ message, markdownComponents }: AssistantBubble
           markdownComponents={componentsWithCitations}
         />
       ))}
-      <WhyPanel
-        message={message}
-        open={whyOpen}
-        onOpenChange={setWhyOpen}
-        flashOrdinal={flashOrdinal}
-      />
+      <span style={{ display: "inline-flex", alignItems: "flex-start", gap: 12 }}>
+        <WhyPanel
+          message={message}
+          open={whyOpen}
+          onOpenChange={setWhyOpen}
+          flashOrdinal={flashOrdinal}
+        />
+        {message.id && (
+          <FeedbackSlot
+            slug={slug}
+            messageId={message.id}
+            initial={message.feedback ?? null}
+          />
+        )}
+      </span>
     </div>
+  );
+}
+
+function FeedbackSlot({
+  slug,
+  messageId,
+  initial,
+}: {
+  slug: string;
+  messageId: string;
+  initial: MessageFeedback | null;
+}) {
+  const { rating, comment, setFeedback, status } = useChatFeedback(
+    slug,
+    messageId,
+    initial,
+  );
+  return (
+    <FeedbackThumbs
+      rating={rating}
+      comment={comment}
+      onChange={(next) => {
+        setFeedback(next).catch(() => {
+          // optimistic revert handled inside the hook; toast is out of scope v1
+        });
+      }}
+      disabled={status === "pending"}
+    />
   );
 }
 

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -127,7 +127,7 @@ export function AssistantBubble({ message, slug, markdownComponents }: Assistant
           markdownComponents={componentsWithCitations}
         />
       ))}
-      <span style={{ display: "inline-flex", alignItems: "flex-start", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
         <WhyPanel
           message={message}
           open={whyOpen}
@@ -141,7 +141,7 @@ export function AssistantBubble({ message, slug, markdownComponents }: Assistant
             initial={message.feedback ?? null}
           />
         )}
-      </span>
+      </div>
     </div>
   );
 }

--- a/packages/highperformer/src/chat/ChatPanel.tsx
+++ b/packages/highperformer/src/chat/ChatPanel.tsx
@@ -25,6 +25,8 @@ export function ChatPanel({ slug }: { slug: string }) {
     const initialHistory: ChatMessage[] = detail.messages.map((m) => ({
       role: m.role,
       parts: [{ kind: "text", text: m.content }],
+      id: m.id,
+      feedback: m.feedback ?? null,
     }));
     setMode({
       kind: "active",

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -239,6 +239,7 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
                 {m.role === "assistant" ? (
                   <AssistantBubble
                     message={m}
+                    slug={slug}
                     markdownComponents={markdownComponents}
                   />
                 ) : (
@@ -251,6 +252,7 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
                 <strong>Assistant: </strong>
                 <AssistantBubble
                   message={state.current}
+                  slug={slug}
                   markdownComponents={markdownComponents}
                 />
               </div>

--- a/packages/highperformer/src/chat/FeedbackThumbs.test.tsx
+++ b/packages/highperformer/src/chat/FeedbackThumbs.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { FeedbackThumbs } from "./FeedbackThumbs";
+
+afterEach(() => cleanup());
+
+describe("FeedbackThumbs", () => {
+  it("renders both thumbs in neutral state when rating is null", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating={null} comment={null} onChange={onChange} />);
+    expect(screen.getByRole("button", { name: /thumbs up/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /thumbs down/i })).toBeDefined();
+    // No comment box in null state.
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("clicking thumb-up calls onChange with rating up", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating={null} comment={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /thumbs up/i }));
+    expect(onChange).toHaveBeenCalledWith({ rating: "up", comment: null });
+  });
+
+  it("clicking the active thumb-up clears the rating", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating="up" comment={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /thumbs up/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("renders the comment textarea when rating is down", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating="down" comment={null} onChange={onChange} />);
+    expect(screen.getByRole("textbox")).toBeDefined();
+  });
+
+  it("sending a comment calls onChange with rating down + comment", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating="down" comment={null} onChange={onChange} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "off-topic answer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      rating: "down",
+      comment: "off-topic answer",
+    });
+  });
+
+  it("disabled prop disables both thumbs and the textarea", () => {
+    const onChange = vi.fn();
+    render(
+      <FeedbackThumbs rating="down" comment="" onChange={onChange} disabled />,
+    );
+    expect(screen.getByRole("button", { name: /thumbs up/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+    expect(screen.getByRole("button", { name: /thumbs down/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+    expect(screen.getByRole("textbox")).toHaveProperty("disabled", true);
+  });
+});

--- a/packages/highperformer/src/chat/FeedbackThumbs.tsx
+++ b/packages/highperformer/src/chat/FeedbackThumbs.tsx
@@ -1,0 +1,97 @@
+/**
+ * Feedback thumbs — presentational thumbs-up/down control for assistant
+ * messages. Pure UI: takes the current rating + comment and an onChange
+ * callback. The hook that wires this to the API lives in useMessageFeedback
+ * (Task 9); integration into AssistantBubble is Task 10.
+ *
+ * Behavior:
+ * - Clicking an inactive thumb selects it (emits {rating, comment: null}).
+ * - Clicking the active thumb clears the rating (emits null).
+ * - Selecting thumb-down reveals an optional comment textbox; pressing Enter
+ *   or Send emits the rating + comment.
+ */
+import {
+  LikeOutlined,
+  LikeFilled,
+  DislikeOutlined,
+  DislikeFilled,
+} from "@ant-design/icons";
+import { Button, Input } from "antd";
+import { useState } from "react";
+import type { MessageFeedback } from "./types";
+
+export type FeedbackThumbsProps = {
+  rating: "up" | "down" | null;
+  comment: string | null;
+  onChange: (next: MessageFeedback | null) => void;
+  disabled?: boolean;
+};
+
+export function FeedbackThumbs({
+  rating,
+  comment,
+  onChange,
+  disabled,
+}: FeedbackThumbsProps) {
+  const [draft, setDraft] = useState(comment ?? "");
+
+  const handleUp = () => {
+    if (rating === "up") {
+      onChange(null);
+    } else {
+      onChange({ rating: "up", comment: null });
+    }
+  };
+
+  const handleDown = () => {
+    if (rating === "down") {
+      onChange(null);
+      setDraft("");
+    } else {
+      onChange({ rating: "down", comment: null });
+    }
+  };
+
+  const sendComment = () => {
+    onChange({ rating: "down", comment: draft.trim() || null });
+  };
+
+  return (
+    <span style={{ display: "inline-flex", flexDirection: "column", gap: 4 }}>
+      <span style={{ display: "inline-flex", gap: 4 }}>
+        <Button
+          aria-label="thumbs up"
+          size="small"
+          type="text"
+          disabled={disabled}
+          icon={rating === "up" ? <LikeFilled /> : <LikeOutlined />}
+          onClick={handleUp}
+        />
+        <Button
+          aria-label="thumbs down"
+          size="small"
+          type="text"
+          disabled={disabled}
+          icon={rating === "down" ? <DislikeFilled /> : <DislikeOutlined />}
+          onClick={handleDown}
+        />
+      </span>
+      {rating === "down" && (
+        <span style={{ display: "inline-flex", gap: 4, alignItems: "center" }}>
+          <Input
+            size="small"
+            placeholder="What was wrong? (optional)"
+            value={draft}
+            disabled={disabled}
+            onChange={(e) => setDraft(e.target.value)}
+            onPressEnter={sendComment}
+            style={{ width: 200 }}
+          />
+          <Button size="small" disabled={disabled} onClick={sendComment}>
+            Send
+          </Button>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -78,6 +78,21 @@ describe("eventReducer.reduce", () => {
     expect(s.status).toBe("idle");
   });
 
+  it("done event carries message_id onto the finalized assistant message", () => {
+    let s = initialState();
+    s = reduce(s, { type: "text_delta", text: "hi" }, noopApply);
+    s = reduce(
+      s,
+      {
+        type: "done",
+        usage: { input_tokens: 1, output_tokens: 2 },
+        message_id: "msg-server-abc",
+      },
+      noopApply,
+    );
+    expect(s.history[0].id).toBe("msg-server-abc");
+  });
+
   it("mid-stream error between text_delta events keeps partial text visible", () => {
     let s = initialState();
     s = reduce(s, { type: "text_delta", text: "before " }, noopApply);

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -142,7 +142,12 @@ export function reduce(
     }
     case "done": {
       const cur = state.current
-        ? { ...state.current, endedAt: Date.now(), usage: ev.usage }
+        ? {
+            ...state.current,
+            endedAt: Date.now(),
+            usage: ev.usage,
+            id: ev.message_id ?? state.current.id,
+          }
         : null;
       return {
         history: cur ? [...state.history, cur] : state.history,

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -45,13 +45,20 @@ export type ThreadSummary = {
 
 export type ThreadListResponse = { threads: ThreadSummary[] };
 
+export type MessageFeedback = {
+  rating: "up" | "down";
+  comment?: string | null;
+};
+
 export type ThreadDetailResponse = {
   id: string;
   title: string;
   messages: {
+    id: string;
     role: "user" | "assistant";
     content: string;
     created_at: string;
+    feedback?: MessageFeedback | null;
   }[];
 };
 
@@ -149,6 +156,10 @@ export type ChatMessage = {
   /** ms timestamps for computing total turn duration. */
   startedAt?: number;
   endedAt?: number;
+  /** Server-assigned message id (present once persisted; absent during streaming). */
+  id?: string;
+  /** Feedback hydrated from the server when reloading a thread. */
+  feedback?: MessageFeedback | null;
 };
 
 // ---------- chip definitions ----------

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -94,6 +94,10 @@ export type ErrorEvent   = { type: "error"; message: string; retryable: boolean 
 export type DoneEvent    = {
   type: "done";
   usage: { input_tokens: number; output_tokens: number };
+  /** Server-assigned id of the persisted assistant message — present once
+   * the backend has flushed the row (which it does inline before yielding
+   * the done event). Absent on older servers. */
+  message_id?: string;
 };
 export type ThreadOpenEvent = {
   type: "thread_open";

--- a/packages/highperformer/src/chat/useChatFeedback.test.ts
+++ b/packages/highperformer/src/chat/useChatFeedback.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useChatFeedback } from "./useChatFeedback";
+import { chat } from "../api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useChatFeedback", () => {
+  it("starts with the seeded rating + comment", () => {
+    const { result } = renderHook(() =>
+      useChatFeedback("slug", "msg-1", { rating: "up", comment: null }),
+    );
+    expect(result.current.rating).toBe("up");
+    expect(result.current.comment).toBeNull();
+  });
+
+  it("setRating('up') calls chat.putFeedback and updates state", async () => {
+    const putSpy = vi
+      .spyOn(chat, "putFeedback")
+      .mockResolvedValue({ rating: "up", comment: null });
+    const { result } = renderHook(() => useChatFeedback("slug", "msg-1", null));
+    await act(async () => {
+      await result.current.setFeedback({ rating: "up", comment: null });
+    });
+    expect(putSpy).toHaveBeenCalledWith(
+      "slug",
+      "msg-1",
+      { rating: "up", comment: null },
+    );
+    expect(result.current.rating).toBe("up");
+  });
+
+  it("setFeedback(null) calls chat.deleteFeedback and clears state", async () => {
+    const deleteSpy = vi.spyOn(chat, "deleteFeedback").mockResolvedValue();
+    const { result } = renderHook(() =>
+      useChatFeedback("slug", "msg-1", { rating: "up", comment: null }),
+    );
+    await act(async () => {
+      await result.current.setFeedback(null);
+    });
+    expect(deleteSpy).toHaveBeenCalledWith("slug", "msg-1");
+    expect(result.current.rating).toBeNull();
+  });
+
+  it("reverts optimistic state on API failure", async () => {
+    vi.spyOn(chat, "putFeedback").mockRejectedValue(new Error("nope"));
+    const { result } = renderHook(() => useChatFeedback("slug", "msg-1", null));
+    await act(async () => {
+      await result.current
+        .setFeedback({ rating: "up", comment: null })
+        .catch(() => {});
+    });
+    // Reverted to initial null.
+    expect(result.current.rating).toBeNull();
+  });
+});

--- a/packages/highperformer/src/chat/useChatFeedback.ts
+++ b/packages/highperformer/src/chat/useChatFeedback.ts
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { chat } from "../api";
+import type { MessageFeedback } from "./types";
+
+export function useChatFeedback(
+  slug: string,
+  messageId: string,
+  initial: MessageFeedback | null,
+) {
+  const [rating, setRating] = useState<"up" | "down" | null>(
+    initial?.rating ?? null,
+  );
+  const [comment, setComment] = useState<string | null>(
+    initial?.comment ?? null,
+  );
+  const [status, setStatus] = useState<"idle" | "pending" | "error">("idle");
+
+  async function setFeedback(next: MessageFeedback | null): Promise<void> {
+    // Capture previous state for rollback.
+    const prev = { rating, comment };
+    setRating(next?.rating ?? null);
+    setComment(next?.comment ?? null);
+    setStatus("pending");
+    try {
+      if (next === null) {
+        await chat.deleteFeedback(slug, messageId);
+      } else {
+        const persisted = await chat.putFeedback(slug, messageId, {
+          rating: next.rating,
+          comment: next.comment ?? null,
+        });
+        setRating(persisted.rating);
+        setComment(persisted.comment ?? null);
+      }
+      setStatus("idle");
+    } catch (err) {
+      setRating(prev.rating);
+      setComment(prev.comment);
+      setStatus("error");
+      throw err;
+    }
+  }
+
+  return { rating, comment, setFeedback, status };
+}


### PR DESCRIPTION
Frontend half of per-turn chat feedback. Pairs with the backend PR (cell-explorer-py#110, merged).

- New `FeedbackThumbs` presentational component (thumbs + inline comment textarea on down)
- New `useChatFeedback` hook — optimistic state, PUT/DELETE plumbing, rollback on error
- `AssistantBubble` renders the thumbs strip next to the WhyPanel chip when the message has a server id (post-stream)
- `ChatPanel` hydrates `id` and `feedback` from the thread-detail response so the right thumb is filled on reload
- Wire types updated to match the new backend response shape

## Test plan
- [x] Presentational tests: thumbs neutral/up/down states, toggle clear, comment send, disabled prop
- [x] Hook tests: PUT on rating set, DELETE on null, optimistic rollback on API error
- [x] AssistantBubble: renders strip with server id; absent on streaming message
- [ ] Manual: thumbs persist across reload, comment persists, cross-user check confirms per-user isolation