### PR TITLE
feat: apply per-dataset default view on load (highperformer)

### DIFF
--- a/.changeset/dataset-default-view.md
+++ b/.changeset/dataset-default-view.md
@@ -1,0 +1,6 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+"@cbioportal-cell-explorer/api-client": patch
+---
+
+Apply a dataset's stored default view on load. When a catalog dataset has a curator-set `default_view` (coloring, cluster labels, point rendering) and no explicit `?config=` link is present, highperformer now applies it via `applyConfig()`. The generated API client exposes the new `default_view` field on `DatasetResponse`.

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -108,6 +108,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh
+         * @description Rotate session cookies using the refresh cookie.
+         *
+         *     Idempotent endpoint used by the frontend's proactive-refresh timer to
+         *     keep the access cookie fresh before its TTL expires. Avoids the
+         *     rotation race that happens when multiple parallel requests all try to
+         *     refresh after expiry. Returns 401 if no refresh cookie or if Keycloak
+         *     rejects the refresh.
+         */
+        post: operations["refresh_api_auth_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/token-exchange": {
         parameters: {
             query?: never;
@@ -362,6 +388,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/{slug}/messages/{message_id}/feedback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Put Message Feedback */
+        put: operations["put_message_feedback_api_chat__slug__messages__message_id__feedback_put"];
+        post?: never;
+        /** Delete Message Feedback */
+        delete: operations["delete_message_feedback_api_chat__slug__messages__message_id__feedback_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -426,6 +470,12 @@ export interface components {
             is_public: boolean;
             /** Required Roles */
             required_roles: string[];
+            /** Prompt Addendum */
+            prompt_addendum: string | null;
+            /** Default View */
+            default_view: {
+                [key: string]: unknown;
+            } | null;
             /** Chat Enabled */
             chat_enabled: boolean;
         };
@@ -451,6 +501,12 @@ export interface components {
              * @default []
              */
             required_roles: string[];
+            /** Prompt Addendum */
+            prompt_addendum?: string | null;
+            /** Default View */
+            default_view?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Chat Enabled
              * @default false
@@ -476,6 +532,10 @@ export interface components {
             url: string | null;
             /** Chat Enabled */
             chat_enabled: boolean;
+            /** Default View */
+            default_view?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** DatasetUpdate */
         DatasetUpdate: {
@@ -489,6 +549,12 @@ export interface components {
             is_public?: boolean | null;
             /** Required Roles */
             required_roles?: string[] | null;
+            /** Prompt Addendum */
+            prompt_addendum?: string | null;
+            /** Default View */
+            default_view?: {
+                [key: string]: unknown;
+            } | null;
             /** Chat Enabled */
             chat_enabled?: boolean | null;
         };
@@ -540,6 +606,31 @@ export interface components {
             /** Credential Ref */
             credential_ref?: string | null;
         };
+        /** FeedbackRequest */
+        FeedbackRequest: {
+            /**
+             * Rating
+             * @enum {string}
+             */
+            rating: "up" | "down";
+            /** Comment */
+            comment?: string | null;
+        };
+        /** FeedbackResponse */
+        FeedbackResponse: {
+            /**
+             * Rating
+             * @enum {string}
+             */
+            rating: "up" | "down";
+            /** Comment */
+            comment: string | null;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -589,8 +680,23 @@ export interface components {
             /** Threads */
             threads: components["schemas"]["ThreadSummaryResponse"][];
         };
+        /** ThreadMessageFeedback */
+        ThreadMessageFeedback: {
+            /**
+             * Rating
+             * @enum {string}
+             */
+            rating: "up" | "down";
+            /** Comment */
+            comment: string | null;
+        };
         /** ThreadMessageResponse */
         ThreadMessageResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
             /**
              * Role
              * @enum {string}
@@ -603,6 +709,7 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            feedback?: components["schemas"]["ThreadMessageFeedback"] | null;
         };
         /** ThreadSummaryResponse */
         ThreadSummaryResponse: {
@@ -780,6 +887,26 @@ export interface operations {
         };
     };
     logout_api_auth_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    refresh_api_auth_refresh_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -1284,6 +1411,72 @@ export interface operations {
             path: {
                 slug: string;
                 thread_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_message_feedback_api_chat__slug__messages__message_id__feedback_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+                message_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FeedbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_message_feedback_api_chat__slug__messages__message_id__feedback_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+                message_id: string;
             };
             cookie?: never;
         };

--- a/packages/highperformer/src/store/openCatalogDefaultView.test.ts
+++ b/packages/highperformer/src/store/openCatalogDefaultView.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const applyConfigMock = vi.fn().mockResolvedValue({ ok: true })
+vi.mock('../config/applyConfig', () => ({ applyConfig: applyConfigMock }))
+
+import useAppStore from './useAppStore'
+
+describe('openCatalogDataset applies default_view', () => {
+  beforeEach(() => {
+    applyConfigMock.mockClear()
+    // Stub openDataset so no real zarr load happens; clear catalog + errors.
+    useAppStore.setState({
+      openDataset: vi.fn().mockResolvedValue(undefined) as never,
+      catalogDatasets: [],
+      loadingError: null as never,
+    })
+  })
+
+  it('calls applyConfig with default_view when the dataset has one', async () => {
+    const default_view = { colorBy: 'category', category: 'cell_type' }
+    useAppStore.setState({
+      catalogDatasets: [
+        {
+          slug: 'ds1',
+          name: 'DS1',
+          description: null,
+          is_public: true,
+          url: 'https://cdn/ds1.zarr',
+          chat_enabled: false,
+          default_view,
+        },
+      ],
+    })
+    await useAppStore.getState().openCatalogDataset('ds1')
+    expect(applyConfigMock).toHaveBeenCalledWith(default_view)
+  })
+
+  it('does not call applyConfig when default_view is absent', async () => {
+    useAppStore.setState({
+      catalogDatasets: [
+        {
+          slug: 'ds2',
+          name: 'DS2',
+          description: null,
+          is_public: true,
+          url: 'https://cdn/ds2.zarr',
+          chat_enabled: false,
+        },
+      ],
+    })
+    await useAppStore.getState().openCatalogDataset('ds2')
+    expect(applyConfigMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -216,6 +216,7 @@ export interface AppState {
     is_public: boolean
     url: string | null
     chat_enabled: boolean
+    default_view?: Record<string, unknown> | null
   }>
   fetchCatalog: () => Promise<void>
   openCatalogDataset: (slug: string) => Promise<void>

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -535,10 +535,19 @@ const useAppStore = create<AppState>((set, get) => ({
       }
     }
 
+    const finishOpen = async () => {
+      set({ datasetSlug: slug })
+      const dv = dataset.default_view
+      if (dv) {
+        const { applyConfig } = await import('../config/applyConfig')
+        await applyConfig(dv)
+      }
+    }
+
     // Public dataset — open directly
     if (dataset.url) {
       await get().openDataset(dataset.url)
-      set({ datasetSlug: slug })
+      await finishOpen()
       return
     }
 
@@ -563,13 +572,13 @@ const useAppStore = create<AppState>((set, get) => ({
         await get().openDataset(data.url, {
           headers: { Authorization: `Bearer ${data.token}` },
         })
-        set({ datasetSlug: slug })
+        await finishOpen()
         return
       }
 
       // signed_cookies or public — no overrides needed
       await get().openDataset(data.url)
-      set({ datasetSlug: slug })
+      await finishOpen()
     } catch {
       set({ loadingError: 'Failed to access dataset' })
     }


### PR DESCRIPTION
Frontend half of the per-dataset default view feature (backend: cBioPortal/cell-explorer-py#170, merged). Implements cBioPortal/cbioportal-cell-explorer#229's parent behavior.

- Regenerated the api-client; `DatasetResponse` now carries `default_view`.
- highperformer applies a dataset's stored `default_view` (coloring, cluster labels, point rendering) via the existing `applyConfig()` when opening a catalog dataset.
- Precedence: `?config=` shared-link → stored `default_view` → today's default (first embedding, gray). The `?config=` path doesn't route through `openCatalogDataset`, so it still wins structurally.

478 highperformer tests pass; changeset included (highperformer minor, api-client patch).