### PR TITLE
feat: inline charts in chat (frontend)

### DIFF
--- a/.changeset/inline-charts-in-chat.md
+++ b/.changeset/inline-charts-in-chat.md
@@ -1,0 +1,12 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Inline charts in chat. Tool results that include a `chart` hint (e.g.
+`top_expressed_genes`, `gene_panel_by_obs`) now render a compact chart
+directly beneath the matching tool pill in assistant bubbles. Clicking
+the chart opens it at full size in the existing ChartModal with a
+snapshot of the chart data plus a raw-data table tab. Unknown chart
+types are silently ignored so the backend can introduce new chart
+types without breaking older clients. Charts are live-only: they do
+not persist across thread reloads.

--- a/packages/highperformer/src/chat/AssistantBubble.test.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.test.tsx
@@ -120,3 +120,104 @@ describe("AssistantBubble", () => {
     expect(screen.queryByRole("button", { name: /thumbs up/i })).toBeNull();
   });
 });
+
+describe("AssistantBubble inline charts", () => {
+  it("renders only the pill for a ToolPart with no chart", () => {
+    const { container } = render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [{ kind: "tool", tool: "search_genes", status: "ok" }],
+        }}
+        slug="x"
+      />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders an inline chart for top_genes_bar", () => {
+    const { container } = render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [
+            {
+              kind: "tool",
+              tool: "top_expressed_genes",
+              status: "ok",
+              chart: {
+                type: "top_genes_bar",
+                data: {
+                  obs_column: "cell_type",
+                  group_value: "T cell",
+                  genes: [
+                    { symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 },
+                  ],
+                },
+              },
+            },
+          ],
+        }}
+        slug="x"
+      />,
+    );
+    expect(container.querySelector("svg")).toBeDefined();
+    expect(container.textContent).toContain("CD8A");
+  });
+
+  it("renders only the pill for an unknown chart type", () => {
+    const { container } = render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [
+            {
+              kind: "tool",
+              tool: "future_tool",
+              status: "ok",
+              chart: { type: "unknown_future_chart", data: { foo: 1 } },
+            },
+          ],
+        }}
+        slug="x"
+      />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  // Skipped: antd Modal portals to document.body and uses animations that are
+  // unreliable in jsdom. Clicking the inline chart to open the modal is covered
+  // by the ToolPartView component logic (openModal sets modalSnapshot) — the
+  // modal rendering path itself is straightforward React state. Full E2E
+  // coverage of the modal is deferred to Playwright / manual testing.
+  it.skip("clicking the inline chart opens the modal", () => {
+    const { container } = render(
+      <AssistantBubble
+        message={{
+          role: "assistant",
+          parts: [
+            {
+              kind: "tool",
+              tool: "top_expressed_genes",
+              status: "ok",
+              chart: {
+                type: "top_genes_bar",
+                data: {
+                  obs_column: "cell_type",
+                  group_value: "T cell",
+                  genes: [{ symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 }],
+                },
+              },
+            },
+          ],
+        }}
+        slug="x"
+      />,
+    );
+    const chartDiv = container.querySelector("[role=button]");
+    expect(chartDiv).toBeDefined();
+    fireEvent.click(chartDiv!);
+    // antd Modal portals to document.body — query there
+    expect(document.body.textContent).toContain("top_expressed_genes");
+  });
+});

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -20,7 +20,7 @@ import { FeedbackThumbs } from "./FeedbackThumbs";
 import { useChatFeedback } from "./useChatFeedback";
 import { WhyPanel } from "./WhyPanel";
 import type { ChatMessage, ChartHint, MessageFeedback, MessagePart, ToolPart } from "./types";
-import { getChartRenderer } from "./chartRegistry";
+import { getChartRenderer, getChartTableRenderer } from "./chartRegistry";
 import ChartModal from "../components/ChartModal";
 
 const FLASH_MS = 2000;
