### PR TITLE
fix(chat): finalize aborted turn onto history to preserve alternation

### DIFF
--- a/.changeset/chat-history-on-abort.md
+++ b/.changeset/chat-history-on-abort.md
@@ -1,0 +1,14 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix: aborting a chat turn (especially mid-tool-call) no longer breaks
+the next turn with a `messages[N].role must be 'assistant'` validation
+error. The reducer's `error` case now finalizes the in-flight assistant
+message onto `state.history` (instead of leaving it in `state.current`),
+preserving the user/assistant alternation that the wire protocol
+requires. When abort happens before any text streamed, a synthetic
+`(interrupted)` text part is prepended so the wire content is non-empty
+(Anthropic-style APIs reject empty assistant content). As a side
+benefit, multiple errors that fire across separate turns now render as
+separate bubbles instead of accumulating into one.

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -57,15 +57,67 @@ describe("eventReducer.reduce", () => {
     expect(asyncApply).toHaveBeenCalledTimes(1);
   });
 
-  it("error event appends ErrorPart and sets status to error, keeps preceding text", () => {
+  it("error event finalizes current onto history with the error part attached", () => {
     let s = initialState();
     s = reduce(s, { type: "text_delta", text: "partial " }, noopApply);
     s = reduce(s, { type: "error", message: "boom", retryable: false }, noopApply);
     expect(s.status).toBe("error");
-    expect(s.current!.parts).toEqual([
+    expect(s.current).toBeNull();
+    expect(s.history).toHaveLength(1);
+    expect(s.history[0].parts).toEqual([
       { kind: "text", text: "partial " },
       { kind: "error", message: "boom" },
     ]);
+  });
+
+  it("error before any text streamed prepends synthetic (interrupted) text so wire content is non-empty", () => {
+    // Repros the abort-during-tool-call case: tool fires, user aborts before
+    // any text streams. Without a synthetic placeholder the resulting wire
+    // assistant message has empty content, which Anthropic-style APIs reject.
+    let s = initialState();
+    s = reduce(s, { type: "tool_progress", tool: "top_genes", status: "started" }, noopApply);
+    s = reduce(s, { type: "error", message: "aborted", retryable: false }, noopApply);
+    expect(s.current).toBeNull();
+    expect(s.history).toHaveLength(1);
+    const parts = s.history[0].parts;
+    expect(parts[0]).toEqual({ kind: "text", text: "(interrupted)" });
+    expect(parts.some((p) => p.kind === "tool")).toBe(true);
+    expect(parts.some((p) => p.kind === "error")).toBe(true);
+  });
+
+  it("error with no in-flight turn creates a synthetic assistant entry for alternation", () => {
+    // Edge case: server errors during handshake, before any text_delta or
+    // tool_progress. The reducer still needs to leave a placeholder so the
+    // next user message lands in a well-formed alternation.
+    let s = initialState();
+    s = reduce(s, { type: "error", message: "no thread", retryable: false }, noopApply);
+    expect(s.current).toBeNull();
+    expect(s.history).toHaveLength(1);
+    expect(s.history[0].role).toBe("assistant");
+    expect(s.history[0].parts[0]).toEqual({ kind: "text", text: "(interrupted)" });
+    expect(s.history[0].parts.some((p) => p.kind === "error")).toBe(true);
+  });
+
+  it("USER_SUBMIT-style append after error produces well-formed user/assistant/user history", () => {
+    // The bug we're fixing: turn 1 aborts mid-tool, user types turn 2,
+    // wire messages must alternate. After the error, history must end with
+    // an assistant entry so the next user message is the only consecutive
+    // role.
+    let s = initialState();
+    // Synthetic turn 1: user → assistant streams a tool → aborts
+    s = {
+      ...s,
+      history: [{ role: "user", parts: [{ kind: "text", text: "what are the top 20?" }] }],
+    };
+    s = reduce(s, { type: "tool_progress", tool: "top_genes", status: "started" }, noopApply);
+    s = reduce(s, { type: "error", message: "aborted", retryable: false }, noopApply);
+    // Now simulate the next user submission appending to history.
+    expect(s.history.map((m) => m.role)).toEqual(["user", "assistant"]);
+    const withNextUser = [
+      ...s.history,
+      { role: "user" as const, parts: [{ kind: "text" as const, text: "nevermind" }] },
+    ];
+    expect(withNextUser.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
   });
 
   it("done finalizes current onto history and clears current", () => {
@@ -93,23 +145,26 @@ describe("eventReducer.reduce", () => {
     expect(s.history[0].id).toBe("msg-server-abc");
   });
 
-  it("mid-stream error between text_delta events keeps partial text visible", () => {
+  it("mid-stream error between text_delta events keeps partial text visible in history", () => {
     let s = initialState();
     s = reduce(s, { type: "text_delta", text: "before " }, noopApply);
     s = reduce(s, { type: "error", message: "x", retryable: false }, noopApply);
-    expect(s.current!.parts.find((p) => p.kind === "text")).toEqual({
+    expect(s.current).toBeNull();
+    expect(s.history[0].parts.find((p) => p.kind === "text")).toEqual({
       kind: "text",
       text: "before ",
     });
   });
 
-  it("unknown event type appends a synthetic error part instead of throwing", () => {
+  it("unknown event type finalizes a synthetic error entry to history", () => {
     const s = reduce(
       initialState(),
       { type: "garbage" } as unknown as ChatEvent,
       noopApply,
     );
     expect(s.status).toBe("error");
-    expect(s.current!.parts.some((p) => p.kind === "error")).toBe(true);
+    expect(s.current).toBeNull();
+    expect(s.history).toHaveLength(1);
+    expect(s.history[0].parts.some((p) => p.kind === "error")).toBe(true);
   });
 });

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -76,6 +76,16 @@ function appendErrorPart(parts: MessagePart[], message: string): MessagePart[] {
   return [...parts, err];
 }
 
+function ensureNonEmptyText(parts: MessagePart[]): MessagePart[] {
+  // Ensure the resulting wire content (text parts joined) is non-empty.
+  // Anthropic-style APIs reject assistant messages with empty content, which
+  // happens when a turn aborts before any text streamed (e.g. mid-tool-call).
+  const hasText = parts.some((p) => p.kind === "text" && p.text.length > 0);
+  if (hasText) return parts;
+  const placeholder: TextPart = { kind: "text", text: "(interrupted)" };
+  return [placeholder, ...parts];
+}
+
 export function reduce(
   state: State,
   ev: ChatEvent,
@@ -130,13 +140,22 @@ export function reduce(
       };
     }
     case "error": {
-      const cur = ensureCurrent(state);
+      // Finalize the in-flight (or synthesize a placeholder) assistant
+      // message onto history with the error attached. Keeping the assistant
+      // turn in history is required so the conversation alternation
+      // (user/assistant/user/...) survives — otherwise the next user submit
+      // produces back-to-back user messages and the server rejects with a
+      // role-alternation 422.
+      const base = ensureCurrent(state);
+      const partsWithText = ensureNonEmptyText(base.parts);
+      const partsWithError = appendErrorPart(partsWithText, ev.message);
+      const finalized = appendTrace(
+        { ...base, parts: partsWithError, endedAt: Date.now() },
+        { kind: "error", message: ev.message },
+      );
       return {
-        ...state,
-        current: appendTrace(
-          { ...cur, parts: appendErrorPart(cur.parts, ev.message) },
-          { kind: "error", message: ev.message },
-        ),
+        history: [...state.history, finalized],
+        current: null,
         status: "error",
       };
     }
@@ -156,14 +175,10 @@ export function reduce(
       };
     }
     default: {
-      // Unknown event type — defensive; surface as error part.
-      const cur = ensureCurrent(state);
+      // Unknown event type — defensive; surface as an error by reusing the
+      // error case's finalize-to-history path so alternation is preserved.
       const message = `unknown event type: ${(ev as { type?: string }).type ?? "<missing>"}`;
-      return {
-        ...state,
-        current: { ...cur, parts: appendErrorPart(cur.parts, message) },
-        status: "error",
-      };
+      return reduce(state, { type: "error", message, retryable: false }, applyConfig);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix: aborting a chat turn mid-tool-call no longer breaks the next turn with `HTTP 422: messages[N].role must be 'assistant'`.

**Root cause:** the reducer's `error` case left the partial assistant message in `state.current` and never moved it to `state.history`. `toWireMessages` only consumes `history`, so the next user submission sent back-to-back user roles, failing server-side alternation validation.

**Fix:** the `error` case now finalizes the in-flight (or a synthetic) assistant message onto history with the error attached. If no text streamed before the error, a `(interrupted)` placeholder is prepended so wire content is non-empty (Anthropic-style APIs reject empty assistant content). The unknown-event-type fallback reuses the same path.

Side benefit: separate-turn errors render as separate bubbles instead of accumulating into one.

## Test plan

- [x] reducer unit tests updated (13/13 passing) — finalize-to-history behavior covered including the no-text + tool-only path
- [x] full highperformer suite: 430/430
- [x] manual: stop mid-tool-call, ask follow-up → succeeds (previously 422)