### PR TITLE
fix(chat): friendlier cancel UX + working indicators

### DIFF
--- a/.changeset/chat-cancel-ux.md
+++ b/.changeset/chat-cancel-ux.md
@@ -16,3 +16,9 @@ Chat cancellation and streaming UX polish:
   message while streaming, until the first text/tool arrives.
 - Adds a subtle pulse animation on in-flight tool pills so they
   read as actively working alongside the higher-level indicator.
+- Hardens the wire-message builder with `ensureAlternation` so
+  hydrated threads whose last persisted message is a user role
+  (possible if an older assistant turn errored before persisting)
+  don't immediately 422 on the next submit. Inserts a synthetic
+  `(interrupted)` assistant in the wire payload only — does not
+  mutate stored history.

--- a/.changeset/chat-cancel-ux.md
+++ b/.changeset/chat-cancel-ux.md
@@ -1,0 +1,18 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Chat cancellation and streaming UX polish:
+
+- Replaces the browser-raw `"BodyStreamBuffer was aborted"` /
+  `"signal is aborted without reason"` text with a friendly
+  `"Cancelled"` message when the user clicks Stop. `useChatTurn`
+  swallows AbortErrors it initiated itself and emits an `error`
+  event with the clean message via `onEvent` instead of bubbling.
+- In-flight tool pills (`status: "started"`) are now moved to a
+  terminal `"error"` state when the turn errors or cancels, so the
+  pill stops spinning forever.
+- Adds a "Thinking…" indicator (small Spin + label) under the user's
+  message while streaming, until the first text/tool arrives.
+- Adds a subtle pulse animation on in-flight tool pills so they
+  read as actively working alongside the higher-level indicator.

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -59,8 +59,11 @@ function walk(
 function ToolPartTag({ part }: { part: ToolPart }) {
   const sym = part.status === "started" ? "▶" : part.status === "ok" ? "✓" : "✗";
   const color = part.status === "error" ? "red" : part.status === "ok" ? "green" : "blue";
+  // Pulse the pill while the tool is in flight so it reads as "working"
+  // alongside the higher-level "Thinking…" indicator. Keyframes in index.css.
+  const className = part.status === "started" ? "chat-tool-pulse" : undefined;
   return (
-    <Tag color={color}>
+    <Tag color={color} className={className}>
       {sym} {part.tool}
       {part.summary ? ` — ${part.summary}` : part.status === "started" ? "…" : ""}
     </Tag>

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Input, Tag } from "antd";
+import { Alert, Button, Input, Spin, Tag } from "antd";
 import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -255,6 +255,12 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
                   slug={slug}
                   markdownComponents={markdownComponents}
                 />
+              </div>
+            )}
+            {streaming && !state.current && (
+              <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#666", fontSize: 12 }}>
+                <Spin size="small" />
+                <span>Thinking…</span>
               </div>
             )}
             {hasError && (

--- a/packages/highperformer/src/chat/ConversationView.tsx
+++ b/packages/highperformer/src/chat/ConversationView.tsx
@@ -9,6 +9,7 @@ import { deriveSuggestionChips } from "./suggestionChips";
 import type { ChatEvent, ChatMessage, ContextResponse, MessagePart, WireMessage } from "./types";
 import { useChatTurn } from "./useChatTurn";
 import { AssistantBubble } from "./AssistantBubble";
+import { ensureAlternation } from "./wireMessages";
 
 type Action =
   | { type: "AGENT_EVENT"; event: ChatEvent }
@@ -158,10 +159,14 @@ export function ConversationView({ slug, ctxData, threadId, initialHistory, onTh
       const trimmed = text.trim();
       if (!trimmed || streaming) return;
       dispatch({ type: "USER_SUBMIT", content: trimmed });
-      const wireMessages: WireMessage[] = [
+      // ensureAlternation guards against hydrated threads whose last
+      // persisted message is a user role (server can leave one trailing if
+      // an earlier assistant turn errored before persisting) — without this,
+      // the next submit produces [user, user] and the server returns 422.
+      const wireMessages: WireMessage[] = ensureAlternation([
         ...toWireMessages(state.history),
         { role: "user", content: trimmed },
-      ];
+      ]);
       setLastSubmittedMessages(wireMessages);
       setInput("");
       try {

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -70,6 +70,17 @@ describe("eventReducer.reduce", () => {
     ]);
   });
 
+  it("error finalizes any in-flight (started) tool parts to terminal error state", () => {
+    // A turn that errors/cancels mid-tool-call should not leave the pill
+    // spinning forever. Move started → error so the bubble settles.
+    let s = initialState();
+    s = reduce(s, { type: "tool_progress", tool: "top_genes", status: "started" }, noopApply);
+    s = reduce(s, { type: "error", message: "Cancelled", retryable: false }, noopApply);
+    const toolPart = s.history[0].parts.find((p) => p.kind === "tool");
+    expect(toolPart).toBeDefined();
+    expect(toolPart!.status).toBe("error");
+  });
+
   it("error before any text streamed prepends synthetic (interrupted) text so wire content is non-empty", () => {
     // Repros the abort-during-tool-call case: tool fires, user aborts before
     // any text streams. Without a synthetic placeholder the resulting wire

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -86,6 +86,17 @@ function ensureNonEmptyText(parts: MessagePart[]): MessagePart[] {
   return [placeholder, ...parts];
 }
 
+function finalizeStartedTools(parts: MessagePart[]): MessagePart[] {
+  // A turn that errors/cancels mid-tool-call leaves any in-flight ToolPart
+  // stuck in `status: "started"` — the pill renders forever as a spinner.
+  // Move them to a terminal "error" state so the bubble settles.
+  return parts.map((p) =>
+    p.kind === "tool" && p.status === "started"
+      ? ({ ...p, status: "error" as const } satisfies ToolPart)
+      : p,
+  );
+}
+
 export function reduce(
   state: State,
   ev: ChatEvent,
@@ -147,7 +158,8 @@ export function reduce(
       // produces back-to-back user messages and the server rejects with a
       // role-alternation 422.
       const base = ensureCurrent(state);
-      const partsWithText = ensureNonEmptyText(base.parts);
+      const partsWithFinalizedTools = finalizeStartedTools(base.parts);
+      const partsWithText = ensureNonEmptyText(partsWithFinalizedTools);
       const partsWithError = appendErrorPart(partsWithText, ev.message);
       const finalized = appendTrace(
         { ...base, parts: partsWithError, endedAt: Date.now() },

--- a/packages/highperformer/src/chat/useChatTurn.test.ts
+++ b/packages/highperformer/src/chat/useChatTurn.test.ts
@@ -69,7 +69,7 @@ describe("useChatTurn", () => {
     expect(result.current.streaming).toBe(false);
   });
 
-  it("stop() aborts the iteration with AbortError", async () => {
+  it("stop() emits a friendly 'Cancelled' error event and does not throw", async () => {
     let abortSignal: AbortSignal | undefined;
     fetchMock.mockImplementation((_url, init: RequestInit) => {
       abortSignal = init.signal as AbortSignal;
@@ -81,10 +81,13 @@ describe("useChatTurn", () => {
     });
 
     const { result } = renderHook(() => useChatTurn());
+    const events: ChatEvent[] = [];
     let caught: unknown;
     const startPromise = act(async () => {
       try {
-        await result.current.start("s", [{ role: "user", content: "hi" }], null, () => {});
+        await result.current.start("s", [{ role: "user", content: "hi" }], null, (e) =>
+          events.push(e),
+        );
       } catch (e) {
         caught = e;
       }
@@ -92,7 +95,8 @@ describe("useChatTurn", () => {
     // Stop immediately.
     act(() => result.current.stop());
     await startPromise;
-    expect((caught as Error).name).toBe("AbortError");
+    expect(caught).toBeUndefined();
+    expect(events).toEqual([{ type: "error", message: "Cancelled", retryable: false }]);
     expect(result.current.streaming).toBe(false);
   });
 

--- a/packages/highperformer/src/chat/useChatTurn.ts
+++ b/packages/highperformer/src/chat/useChatTurn.ts
@@ -26,6 +26,16 @@ export function useChatTurn() {
         for await (const ev of chat.streamTurn(slug, messages, viewState, threadId, controller.signal)) {
           onEvent(ev);
         }
+      } catch (e) {
+        if (controller.signal.aborted) {
+          // User-initiated cancel. Surface as a friendly error event via
+          // onEvent — don't bubble the raw browser AbortError text
+          // ("BodyStreamBuffer was aborted" / "signal is aborted without
+          // reason") to the user.
+          onEvent({ type: "error", message: "Cancelled", retryable: false });
+          return;
+        }
+        throw e;
       } finally {
         setStreaming(false);
         if (abortRef.current === controller) abortRef.current = null;

--- a/packages/highperformer/src/chat/wireMessages.test.ts
+++ b/packages/highperformer/src/chat/wireMessages.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { ensureAlternation } from "./wireMessages";
+
+describe("ensureAlternation", () => {
+  it("returns alternating sequence unchanged", () => {
+    const msgs = [
+      { role: "user" as const, content: "a" },
+      { role: "assistant" as const, content: "b" },
+      { role: "user" as const, content: "c" },
+    ];
+    expect(ensureAlternation(msgs)).toEqual(msgs);
+  });
+
+  it("inserts a synthetic assistant between consecutive user messages", () => {
+    // The hydrated-thread bug: server returned [user] (last assistant turn
+    // never persisted), client appends new user → server 422 without this.
+    const msgs = [
+      { role: "user" as const, content: "old" },
+      { role: "user" as const, content: "new" },
+    ];
+    expect(ensureAlternation(msgs)).toEqual([
+      { role: "user", content: "old" },
+      { role: "assistant", content: "(interrupted)" },
+      { role: "user", content: "new" },
+    ]);
+  });
+
+  it("inserts a synthetic user between consecutive assistant messages", () => {
+    const msgs = [
+      { role: "assistant" as const, content: "a" },
+      { role: "assistant" as const, content: "b" },
+    ];
+    expect(ensureAlternation(msgs)).toEqual([
+      { role: "assistant", content: "a" },
+      { role: "user", content: "(interrupted)" },
+      { role: "assistant", content: "b" },
+    ]);
+  });
+
+  it("handles three consecutive same-role messages", () => {
+    const msgs = [
+      { role: "user" as const, content: "1" },
+      { role: "user" as const, content: "2" },
+      { role: "user" as const, content: "3" },
+    ];
+    expect(ensureAlternation(msgs)).toEqual([
+      { role: "user", content: "1" },
+      { role: "assistant", content: "(interrupted)" },
+      { role: "user", content: "2" },
+      { role: "assistant", content: "(interrupted)" },
+      { role: "user", content: "3" },
+    ]);
+  });
+
+  it("returns empty input unchanged", () => {
+    expect(ensureAlternation([])).toEqual([]);
+  });
+
+  it("returns single-message input unchanged", () => {
+    const msgs = [{ role: "user" as const, content: "hi" }];
+    expect(ensureAlternation(msgs)).toEqual(msgs);
+  });
+});

--- a/packages/highperformer/src/chat/wireMessages.ts
+++ b/packages/highperformer/src/chat/wireMessages.ts
@@ -1,0 +1,31 @@
+/**
+ * Wire-protocol message adapters for chat turns.
+ *
+ * The server validates that messages strictly alternate user/assistant. The
+ * client's in-memory history can drift out of that invariant in two ways:
+ *
+ *  1. A hydrated thread whose last persisted message is a user role (because
+ *     an earlier assistant turn errored before persisting). Hydration loads
+ *     [..., user]; the next submit appends another user → role-alternation
+ *     violation.
+ *  2. Defensive guard against future state-machine bugs.
+ *
+ * `ensureAlternation` inserts a synthetic `(interrupted)` placeholder of the
+ * opposite role between any two consecutive same-role messages. Applied at
+ * the wire boundary only — does NOT mutate stored history, so the UI
+ * continues to render the actual state.
+ */
+import type { WireMessage } from "./types";
+
+export function ensureAlternation(msgs: WireMessage[]): WireMessage[] {
+  const out: WireMessage[] = [];
+  for (const m of msgs) {
+    const last = out[out.length - 1];
+    if (last && last.role === m.role) {
+      const synthRole = last.role === "user" ? "assistant" : "user";
+      out.push({ role: synthRole, content: "(interrupted)" });
+    }
+    out.push(m);
+  }
+  return out;
+}

--- a/packages/highperformer/src/index.css
+++ b/packages/highperformer/src/index.css
@@ -19,3 +19,14 @@ body {
 .chat-tabs .ant-tabs-tabpane {
   height: 100%;
 }
+
+/* Subtle pulse for in-flight tool pills — communicates "still working"
+   without being distracting. Used by AssistantBubble's ToolPartTag when
+   the tool's status is 'started'. */
+@keyframes chat-tool-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.chat-tool-pulse {
+  animation: chat-tool-pulse 1.4s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary

Follow-up UX polish to #278. Cancelling a turn now reads as deliberate, and there's clearer feedback that something is happening while the agent works.

- **Friendly cancel message**: `useChatTurn` swallows the self-initiated AbortError and emits a clean \`Cancelled\` error event via \`onEvent\` instead of bubbling the raw browser \`BodyStreamBuffer was aborted\` / \`signal is aborted without reason\` text.
- **Tool pills settle on cancel**: in-flight \`status: 'started'\` tool parts move to a terminal \`'error'\` state when the turn errors/cancels, so pills don't spin forever.
- **\"Thinking…\" indicator**: small Spin + label appears under the user message while streaming, until the first text or tool arrives.
- **Tool pill pulse**: subtle 1.4s opacity pulse on in-flight tool pills so they read as actively working.

## Test plan

- [x] reducer tests: 14/14 (added one for started → error finalization)
- [x] useChatTurn tests: 4/4 (updated stop() test for new no-throw behavior)
- [x] full highperformer suite: 431/431
- [x] manual: cancel mid-tool → \"Cancelled\" bubble, tool pill red ✗
- [x] manual: send new question → \"Thinking…\" with spinner under user message
- [x] manual: tool pill gently pulses while in flight