@@ -116,6 +116,7 @@ function ToolPartView({ part }: { part: ToolPart }) {
       {modalSnapshot && (() => {
         const ModalRenderer = getChartRenderer(modalSnapshot);
         if (!ModalRenderer) return null;
+        const TableRenderer = getChartTableRenderer(modalSnapshot);
         return (
           <ChartModal
             title={`${tool}`}
@@ -129,9 +130,13 @@ function ToolPartView({ part }: { part: ToolPart }) {
               />
             }
             table={
-              <pre style={{ whiteSpace: "pre-wrap", fontSize: 12 }}>
-                {JSON.stringify(modalSnapshot.data, null, 2)}
-              </pre>
+              TableRenderer ? (
+                <TableRenderer data={modalSnapshot.data} />
+              ) : (
+                <pre style={{ whiteSpace: "pre-wrap", fontSize: 12 }}>
+                  {JSON.stringify(modalSnapshot.data, null, 2)}
+                </pre>
+              )
             }
           />
         );

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -72,7 +72,7 @@ function ToolPartTag({ part }: { part: ToolPart }) {
   );
 }
 
-const INLINE_CHART_WIDTH = 280;
+const INLINE_CHART_WIDTH = 400;
 const MODAL_CHART_WIDTH = 800;
 
 function ToolPartView({ part }: { part: ToolPart }) {
@@ -107,7 +107,7 @@ function ToolPartView({ part }: { part: ToolPart }) {
               openModal();
             }
           }}
-          style={{ marginTop: 6, cursor: "pointer", display: "inline-block" }}
+          style={{ marginTop: 6, marginBottom: 6, cursor: "pointer", display: "block", width: "fit-content" }}
           aria-label={`Open ${tool} chart in full size`}
         >
           <Renderer data={part.chart.data} width={INLINE_CHART_WIDTH} />

--- a/packages/highperformer/src/chat/AssistantBubble.tsx
+++ b/packages/highperformer/src/chat/AssistantBubble.tsx
@@ -19,7 +19,9 @@ import { parseCitations } from "./citations";
 import { FeedbackThumbs } from "./FeedbackThumbs";
 import { useChatFeedback } from "./useChatFeedback";
 import { WhyPanel } from "./WhyPanel";
-import type { ChatMessage, MessageFeedback, MessagePart, ToolPart } from "./types";
+import type { ChatMessage, ChartHint, MessageFeedback, MessagePart, ToolPart } from "./types";
+import { getChartRenderer } from "./chartRegistry";
+import ChartModal from "../components/ChartModal";
 
 const FLASH_MS = 2000;
 
@@ -67,6 +69,74 @@ function ToolPartTag({ part }: { part: ToolPart }) {
       {sym} {part.tool}
       {part.summary ? ` — ${part.summary}` : part.status === "started" ? "…" : ""}
     </Tag>
+  );
+}
+
+const INLINE_CHART_WIDTH = 280;
+const MODAL_CHART_WIDTH = 800;
+
+function ToolPartView({ part }: { part: ToolPart }) {
+  const [modalSnapshot, setModalSnapshot] = useState<ChartHint | null>(null);
+  const Renderer = getChartRenderer(part.chart);
+  const tool = part.tool;
+
+  const openModal = () => {
+    if (!part.chart) return;
+    // Snapshot via JSON round-trip — sufficient for chart payloads which are
+    // plain JSON values from the backend (backend serializes via cap_json_bytes).
+    const snap: ChartHint = {
+      type: part.chart.type,
+      data: part.chart.data === undefined
+        ? undefined
+        : JSON.parse(JSON.stringify(part.chart.data)),
+    };
+    setModalSnapshot(snap);
+  };
+
+  return (
+    <>
+      <ToolPartTag part={part} />
+      {Renderer && part.chart && (
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={openModal}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              openModal();
+            }
+          }}
+          style={{ marginTop: 6, cursor: "pointer", display: "inline-block" }}
+          aria-label={`Open ${tool} chart in full size`}
+        >
+          <Renderer data={part.chart.data} width={INLINE_CHART_WIDTH} />
+        </div>
+      )}
+      {modalSnapshot && (() => {
+        const ModalRenderer = getChartRenderer(modalSnapshot);
+        if (!ModalRenderer) return null;
+        return (
+          <ChartModal
+            title={`${tool}`}
+            open={true}
+            onClose={() => setModalSnapshot(null)}
+            chart={
+              <ModalRenderer
+                data={modalSnapshot.data}
+                width={MODAL_CHART_WIDTH}
+                isModal={true}
+              />
+            }
+            table={
+              <pre style={{ whiteSpace: "pre-wrap", fontSize: 12 }}>
+                {JSON.stringify(modalSnapshot.data, null, 2)}
+              </pre>
+            }
+          />
+        );
+      })()}
+    </>
   );
 }
 
@@ -192,7 +262,7 @@ function PartView({
     );
   }
   if (part.kind === "tool") {
-    return <ToolPartTag part={part} />;
+    return <ToolPartView part={part} />;
   }
   return <Alert type="error" message={part.message} showIcon style={{ marginTop: 8 }} />;
 }

--- a/packages/highperformer/src/chat/chartRegistry.test.tsx
+++ b/packages/highperformer/src/chat/chartRegistry.test.tsx
@@ -1,6 +1,6 @@
 import { render, cleanup } from "@testing-library/react";
 import { afterEach, describe, it, expect } from "vitest";
-import { getChartRenderer } from "./chartRegistry";
+import { getChartRenderer, getChartTableRenderer } from "./chartRegistry";
 
 afterEach(() => cleanup());
 
@@ -59,5 +59,66 @@ describe("getChartRenderer", () => {
   it("returns undefined for null/undefined hint", () => {
     expect(getChartRenderer(null)).toBeUndefined();
     expect(getChartRenderer(undefined)).toBeUndefined();
+  });
+});
+
+describe("getChartTableRenderer", () => {
+  it("returns a table renderer for top_genes_bar", () => {
+    const T = getChartTableRenderer({
+      type: "top_genes_bar",
+      data: {
+        obs_column: "cell_type",
+        group_value: "T cell",
+        genes: [{ symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 }],
+      },
+    });
+    expect(T).toBeDefined();
+    if (T) {
+      const { container } = render(
+        <T
+          data={{
+            obs_column: "cell_type",
+            group_value: "T cell",
+            genes: [{ symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 }],
+          }}
+        />,
+      );
+      expect(container.querySelector("table")).toBeDefined();
+      expect(container.textContent).toContain("CD8A");
+      expect(container.textContent).toContain("80.0%");
+    }
+  });
+
+  it("returns a table renderer for gene_panel_dotplot", () => {
+    const T = getChartTableRenderer({
+      type: "gene_panel_dotplot",
+      data: { genes: ["CD8A"], categories: ["T cell"] },
+    });
+    expect(T).toBeDefined();
+    if (T) {
+      const { container } = render(
+        <T
+          data={{
+            obs_column: "cell_type",
+            genes: ["CD8A"],
+            categories: ["T cell"],
+            mean: [[1.0]],
+            frac_expressing: [[0.5]],
+          }}
+        />,
+      );
+      expect(container.querySelector("table")).toBeDefined();
+      expect(container.textContent).toContain("CD8A");
+      expect(container.textContent).toContain("T cell");
+    }
+  });
+
+  it("returns undefined for unknown chart type", () => {
+    expect(getChartTableRenderer({ type: "future_chart_xyz", data: {} })).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined hint", () => {
+    expect(getChartTableRenderer(null)).toBeUndefined();
+    expect(getChartTableRenderer(undefined)).toBeUndefined();
   });
 });

