### PR TITLE
feat(zarrstore): recognize 'gene' as a gene-symbol column candidate

### DIFF
--- a/.changeset/gene-symbol-column-candidate-gene.md
+++ b/.changeset/gene-symbol-column-candidate-gene.md
@@ -1,0 +1,9 @@
+---
+"@cbioportal-cell-explorer/zarrstore": patch
+---
+
+Recognize `gene` as a gene-symbol column candidate. Datasets like
+egfr_all_cells.zarr store symbols in a column literally named `gene` rather
+than the common `feature_name` / `gene_symbol` conventions. Added at the
+end of the priority list so canonical columns still win when both exist.
+Mirrors the matching backend change.

--- a/packages/zarrstore/src/AnnDataStore.ts
+++ b/packages/zarrstore/src/AnnDataStore.ts
@@ -39,7 +39,18 @@ interface CachedOpts<T> {
   getLabel?: (result: T) => Promise<string | undefined> | string | undefined;
 }
 
-/** Common var column names that hold human-readable gene symbols (case-sensitive candidates). */
+/**
+ * Common var column names that hold human-readable gene symbols (case-sensitive
+ * candidates). The first column present in a given dataset wins.
+ *
+ * `gene` is the most ambiguous candidate (a future dataset could store
+ * something else under that name) so it sits at the end — a dataset that has
+ * both a canonical column AND `gene` still picks the canonical one. Per-dataset
+ * overrides for unusual schemas are tracked separately.
+ *
+ * Keep in sync with cell-explorer-py's GENE_SYMBOL_COLUMNS in
+ * packages/api/src/cell_explorer_api/services/zarr_adapter.py.
+ */
 export const GENE_SYMBOL_COLUMNS: readonly string[] = [
   "gene_symbol",
   "GeneSymbol",
@@ -50,6 +61,7 @@ export const GENE_SYMBOL_COLUMNS: readonly string[] = [
   "gene_short_name",
   "symbol",
   "name",
+  "gene",
 ];
 
 export class AnnDataStore {


### PR DESCRIPTION
## Summary
Mirror of cBioPortal/cell-explorer-py#162. Adds \`gene\` (the literal column name) to \`GENE_SYMBOL_COLUMNS\` so datasets like \`egfr_all_cells.zarr\` — which store symbols in a column named \`gene\` rather than the common \`feature_name\`/\`gene_symbol\` conventions — auto-resolve gene symbols in the UI's gene-color/gene-search paths.

\`gene\` is the most ambiguous candidate (the name could in theory mean other things), so it sits at the **end** of the priority list. A dataset that has both \`feature_name\` and \`gene\` still picks \`feature_name\`.

Per-dataset overrides for truly unusual schemas are tracked separately.

## Test plan
- [x] 79 zarrstore tests pass locally (no behavioral changes; static list extension)
- [ ] CI green