### PR TITLE
fix(chat): disable feedback Send when draft matches saved comment

### DIFF
--- a/.changeset/feedback-send-disabled-on-no-op.md
+++ b/.changeset/feedback-send-disabled-on-no-op.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Feedback comment Send button now disables when the textarea matches the saved
+comment, giving a clear visual signal that a thumbs-down comment was sent
+successfully. Typing more re-enables Send; clearing the textarea after a
+saved comment also re-enables (clearing is a legitimate "remove my comment"
+action).

--- a/packages/highperformer/src/chat/FeedbackThumbs.test.tsx
+++ b/packages/highperformer/src/chat/FeedbackThumbs.test.tsx
@@ -62,4 +62,62 @@ describe("FeedbackThumbs", () => {
     );
     expect(screen.getByRole("textbox")).toHaveProperty("disabled", true);
   });
+
+  it("Send is disabled when textarea is empty and no comment is saved", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating="down" comment={null} onChange={onChange} />);
+    expect(screen.getByRole("button", { name: /send/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("Send re-enables when the user types", () => {
+    const onChange = vi.fn();
+    render(<FeedbackThumbs rating="down" comment={null} onChange={onChange} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "x" } });
+    expect(screen.getByRole("button", { name: /send/i })).toHaveProperty(
+      "disabled",
+      false,
+    );
+  });
+
+  it("Send greys out after a successful save (draft matches saved comment)", () => {
+    // Simulate the post-save state: the saved comment now matches the draft
+    // the user typed. The Send button should disable on its own.
+    const onChange = vi.fn();
+    render(
+      <FeedbackThumbs
+        rating="down"
+        comment="off-topic answer"
+        onChange={onChange}
+      />,
+    );
+    // Local draft initialized to "off-topic answer" via useState(comment ?? "")
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "off-topic answer" },
+    });
+    expect(screen.getByRole("button", { name: /send/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("Send re-enables when the user clears a previously-saved comment", () => {
+    // After clearing the textarea, draft="" → null, saved="text" → "text".
+    // Sending now would null out the saved comment, which is a legitimate change.
+    const onChange = vi.fn();
+    render(
+      <FeedbackThumbs
+        rating="down"
+        comment="off-topic answer"
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
+    expect(screen.getByRole("button", { name: /send/i })).toHaveProperty(
+      "disabled",
+      false,
+    );
+  });
 });

--- a/packages/highperformer/src/chat/FeedbackThumbs.tsx
+++ b/packages/highperformer/src/chat/FeedbackThumbs.tsx
@@ -56,6 +56,13 @@ export function FeedbackThumbs({
     onChange({ rating: "down", comment: draft.trim() || null });
   };
 
+  // Send is a no-op when the draft (normalized) already matches the saved
+  // comment. Disabling on no-op gives the user a visible signal that their
+  // comment was successfully saved — the button greys out after a send and
+  // re-enables only when they type something different.
+  const sendDisabled =
+    disabled || (draft.trim() || null) === (comment ?? null);
+
   return (
     <span style={{ display: "inline-flex", flexDirection: "column", gap: 4 }}>
       <span style={{ display: "inline-flex", gap: 4 }}>
@@ -87,7 +94,7 @@ export function FeedbackThumbs({
             onPressEnter={sendComment}
             style={{ width: 200 }}
           />
-          <Button size="small" disabled={disabled} onClick={sendComment}>
+          <Button size="small" disabled={sendDisabled} onClick={sendComment}>
             Send
           </Button>
         </span>


### PR DESCRIPTION
## Summary
Thumbs-down comment Send had no visual feedback after a successful save — the user clicked Send, the PUT fired, but the button looked identical so it appeared nothing happened.

This change disables Send whenever sending wouldn't change anything: `(draft.trim() || null) === (comment ?? null)`. One rule covers every state:

| State | Send |
|---|---|
| Just opened thumb-down, empty textarea | disabled |
| User typing | enabled |
| After successful save (draft matches saved) | disabled (the requested signal) |
| User edits → draft diverges | enabled |
| User clears a saved comment | enabled (legitimate "remove my comment") |

## Test plan
- [x] 476 tests passing (+4 new: empty=disabled, typing=enabled, matches-saved=disabled, clear-saved=enabled)
- [x] Live smoke: thumbs-down → type → Send → button greys out
- [ ] CI green