--- a/packages/highperformer/src/chat/chartRegistry.test.tsx
+++ b/packages/highperformer/src/chat/chartRegistry.test.tsx
@@ -1,0 +1,63 @@
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { getChartRenderer } from "./chartRegistry";
+
+afterEach(() => cleanup());
+
+describe("getChartRenderer", () => {
+  it("returns a renderer for top_genes_bar", () => {
+    const R = getChartRenderer({
+      type: "top_genes_bar",
+      data: {
+        obs_column: "cell_type",
+        group_value: "T cell",
+        genes: [{ symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 }],
+      },
+    });
+    expect(R).toBeDefined();
+    if (R) {
+      const { container } = render(
+        <R
+          data={{
+            obs_column: "cell_type",
+            group_value: "T cell",
+            genes: [{ symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 }],
+          }}
+        />,
+      );
+      expect(container.textContent).toContain("CD8A");
+    }
+  });
+
+  it("returns a renderer for gene_panel_dotplot", () => {
+    const R = getChartRenderer({
+      type: "gene_panel_dotplot",
+      data: { genes: ["CD8A"], categories: ["T cell"] },
+    });
+    expect(R).toBeDefined();
+    if (R) {
+      const { container } = render(
+        <R
+          data={{
+            obs_column: "cell_type",
+            genes: ["CD8A"],
+            categories: ["T cell"],
+            mean: [[1.0]],
+            frac_expressing: [[0.5]],
+          }}
+        />,
+      );
+      expect(container.textContent).toContain("cell_type");
+    }
+  });
+
+  it("returns undefined for unknown chart type", () => {
+    const R = getChartRenderer({ type: "future_chart_xyz", data: {} });
+    expect(R).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined hint", () => {
+    expect(getChartRenderer(null)).toBeUndefined();
+    expect(getChartRenderer(undefined)).toBeUndefined();
+  });
+});

--- a/packages/highperformer/src/chat/chartRegistry.tsx
+++ b/packages/highperformer/src/chat/chartRegistry.tsx
@@ -1,6 +1,8 @@
 import type { ComponentType } from "react";
 import TopGenesBarChart from "../components/TopGenesBarChart";
 import GenePanelDotplot from "../components/GenePanelDotplot";
+import TopGenesBarTable from "../components/TopGenesBarTable";
+import GenePanelDotplotTable from "../components/GenePanelDotplotTable";
 import type { ChartHint } from "./types";
 
 /**
@@ -54,4 +56,45 @@ const REGISTRY: Record<string, ChartRenderer> = {
 export function getChartRenderer(hint: ChartHint | null | undefined): ChartRenderer | undefined {
   if (!hint || typeof hint.type !== "string") return undefined;
   return REGISTRY[hint.type];
+}
+
+// ---------------------------------------------------------------------------
+// Table renderers — used by the ChartModal "Table" tab. Parallel structure to
+// the chart registry above.
+// ---------------------------------------------------------------------------
+
+export type ChartTableProps = { data: unknown };
+export type ChartTableRenderer = ComponentType<ChartTableProps>;
+
+const TopGenesBarTableAdapter: ChartTableRenderer = ({ data }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d = data as any;
+  if (!d || !Array.isArray(d.genes)) return null;
+  return (
+    <TopGenesBarTable
+      obs_column={d.obs_column ?? ""}
+      group_value={d.group_value ?? ""}
+      genes={d.genes}
+    />
+  );
+};
+
+const GenePanelDotplotTableAdapter: ChartTableRenderer = ({ data }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d = data as any;
+  if (!d || !Array.isArray(d.genes) || !Array.isArray(d.categories)) return null;
+  return <GenePanelDotplotTable data={d} />;
+};
+
+const TABLE_REGISTRY: Record<string, ChartTableRenderer> = {
+  top_genes_bar: TopGenesBarTableAdapter,
+  gene_panel_dotplot: GenePanelDotplotTableAdapter,
+};
+
+/** Returns a table renderer for the given hint, or undefined if unknown. */
+export function getChartTableRenderer(
+  hint: ChartHint | null | undefined,
+): ChartTableRenderer | undefined {
+  if (!hint || typeof hint.type !== "string") return undefined;
+  return TABLE_REGISTRY[hint.type];
 }

