### PR TITLE
feat(auth): proactive token refresh timer

### DIFF
--- a/.changeset/proactive-token-refresh.md
+++ b/.changeset/proactive-token-refresh.md
@@ -1,0 +1,11 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Add a proactive token refresh timer. While a user is signed in, the app
+calls `POST /api/auth/refresh` every 4 minutes (well before the 5-minute
+access-cookie TTL) so chat requests always cross the boundary with a
+fresh cookie. Also fires once on `visibilitychange` to visible, in case
+the tab was suspended longer than the interval. Replaces the reactive
+refresh-on-401 path for normal usage — the rotation race and clock-skew
+edge cases no longer surface as `Session expired` mid-conversation.

--- a/packages/highperformer/src/App.tsx
+++ b/packages/highperformer/src/App.tsx
@@ -6,6 +6,7 @@ import Home from './pages/Home'
 import View from './pages/View'
 import ZarrView from './pages/ZarrView'
 import useAppStore from './store/useAppStore'
+import { useTokenRefresh } from './hooks/useTokenRefresh'
 
 const { Content } = Layout
 
@@ -31,6 +32,10 @@ function App() {
     const { backendInfo } = useAppStore.getState()
     if (backendInfo) fetchCatalog()
   }, [user, fetchCatalog])
+
+  // Keep the access cookie fresh while signed in. Sidesteps the rotation
+  // race that surfaces as 'Session expired' on long-lived chat streams.
+  useTokenRefresh(user !== null)
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>

--- a/packages/highperformer/src/hooks/useTokenRefresh.test.ts
+++ b/packages/highperformer/src/hooks/useTokenRefresh.test.ts
@@ -1,0 +1,88 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTokenRefresh } from "./useTokenRefresh";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+});
+
+afterEach(() => {
+  // Force-unmount any mounted hooks so their visibilitychange listeners
+  // don't leak into the next test (the project's vitest setup does not
+  // auto-cleanup between tests).
+  cleanup();
+  vi.useRealTimers();
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("useTokenRefresh", () => {
+  it("does not fire when disabled", async () => {
+    renderHook(() => useTokenRefresh(false));
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls /api/auth/refresh every 4 minutes while enabled", async () => {
+    renderHook(() => useTokenRefresh(true));
+    // No call at t=0 — interval-based, first call is at t=4m
+    expect(fetchMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/auth/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops firing after the hook unmounts", async () => {
+    const { unmount } = renderHook(() => useTokenRefresh(true));
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    unmount();
+    await vi.advanceTimersByTimeAsync(240_000 * 3);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows fetch errors so the timer keeps ticking", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    renderHook(() => useTokenRefresh(true));
+    await vi.advanceTimersByTimeAsync(240_000);
+    // First call rejected; subsequent call should still happen.
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires immediately on visibilitychange to 'visible'", async () => {
+    renderHook(() => useTokenRefresh(true));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire on visibilitychange when becoming hidden", async () => {
+    renderHook(() => useTokenRefresh(true));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/highperformer/src/hooks/useTokenRefresh.ts
+++ b/packages/highperformer/src/hooks/useTokenRefresh.ts
@@ -1,0 +1,63 @@
+/**
+ * Proactive auth token refresh.
+ *
+ * While the user is authenticated, this hook calls `POST /api/auth/refresh`
+ * every ~4 minutes (well before the 5-minute access-cookie TTL elapses).
+ * This:
+ *
+ *  - Avoids the reactive refresh path on the streaming chat endpoint —
+ *    requests always have a fresh access cookie at boundary time, so the
+ *    rotation race between parallel refreshes never fires.
+ *  - Recovers from transient Keycloak hiccups on the next tick rather than
+ *    surfacing as "Session expired" to the user mid-conversation.
+ *  - Costs ~15 requests/hour. Each is a thin POST that returns 204.
+ *
+ * Also fires once on `visibilitychange` to visible — if the tab was
+ * suspended for long enough that the next interval would have arrived
+ * past the cookie boundary, this catches up immediately.
+ */
+import { useEffect } from "react";
+
+const REFRESH_INTERVAL_MS = 240_000; // 4 minutes; access TTL is 5 minutes
+
+export function useTokenRefresh(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const refresh = async () => {
+      try {
+        await fetch("/api/auth/refresh", {
+          method: "POST",
+          credentials: "include",
+        });
+      } catch {
+        // Best-effort. If this fails, the reactive refresh on the next real
+        // request remains the fallback. Don't surface to the user.
+      }
+    };
+
+    const schedule = () => {
+      if (cancelled) return;
+      timer = setTimeout(async () => {
+        await refresh();
+        schedule();
+      }, REFRESH_INTERVAL_MS);
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+
+    schedule();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [enabled]);
+}


### PR DESCRIPTION
## Summary

While signed in, the app calls \`POST /api/auth/refresh\` every 4 minutes (and once on \`visibilitychange\` to visible). Pre-empts the 5-minute access-cookie boundary so chat requests always cross with a fresh cookie. Eliminates the reactive refresh path on the streaming chat endpoint, where the rotation race + clock-skew edge cases surfaced as \`HTTP 401: Session expired\` mid-conversation.

Pairs with cell-explorer-py's matching backend PR (adds the \`/api/auth/refresh\` endpoint + JWT clock-skew leeway + pure-ASGI cookie middleware).

## Test plan

- [x] 6 new tests for the hook (interval cadence, disabled state, unmount cleanup, error swallowing, visibilitychange)
- [x] highperformer suite: 443/443
- [x] manual: chat session past the 5-min boundary survives without UI interruption