### PR TITLE
fix(config): apply clear-filter payloads (empty ids dispatches clearCustomGroup)

### DIFF
--- a/.changeset/applyconfig-clear-filter.md
+++ b/.changeset/applyconfig-clear-filter.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix `applyConfig` silently no-op'ing on filter-clear payloads. The chat
+agent's `clear_filter` tool emits `{filter: {obsColumn: "_none", ids: []}}`,
+but the prior guard required `ids.length > 0` so the payload was
+ignored — the agent would say "filter cleared!" while the filter
+stayed active. Empty `ids` now dispatches `clearCustomGroup`.

--- a/packages/highperformer/src/config/applyConfig.test.ts
+++ b/packages/highperformer/src/config/applyConfig.test.ts
@@ -223,6 +223,60 @@ describe('applyConfig', () => {
     expect(selectByIds).toHaveBeenCalledWith('sample_id', ['cell1', 'cell2'])
     selectByIds.mockRestore()
   })
+
+  it('clears the filter when ids is empty (clear sentinel from chat-agent clear_filter)', async () => {
+    // The chat-agent's clear_filter tool emits { filter: { obsColumn: "_none", ids: [] } }.
+    // applyConfig must dispatch clearCustomGroup so the viewer actually resets,
+    // not silently no-op (which is what happened before this fix).
+    const clearCustomGroup = vi
+      .spyOn(useAppStore.getState(), 'clearCustomGroup')
+      .mockImplementation(() => {})
+    const selectByIds = vi
+      .spyOn(useAppStore.getState(), 'selectByIds')
+      .mockImplementation(() => {})
+
+    useAppStore.setState({
+      obsColumnNames: ['cell_type'],
+      obsmKeys: [],
+      varNames: [],
+      varColumns: [],
+    })
+
+    const result = await applyConfig({
+      filter: { obsColumn: '_none', ids: [] },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(clearCustomGroup).toHaveBeenCalledTimes(1)
+    expect(selectByIds).not.toHaveBeenCalled()
+
+    clearCustomGroup.mockRestore()
+    selectByIds.mockRestore()
+  })
+
+  it('does not validate obsColumn against schema when clearing', async () => {
+    // The clear sentinel uses "_none" which isn't a real obs column. Validating
+    // would falsely reject the clear payload with field_value_invalid.
+    const clearCustomGroup = vi
+      .spyOn(useAppStore.getState(), 'clearCustomGroup')
+      .mockImplementation(() => {})
+
+    useAppStore.setState({
+      obsColumnNames: ['cell_type', 'sample_id'],
+      obsmKeys: [],
+      varNames: [],
+      varColumns: [],
+    })
+
+    const result = await applyConfig({
+      filter: { obsColumn: '_none', ids: [] },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(clearCustomGroup).toHaveBeenCalledTimes(1)
+
+    clearCustomGroup.mockRestore()
+  })
 })
 
 describe('applyConfig — return type and schema validation', () => {

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -300,22 +300,29 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
     }
   }
 
-  // 3e: Custom group filter
-  if (config.filter && config.filter.ids.length > 0) {
-    const { obsColumnNames } = store.getState()
-    if (!obsColumnNames.includes(config.filter.obsColumn)) {
-      return err({
-        kind: 'field_value_invalid',
-        field: 'filter.obsColumn',
-        value: config.filter.obsColumn,
-        reason: 'not found in dataset',
-      })
-    }
-    store.getState().selectByIds(config.filter.obsColumn, config.filter.ids)
-    // Default: when filter is set, switch summary to selections — UNLESS the
-    // caller explicitly specified summaryContext (then their value wins).
-    if (config.summaryContext === undefined) {
-      store.setState({ summaryContext: 'selections' })
+  // 3e: Custom group filter. Empty `ids` is the clear sentinel — the agent's
+  // `clear_filter` tool emits `{filter: {obsColumn: "_none", ids: []}}`. Skip
+  // obsColumn validation in that case because the sentinel name won't appear
+  // in the dataset schema.
+  if (config.filter) {
+    if (config.filter.ids.length === 0) {
+      store.getState().clearCustomGroup()
+    } else {
+      const { obsColumnNames } = store.getState()
+      if (!obsColumnNames.includes(config.filter.obsColumn)) {
+        return err({
+          kind: 'field_value_invalid',
+          field: 'filter.obsColumn',
+          value: config.filter.obsColumn,
+          reason: 'not found in dataset',
+        })
+      }
+      store.getState().selectByIds(config.filter.obsColumn, config.filter.ids)
+      // Default: when filter is set, switch summary to selections — UNLESS
+      // the caller explicitly specified summaryContext (then their value wins).
+      if (config.summaryContext === undefined) {
+        store.setState({ summaryContext: 'selections' })
+      }
     }
   }
 


### PR DESCRIPTION
The chat agent's \`clear_filter\` tool emits \`{filter: {obsColumn: "_none", ids: []}}\`. The frontend's \`applyConfig\` guarded the filter branch with \`ids.length > 0\`, so the payload was silently dropped — the agent reported "filter cleared!" while the filter stayed active.

- Empty \`ids\` now dispatches \`clearCustomGroup\` instead of falling through
- Skip the obsColumn-against-schema check in the clear case (the \`"_none"\` sentinel isn't a real column and would otherwise trigger a false \`field_value_invalid\` error)

Pairs with cell-explorer-py#114 (prompt rule that makes the agent actually call \`clear_filter\` for "undo filter" phrases). Without this frontend fix, the prompt fix alone wasn't enough.

## Test plan
- [x] \`pnpm test\` — 427 passing in highperformer
- [x] New tests cover: clear-with-empty-ids dispatches clearCustomGroup, no false validation error on \`obsColumn: "_none"\`