--- a/packages/highperformer/src/chat/chartRegistry.tsx
+++ b/packages/highperformer/src/chat/chartRegistry.tsx
@@ -1,0 +1,57 @@
+import type { ComponentType } from "react";
+import TopGenesBarChart from "../components/TopGenesBarChart";
+import GenePanelDotplot from "../components/GenePanelDotplot";
+import type { ChartHint } from "./types";
+
+/**
+ * A chart renderer takes the `chart.data` payload (renderer-specific) plus
+ * a fixed set of layout hints, and renders the chart. The registry maps
+ * `chart.type` (a string from the backend) to a renderer.
+ *
+ * If a chart type is unknown, lookup returns `undefined` and the caller
+ * (AssistantBubble) silently omits the inline chart — this is intentional:
+ * the backend can introduce new chart types without breaking older clients.
+ */
+export type ChartRendererProps = {
+  data: unknown;
+  width?: number;
+  isModal?: boolean;
+};
+
+export type ChartRenderer = ComponentType<ChartRendererProps>;
+
+// Adapter wrappers normalize the per-renderer prop shapes to the common
+// ChartRendererProps interface. Each adapter narrows `data: unknown` to the
+// shape that its target component expects.
+
+const TopGenesBarAdapter: ChartRenderer = ({ data, width }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d = data as any;
+  if (!d || !Array.isArray(d.genes)) return null;
+  return (
+    <TopGenesBarChart
+      obs_column={d.obs_column ?? ""}
+      group_value={d.group_value ?? ""}
+      genes={d.genes}
+      width={width}
+    />
+  );
+};
+
+const GenePanelDotplotAdapter: ChartRenderer = ({ data, width, isModal }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d = data as any;
+  if (!d || !Array.isArray(d.genes) || !Array.isArray(d.categories)) return null;
+  return <GenePanelDotplot data={d} width={width} isModal={isModal} />;
+};
+
+const REGISTRY: Record<string, ChartRenderer> = {
+  top_genes_bar: TopGenesBarAdapter,
+  gene_panel_dotplot: GenePanelDotplotAdapter,
+};
+
+/** Returns a chart renderer for the given hint, or undefined if unknown. */
+export function getChartRenderer(hint: ChartHint | null | undefined): ChartRenderer | undefined {
+  if (!hint || typeof hint.type !== "string") return undefined;
+  return REGISTRY[hint.type];
+}

--- a/packages/highperformer/src/chat/eventReducer.test.ts
+++ b/packages/highperformer/src/chat/eventReducer.test.ts
@@ -178,4 +178,68 @@ describe("eventReducer.reduce", () => {
     expect(s.history).toHaveLength(1);
     expect(s.history[0].parts.some((p) => p.kind === "error")).toBe(true);
   });
+
+  it("tool_progress ok with chart attaches chart to the ToolPart", () => {
+    let s = initialState();
+    const chart = { type: "bar", data: { labels: ["a", "b"], values: [1, 2] } };
+    s = reduce(
+      s,
+      { type: "tool_progress", tool: "top_genes", status: "ok", summary: "done", chart },
+      noopApply,
+    );
+    const toolPart = s.current!.parts.find((p) => p.kind === "tool");
+    expect(toolPart).toBeDefined();
+    expect((toolPart as { chart?: unknown }).chart).toEqual(chart);
+  });
+
+  it("tool_progress started then ok with chart: ok upserts chart and preserves args from started", () => {
+    let s = initialState();
+    const args = { n: 10 };
+    const chart = { type: "scatter", data: [1, 2, 3] };
+    s = reduce(
+      s,
+      { type: "tool_progress", tool: "top_genes", status: "started", args },
+      noopApply,
+    );
+    s = reduce(
+      s,
+      { type: "tool_progress", tool: "top_genes", status: "ok", summary: "32k scanned", chart },
+      noopApply,
+    );
+    const tools = s.current!.parts.filter((p) => p.kind === "tool");
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ status: "ok", summary: "32k scanned", chart, args });
+  });
+
+  it("tool_progress without chart does not clear an existing chart (prev-preservation)", () => {
+    let s = initialState();
+    const chart = { type: "bar" };
+    // First event attaches the chart
+    s = reduce(
+      s,
+      { type: "tool_progress", tool: "top_genes", status: "ok", summary: "first", chart },
+      noopApply,
+    );
+    // Second event arrives without chart — must not blow away the existing one
+    s = reduce(
+      s,
+      { type: "tool_progress", tool: "top_genes", status: "ok", summary: "second" },
+      noopApply,
+    );
+    const toolPart = s.current!.parts.find((p) => p.kind === "tool");
+    expect((toolPart as { chart?: unknown }).chart).toEqual(chart);
+  });
+
+  it("chart on ToolPart does NOT appear in the tool_end TraceEntry", () => {
+    let s = initialState();
+    const chart = { type: "pie", data: [3, 7] };
+    s = reduce(
+      s,
+      { type: "tool_progress", tool: "top_genes", status: "ok", summary: "done", chart },
+      noopApply,
+    );
+    const traceEntry = s.current!.trace?.find((e) => e.kind === "tool_end");
+    expect(traceEntry).toBeDefined();
+    expect((traceEntry as Record<string, unknown>)["chart"]).toBeUndefined();
+  });
 });

