### PR TITLE
fix(highperformer): apply stored default view reliably (obs metadata race)

### DIFF
--- a/.changeset/fix-default-view-apply-race.md
+++ b/.changeset/fix-default-view-apply-race.md
@@ -1,0 +1,5 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Fix intermittent failure applying a dataset's stored default view. `applyConfig` now treats a dataset as still-loading when its handle is open (`adata`) but obs columns haven't arrived yet — the async window after `openDataset` resolves but before `fetchEmbedding`'s background obs-columns fetch completes — so it waits for metadata instead of bailing with `metadata_unavailable`.

--- a/packages/highperformer/src/config/applyConfig.ts
+++ b/packages/highperformer/src/config/applyConfig.ts
@@ -99,8 +99,17 @@ export async function applyConfig(input: unknown): Promise<ApplyResult> {
   if (!hasPostLoadConfig) return ok()
 
   const metadataReady = store.getState().obsColumnNames.length > 0
+  // `adata != null` covers the window after openDataset() resolves (it sets
+  // `adata` and flips `loading` off) but before obsColumnNames arrives — those
+  // are fetched a couple async hops later in fetchEmbedding's background
+  // Promise. Without this, a post-load config applied with no url/dataset (e.g.
+  // a stored default_view) wrongly bails with metadata_unavailable.
   const datasetLoading =
-    !metadataReady && (config.dataset !== undefined || config.url !== undefined || store.getState().loading)
+    !metadataReady &&
+    (config.dataset !== undefined ||
+      config.url !== undefined ||
+      store.getState().loading ||
+      store.getState().adata != null)
 
   if (!metadataReady && datasetLoading) {
     try {

--- a/packages/highperformer/src/config/applyConfigMetadataRace.test.ts
+++ b/packages/highperformer/src/config/applyConfigMetadataRace.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { applyConfig } from './applyConfig'
+import useAppStore from '../store/useAppStore'
+
+// Regression: a stored default_view is applied via applyConfig WITHOUT a
+// url/dataset field, right after openCatalogDataset's openDataset() resolves.
+// openDataset resolves with `adata` set but `obsColumnNames` still empty
+// (obs columns are fetched a couple async hops later, in fetchEmbedding's
+// background Promise). applyConfig must recognize the dataset is open and wait
+// for obs metadata rather than bailing with metadata_unavailable.
+describe('applyConfig — dataset open but obs metadata not yet loaded', () => {
+  it('waits for obsColumnNames instead of bailing, then applies the category', async () => {
+    const setColorMode = vi.fn()
+    const selectObsColumn = vi.fn((c: string) => useAppStore.setState({ selectedObsColumn: c }))
+
+    useAppStore.setState({
+      adata: {} as never, // dataset handle is open …
+      obsColumnNames: [], // … but obs columns haven't arrived yet
+      loading: false, // openDataset already flipped loading off
+      categoryMap: [],
+      selectedObsColumn: null,
+      setColorMode: setColorMode as never,
+      selectObsColumn: selectObsColumn as never,
+    })
+
+    // Simulate the background obsColumns() fetch completing a tick later.
+    setTimeout(() => useAppStore.setState({ obsColumnNames: ['author_cell_type'] }), 0)
+
+    const res = await applyConfig({
+      colorBy: 'category',
+      category: 'author_cell_type',
+      showCategoryLabels: true,
+    })
+
+    expect(res.ok).toBe(true)
+    expect(setColorMode).toHaveBeenCalledWith('category')
+    expect(selectObsColumn).toHaveBeenCalledWith('author_cell_type')
+  })
+})


### PR DESCRIPTION
Closes #288.

Fixes the intermittent failure applying a dataset's stored `default_view` on load.

**Root cause:** `openCatalogDataset` applies the stored view via `applyConfig(default_view)` (no `url`/`dataset` in the config) right after `openDataset` resolves — but at that point `adata` is set while `obsColumnNames` is still empty (obs columns load a couple async hops later in `fetchEmbedding`'s background fetch) and `loading` is already `false`. `applyConfig` saw "nothing loading, metadata absent" and bailed with `metadata_unavailable`. The dynamic-import delay racing the background fetch made it timing-dependent.

**Fix:** `applyConfig` now treats a dataset as still-loading when its handle is open (`adata != null`) but obs columns haven't arrived, so it waits for metadata instead of bailing. Benefits any post-load caller.

Regression test `applyConfigMetadataRace.test.ts` reproduces the race (failed before, passes now). Full highperformer suite: 479 passed / 1 skipped.