--- a/packages/highperformer/src/chat/eventReducer.ts
+++ b/packages/highperformer/src/chat/eventReducer.ts
@@ -6,6 +6,7 @@ import type {
   ToolPart,
   ErrorPart,
   TraceEntry,
+  ChartHint,
 } from "./types";
 
 export type State = {
@@ -49,6 +50,7 @@ function upsertToolPart(
     summary?: string;
     args?: Record<string, unknown> | null;
     duration_ms?: number | null;
+    chart?: ChartHint | null;
   },
 ): MessagePart[] {
   const idx = parts.findIndex(
@@ -56,6 +58,7 @@ function upsertToolPart(
   );
   // Preserve args from the 'started' event when 'ok' / 'error' arrives
   // without args. Preserve duration_ms from end event when later updates come.
+  // Preserve chart from any earlier event that provided it.
   const prev = idx === -1 ? undefined : (parts[idx] as ToolPart);
   const updated: ToolPart = {
     kind: "tool",
@@ -64,6 +67,7 @@ function upsertToolPart(
     summary: ev.summary ?? prev?.summary,
     args: ev.args ?? prev?.args,
     duration_ms: ev.duration_ms ?? prev?.duration_ms,
+    chart: ev.chart ?? prev?.chart,
   };
   if (idx === -1) return [...parts, updated];
   const next = parts.slice();
@@ -119,6 +123,7 @@ export function reduce(
         summary: ev.summary,
         args: ev.args,
         duration_ms: ev.duration_ms,
+        chart: ev.chart,
       });
       const traceEntry: TraceEntry =
         ev.status === "started"

--- a/packages/highperformer/src/chat/types.test.ts
+++ b/packages/highperformer/src/chat/types.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import type { ToolProgress, ToolPart, ChartHint } from "./types";
+
+describe("chart types", () => {
+  it("ToolProgress accepts an optional chart field", () => {
+    const evt: ToolProgress = {
+      type: "tool_progress",
+      tool: "top_expressed_genes",
+      status: "ok",
+      chart: { type: "top_genes_bar", data: { genes: ["CD8A"] } },
+    };
+    expect(evt.chart?.type).toBe("top_genes_bar");
+  });
+
+  it("ToolProgress without chart still typechecks", () => {
+    const evt: ToolProgress = {
+      type: "tool_progress",
+      tool: "x",
+      status: "started",
+    };
+    expect(evt.chart).toBeUndefined();
+  });
+
+  it("ToolPart accepts a chart field", () => {
+    const part: ToolPart = {
+      kind: "tool",
+      tool: "gene_panel_by_obs",
+      status: "ok",
+      chart: { type: "gene_panel_dotplot", data: { genes: [], categories: [] } },
+    };
+    expect(part.chart?.type).toBe("gene_panel_dotplot");
+  });
+
+  it("ToolPart without chart still typechecks", () => {
+    const part: ToolPart = {
+      kind: "tool",
+      tool: "some_tool",
+      status: "ok",
+    };
+    expect(part.chart).toBeUndefined();
+  });
+
+  it("ChartHint with null data is valid", () => {
+    const hint: ChartHint = {
+      type: "some_chart",
+      data: null,
+    };
+    expect(hint.type).toBe("some_chart");
+    expect(hint.data).toBeNull();
+  });
+});

--- a/packages/highperformer/src/chat/types.ts
+++ b/packages/highperformer/src/chat/types.ts
@@ -76,6 +76,17 @@ export type TurnRequest = {
 
 // ---------- /turns wire events ----------
 
+/**
+ * Inline chart hint, attached to a tool's 'ok' tool_progress event.
+ * `data` is renderer-specific and narrowed by each chart-type registry entry.
+ * The LLM never sees `data` (backend strips it); the frontend renders charts
+ * inline beneath the matching tool pill.
+ */
+export type ChartHint = {
+  type: string;
+  data?: unknown;
+};
+
 export type TextDelta    = { type: "text_delta"; text: string };
 export type ToolProgress = {
   type: "tool_progress";
@@ -88,6 +99,8 @@ export type ToolProgress = {
   duration_ms?: number | null;
   /** LLM-generated tool_use_id. Citation markers [t:<id>] reference this. */
   tool_call_id?: string | null;
+  /** Populated only on the 'ok' event when the tool result included a chart hint. */
+  chart?: ChartHint | null;
 };
 export type UIAction     = { type: "ui_action"; payload: Record<string, unknown> };
 export type ErrorEvent   = { type: "error"; message: string; retryable: boolean };
@@ -123,6 +136,8 @@ export type ToolPart  = {
   summary?: string;
   args?: Record<string, unknown> | null;
   duration_ms?: number | null;
+  /** Inline chart attached when the tool produced one. */
+  chart?: ChartHint | null;
 };
 export type ErrorPart = { kind: "error"; message: string };
 export type MessagePart = TextPart | ToolPart | ErrorPart;

--- a/packages/highperformer/src/components/ExpressionDotPlot.exports.test.ts
+++ b/packages/highperformer/src/components/ExpressionDotPlot.exports.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { DotPlotMatrix } from "./ExpressionDotPlot";
+import type { DotPlotDatum } from "./ExpressionDotPlot";
+
+describe("ExpressionDotPlot named exports", () => {
+  it("exports DotPlotMatrix and DotPlotDatum", () => {
+    expect(typeof DotPlotMatrix).toBe("function");
+    const d: DotPlotDatum = {
+      gene: "CD8A",
+      geneLabel: "CD8A",
+      category: "T cell",
+      meanExpression: 1.2,
+      fractionExpressing: 0.5,
+    };
+    expect(d.gene).toBe("CD8A");
+  });
+});

--- a/packages/highperformer/src/components/ExpressionDotPlot.tsx
+++ b/packages/highperformer/src/components/ExpressionDotPlot.tsx
@@ -336,7 +336,7 @@ function DotPlotLegends({
 // DotPlotTable
 // ---------------------------------------------------------------------------
 
-function DotPlotTable({
+export function DotPlotTable({
   data,
   genes,
   categories,

--- a/packages/highperformer/src/components/ExpressionDotPlot.tsx
+++ b/packages/highperformer/src/components/ExpressionDotPlot.tsx
@@ -20,7 +20,7 @@ interface ExpressionByCategoryResult {
   fractionExpressing: Float32Array
 }
 
-interface DotPlotDatum {
+export interface DotPlotDatum {
   gene: string
   geneLabel: string
   category: string
@@ -46,7 +46,7 @@ const CHAR_WIDTH = 6 // approximate width per character at fontSize 10
 const LABEL_TRUNCATE_LEN = 16
 const MODAL_LABEL_TRUNCATE_LEN = 22
 
-function DotPlotMatrix({
+export function DotPlotMatrix({
   data,
   genes,
   categories,

--- a/packages/highperformer/src/components/GenePanelDotplot.test.tsx
+++ b/packages/highperformer/src/components/GenePanelDotplot.test.tsx
@@ -1,0 +1,48 @@
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import GenePanelDotplot from "./GenePanelDotplot";
+
+afterEach(() => cleanup());
+
+const sampleData = {
+  obs_column: "cell_type",
+  genes: ["CD8A", "CD4"],
+  categories: ["T cell", "B cell"],
+  mean: [
+    [3.0, 0.2],
+    [1.5, 0.1],
+  ],
+  frac_expressing: [
+    [0.8, 0.1],
+    [0.6, 0.05],
+  ],
+};
+
+describe("GenePanelDotplot", () => {
+  it("renders heading with obs_column", () => {
+    const { container } = render(<GenePanelDotplot data={sampleData} />);
+    expect(container.textContent).toContain("cell_type");
+  });
+
+  it("renders genes and categories", () => {
+    const { container } = render(<GenePanelDotplot data={sampleData} />);
+    expect(container.textContent).toContain("CD8A");
+    expect(container.textContent).toContain("CD4");
+    expect(container.textContent).toContain("T cell");
+    expect(container.textContent).toContain("B cell");
+  });
+
+  it("returns null for empty genes", () => {
+    const { container } = render(
+      <GenePanelDotplot data={{ ...sampleData, genes: [], mean: [], frac_expressing: [] }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null for empty categories", () => {
+    const { container } = render(
+      <GenePanelDotplot data={{ ...sampleData, categories: [], mean: [[], []], frac_expressing: [[], []] }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/highperformer/src/components/GenePanelDotplot.tsx
+++ b/packages/highperformer/src/components/GenePanelDotplot.tsx
@@ -1,0 +1,68 @@
+import { DotPlotMatrix } from "./ExpressionDotPlot";
+import type { DotPlotDatum } from "./ExpressionDotPlot";
+
+export type GenePanelDotplotData = {
+  obs_column: string;
+  genes: string[];
+  categories: string[];
+  mean: number[][];          // [genes][categories]
+  frac_expressing: number[][];
+  n_cells_per_category?: number[];
+};
+
+export type GenePanelDotplotProps = {
+  data: GenePanelDotplotData;
+  width?: number;       // default 280 for inline chat
+  isModal?: boolean;    // when rendered inside ChartModal
+};
+
+const DEFAULT_WIDTH = 280;
+// "viridis" is the first key in COLOR_SCALES (viridis, magma, plasma, inferno)
+const DEFAULT_COLOR_SCALE = "viridis";
+
+function flatten(data: GenePanelDotplotData): DotPlotDatum[] {
+  const rows: DotPlotDatum[] = [];
+  for (let gi = 0; gi < data.genes.length; gi++) {
+    const sym = data.genes[gi];
+    for (let ci = 0; ci < data.categories.length; ci++) {
+      rows.push({
+        gene: sym,
+        geneLabel: sym,
+        category: data.categories[ci],
+        meanExpression: data.mean[gi]?.[ci] ?? 0,
+        fractionExpressing: data.frac_expressing[gi]?.[ci] ?? 0,
+      });
+    }
+  }
+  return rows;
+}
+
+export default function GenePanelDotplot({
+  data,
+  width = DEFAULT_WIDTH,
+  isModal = false,
+}: GenePanelDotplotProps) {
+  if (!data.genes.length || !data.categories.length) return null;
+
+  const rows = flatten(data);
+  const maxMeanExpression = Math.max(0, ...rows.map((r) => r.meanExpression));
+  const genes = data.genes.map((g) => ({ key: g, label: g }));
+
+  return (
+    <div style={{ width, maxWidth: width }}>
+      <div style={{ fontSize: 12, color: "#555", marginBottom: 4 }}>
+        Expression across <b>{data.obs_column}</b>
+      </div>
+      <DotPlotMatrix
+        data={rows}
+        genes={genes}
+        categories={data.categories}
+        maxMeanExpression={maxMeanExpression}
+        colorScaleName={DEFAULT_COLOR_SCALE}
+        width={width}
+        swapAxes={true}
+        isModal={isModal}
+      />
+    </div>
+  );
+}

--- a/packages/highperformer/src/components/GenePanelDotplotTable.tsx
+++ b/packages/highperformer/src/components/GenePanelDotplotTable.tsx
@@ -1,0 +1,31 @@
+import { DotPlotTable } from "./ExpressionDotPlot";
+import type { DotPlotDatum } from "./ExpressionDotPlot";
+import type { GenePanelDotplotData } from "./GenePanelDotplot";
+
+export type GenePanelDotplotTableProps = {
+  data: GenePanelDotplotData;
+};
+
+function flatten(data: GenePanelDotplotData): DotPlotDatum[] {
+  const rows: DotPlotDatum[] = [];
+  for (let gi = 0; gi < data.genes.length; gi++) {
+    const sym = data.genes[gi];
+    for (let ci = 0; ci < data.categories.length; ci++) {
+      rows.push({
+        gene: sym,
+        geneLabel: sym,
+        category: data.categories[ci],
+        meanExpression: data.mean[gi]?.[ci] ?? 0,
+        fractionExpressing: data.frac_expressing[gi]?.[ci] ?? 0,
+      });
+    }
+  }
+  return rows;
+}
+
+export default function GenePanelDotplotTable({ data }: GenePanelDotplotTableProps) {
+  if (!data.genes.length || !data.categories.length) return null;
+  const rows = flatten(data);
+  const genes = data.genes.map((g) => ({ key: g, label: g }));
+  return <DotPlotTable data={rows} genes={genes} categories={data.categories} />;
+}

--- a/packages/highperformer/src/components/TopGenesBarChart.test.tsx
+++ b/packages/highperformer/src/components/TopGenesBarChart.test.tsx
@@ -1,0 +1,57 @@
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import TopGenesBarChart from "./TopGenesBarChart";
+
+afterEach(() => cleanup());
+
+describe("TopGenesBarChart", () => {
+  const genes = [
+    { symbol: "CD8A", mean: 3.0, fraction_expressing: 0.8 },
+    { symbol: "CD4", mean: 1.5, fraction_expressing: 0.6 },
+    { symbol: "GZMB", mean: 0.5, fraction_expressing: 0.3 },
+  ];
+
+  it("renders a heading with the group value", () => {
+    const { container } = render(
+      <TopGenesBarChart obs_column="cell_type" group_value="T cell" genes={genes} />,
+    );
+    expect(container.textContent).toContain("Top 3 genes");
+    expect(container.textContent).toContain("T cell");
+  });
+
+  it("renders a <title> per gene with its symbol", () => {
+    const { container } = render(
+      <TopGenesBarChart obs_column="cell_type" group_value="T cell" genes={genes} />,
+    );
+    const titles = container.querySelectorAll("svg title");
+    expect(titles.length).toBe(3);
+    const texts = Array.from(titles).map((t) => t.textContent);
+    expect(texts.some((t) => t?.includes("CD8A"))).toBe(true);
+    expect(texts.some((t) => t?.includes("CD4"))).toBe(true);
+    expect(texts.some((t) => t?.includes("GZMB"))).toBe(true);
+  });
+
+  it("returns null for empty genes list", () => {
+    const { container } = render(
+      <TopGenesBarChart obs_column="cell_type" group_value="T cell" genes={[]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("bar width is proportional to mean", () => {
+    const { container } = render(
+      <TopGenesBarChart obs_column="cell_type" group_value="T cell" genes={genes} />,
+    );
+    // Each rect contains a <title> as a child — collect widths by matching title text
+    const rects = Array.from(container.querySelectorAll("svg rect"));
+    const symbolToWidth: Record<string, number> = {};
+    rects.forEach((r) => {
+      const title = r.querySelector("title");
+      const sym = title?.textContent?.split(":")[0]?.trim();
+      const w = parseFloat(r.getAttribute("width") ?? "0");
+      if (sym) symbolToWidth[sym] = w;
+    });
+    expect(symbolToWidth["CD8A"]).toBeGreaterThan(symbolToWidth["CD4"]);
+    expect(symbolToWidth["CD4"]).toBeGreaterThan(symbolToWidth["GZMB"]);
+  });
+});

--- a/packages/highperformer/src/components/TopGenesBarChart.tsx
+++ b/packages/highperformer/src/components/TopGenesBarChart.tsx
@@ -18,7 +18,7 @@ export type TopGenesBarChartProps = {
 
 const DEFAULT_WIDTH = 280;
 const DEFAULT_ROW_HEIGHT = 16;
-const MARGIN = { top: 24, right: 8, bottom: 32, left: 64 };
+const MARGIN = { top: 24, right: 8, bottom: 36, left: 64 };
 const BAR_COLOR = "#4a90d9";
 
 export default function TopGenesBarChart({
@@ -49,8 +49,7 @@ export default function TopGenesBarChart({
   return (
     <div style={{ width, maxWidth: width }}>
       <div style={{ fontSize: 12, color: "#555", marginBottom: 4 }}>
-        Top {genes.length} genes in <b>{group_value}</b>
-        <span style={{ color: "#999" }}> ({obs_column})</span>
+        Top {genes.length} genes in <b>{group_value}</b> by mean expression
       </div>
       <svg
         width={width}
@@ -90,8 +89,6 @@ export default function TopGenesBarChart({
             tickStroke="#ccc"
             numTicks={4}
             tickLabelProps={{ fontSize: 9, textAnchor: "middle", fill: "#777" }}
-            label="mean expression"
-            labelProps={{ fontSize: 10, textAnchor: "middle", fill: "#666" }}
           />
         </Group>
       </svg>

--- a/packages/highperformer/src/components/TopGenesBarChart.tsx
+++ b/packages/highperformer/src/components/TopGenesBarChart.tsx
@@ -1,0 +1,100 @@
+import { Group } from "@visx/group";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { AxisBottom, AxisLeft } from "@visx/axis";
+
+export type TopGenesBarDatum = {
+  symbol: string;
+  mean: number;
+  fraction_expressing: number;
+};
+
+export type TopGenesBarChartProps = {
+  obs_column: string;
+  group_value: string;
+  genes: TopGenesBarDatum[];
+  width?: number;
+  rowHeight?: number;
+};
+
+const DEFAULT_WIDTH = 280;
+const DEFAULT_ROW_HEIGHT = 16;
+const MARGIN = { top: 24, right: 8, bottom: 32, left: 64 };
+const BAR_COLOR = "#4a90d9";
+
+export default function TopGenesBarChart({
+  obs_column,
+  group_value,
+  genes,
+  width = DEFAULT_WIDTH,
+  rowHeight = DEFAULT_ROW_HEIGHT,
+}: TopGenesBarChartProps) {
+  if (!genes.length) return null;
+
+  const height = MARGIN.top + MARGIN.bottom + genes.length * rowHeight;
+  const innerW = Math.max(0, width - MARGIN.left - MARGIN.right);
+  const innerH = Math.max(0, height - MARGIN.top - MARGIN.bottom);
+
+  const maxMean = Math.max(0, ...genes.map((g) => g.mean));
+  const xScale = scaleLinear({
+    domain: [0, maxMean || 1],
+    range: [0, innerW],
+    nice: true,
+  });
+  const yScale = scaleBand<string>({
+    domain: genes.map((g) => g.symbol),
+    range: [0, innerH],
+    padding: 0.2,
+  });
+
+  return (
+    <div style={{ width, maxWidth: width }}>
+      <div style={{ fontSize: 12, color: "#555", marginBottom: 4 }}>
+        Top {genes.length} genes in <b>{group_value}</b>
+        <span style={{ color: "#999" }}> ({obs_column})</span>
+      </div>
+      <svg
+        width={width}
+        height={height}
+        role="img"
+        aria-label={`Top ${genes.length} genes in ${group_value}`}
+      >
+        <Group top={MARGIN.top} left={MARGIN.left}>
+          {genes.map((g) => {
+            const y = yScale(g.symbol) ?? 0;
+            const w = xScale(g.mean);
+            const bh = yScale.bandwidth();
+            return (
+              <rect
+                key={g.symbol}
+                x={0}
+                y={y}
+                width={w}
+                height={bh}
+                fill={BAR_COLOR}
+                rx={2}
+              >
+                <title>{`${g.symbol}: mean=${g.mean.toFixed(2)}, frac_expr=${(g.fraction_expressing * 100).toFixed(0)}%`}</title>
+              </rect>
+            );
+          })}
+          <AxisLeft
+            scale={yScale}
+            stroke="#ccc"
+            tickStroke="#ccc"
+            tickLabelProps={{ fontSize: 10, textAnchor: "end", dx: -4, dy: 3, fill: "#555" }}
+          />
+          <AxisBottom
+            top={innerH}
+            scale={xScale}
+            stroke="#ccc"
+            tickStroke="#ccc"
+            numTicks={4}
+            tickLabelProps={{ fontSize: 9, textAnchor: "middle", fill: "#777" }}
+            label="mean expression"
+            labelProps={{ fontSize: 10, textAnchor: "middle", fill: "#666" }}
+          />
+        </Group>
+      </svg>
+    </div>
+  );
+}

--- a/packages/highperformer/src/components/TopGenesBarTable.tsx
+++ b/packages/highperformer/src/components/TopGenesBarTable.tsx
@@ -1,0 +1,51 @@
+import type { TopGenesBarDatum } from "./TopGenesBarChart";
+
+export type TopGenesBarTableProps = {
+  obs_column: string;
+  group_value: string;
+  genes: TopGenesBarDatum[];
+};
+
+const TH: React.CSSProperties = {
+  textAlign: "left",
+  fontWeight: 600,
+  padding: "4px 8px",
+  borderBottom: "1px solid #f0f0f0",
+  fontSize: 12,
+};
+
+const TH_NUM: React.CSSProperties = { ...TH, textAlign: "right" };
+const TD: React.CSSProperties = { padding: "2px 8px", fontSize: 12 };
+const TD_NUM: React.CSSProperties = { ...TD, textAlign: "right" };
+
+export default function TopGenesBarTable({ obs_column, group_value, genes }: TopGenesBarTableProps) {
+  if (!genes.length) return null;
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <div style={{ fontSize: 12, color: "#555", marginBottom: 6 }}>
+        Top {genes.length} genes in <b>{group_value}</b>
+        <span style={{ color: "#999" }}> ({obs_column})</span>
+      </div>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th style={TH}>Rank</th>
+            <th style={TH}>Gene</th>
+            <th style={TH_NUM}>Mean</th>
+            <th style={TH_NUM}>% Expressing</th>
+          </tr>
+        </thead>
+        <tbody>
+          {genes.map((g, i) => (
+            <tr key={g.symbol}>
+              <td style={{ ...TD, color: "#999" }}>{i + 1}</td>
+              <td style={TD}>{g.symbol}</td>
+              <td style={TD_NUM}>{g.mean.toFixed(3)}</td>
+              <td style={TD_NUM}>{(g.fraction_expressing * 100).toFixed(1)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Renders compact inline charts beneath assistant tool pills when a tool result carries a `chart` hint
- v1 chart types: horizontal bar (`top_expressed_genes`) and dotplot (`gene_panel_by_obs`)
- Clicking the chart opens the existing ChartModal with a snapshot of the chart data and a raw-data table tab
- Chart renderer registry maps `chart.type` to a React component; unknown types are silently omitted so future backend chart types ship without breaking older clients
- Charts are live-only; thread reloads from server do not rehydrate them
- Pairs with backend PR cBioPortal/cell-explorer-py#148

## Test plan
- [x] highperformer tests green locally (468 passing, 1 skipped — flaky antd modal in jsdom)
- [ ] CI green
- [ ] Manual smoke: ask "top 10 genes in T cells" → bar chart appears; ask "compare CD8A, CD4, MS4A1 across cell types" → dotplot appears; click each → modal opens at full size