### PR TITLE
feat(highperformer): high-cardinality categorical coloring (palette 24, Uint16 codes, tiered)

### DIFF
--- a/.changeset/high-cardinality-categorical-coloring.md
+++ b/.changeset/high-cardinality-categorical-coloring.md
@@ -1,0 +1,5 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Improve coloring by high-cardinality obs categories. Expand the categorical palette to 24 colors, fix a silent code-wrap that merged categories past 256 (codes are now Uint16, ceiling 65,535), and replace the hard 1000-value block with tiered behavior: color with a recycled palette (and an informational "colors repeat" note) up to 65,535 distinct values, block above that. The on-plot legend collapses to a compact summary above 500 categories instead of rendering every row.

--- a/packages/highperformer/src/components/CategoricalLegend.test.tsx
+++ b/packages/highperformer/src/components/CategoricalLegend.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+vi.mock('../pool/WorkerPool', () => ({
+  WorkerPool: class { dispatch = vi.fn().mockResolvedValue({}); clearQueue = vi.fn(); dispose() {} },
+}))
+vi.mock('../workers/universal.worker.ts?worker', () => ({ default: class {} }))
+
+const { default: useAppStore } = await import('../store/useAppStore')
+const { default: CategoricalLegend } = await import('./CategoricalLegend')
+
+afterEach(() => cleanup())
+
+function mapOf(n: number) {
+  return Array.from({ length: n }, (_, i) => ({ label: `c${i}`, color: [0, 0, 0] as [number, number, number] }))
+}
+
+describe('CategoricalLegend list cap', () => {
+  it('renders per-category rows at or below the cap', () => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({ categoryMap: mapOf(3) } as any)
+    render(<CategoricalLegend />)
+    expect(screen.getByText('c0')).toBeDefined()
+    expect(screen.getByText('c2')).toBeDefined()
+  })
+
+  it('renders a compact summary above the cap (no per-row list)', () => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({ categoryMap: mapOf(501) } as any)
+    render(<CategoricalLegend />)
+    expect(screen.queryByText('c0')).toBeNull()
+    expect(screen.getByText(/501 categories/)).toBeDefined()
+    expect(screen.getByText(/too many to list/)).toBeDefined()
+  })
+})

--- a/packages/highperformer/src/components/CategoricalLegend.tsx
+++ b/packages/highperformer/src/components/CategoricalLegend.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Input } from 'antd'
 import { SearchOutlined } from '@ant-design/icons'
 import useAppStore from '../store/useAppStore'
+import { CATEGORY_LEGEND_LIST_CAP } from '../utils/categoryEncoding'
 
 const MAX_LIST_HEIGHT = 150
 
@@ -13,6 +14,19 @@ export default function CategoricalLegend() {
   const [search, setSearch] = useState('')
 
   if (categoryMap.length === 0) return null
+
+  if (categoryMap.length > CATEGORY_LEGEND_LIST_CAP) {
+    return (
+      <div style={{ marginTop: 8 }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: '#888', textTransform: 'uppercase', marginBottom: 4 }}>
+          Legend
+        </div>
+        <div style={{ fontSize: 12, color: '#999', padding: '4px 0' }}>
+          {categoryMap.length} categories (colors repeat) — too many to list
+        </div>
+      </div>
+    )
+  }
 
   const filtered = search
     ? categoryMap

--- a/packages/highperformer/src/components/ColorBySection.test.tsx
+++ b/packages/highperformer/src/components/ColorBySection.test.tsx
@@ -92,3 +92,37 @@ describe('ColorBySection — cluster labels', () => {
     expect(useAppStore.getState().categoryLabelsObsColumn).toBe('leiden')
   })
 })
+
+describe('ColorBySection — cardinality note', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      obsColumnNames: ['leiden'],
+      colorMode: 'category',
+      selectedObsColumn: 'leiden',
+    } as any)
+  })
+
+  it('renders the repeat note as an info alert when the column is still colored', () => {
+    useAppStore.setState({
+      categoryWarning: '30 values — colors repeat',
+      categoryMap: [{ label: 'a', color: [0, 0, 0] }],
+      _categoryCodes: new Uint16Array([0]),
+    } as any)
+    const { container } = render(<ColorBySection />)
+    expect(screen.getByText('30 values — colors repeat')).toBeDefined()
+    expect(container.querySelector('.ant-alert-info')).not.toBeNull()
+    expect(container.querySelector('.ant-alert-warning')).toBeNull()
+  })
+
+  it('renders a warning alert when coloring is blocked (no categoryMap)', () => {
+    useAppStore.setState({
+      categoryWarning: '99999 distinct values — too many to color; likely an ID or continuous column',
+      categoryMap: [],
+      _categoryCodes: null,
+    } as any)
+    const { container } = render(<ColorBySection />)
+    expect(container.querySelector('.ant-alert-warning')).not.toBeNull()
+    expect(container.querySelector('.ant-alert-info')).toBeNull()
+  })
+})

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -74,6 +74,7 @@ export default function ColorBySection() {
   const selectGene = useAppStore((s) => s.selectGene)
   const clearGene = useAppStore((s) => s.clearGene)
   const categoryWarning = useAppStore((s) => s.categoryWarning)
+  const categoryMap = useAppStore((s) => s.categoryMap)
   const geneLabelMap = useAppStore((s) => s.geneLabelMap)
   const showCategoryLabels = useAppStore((s) => s.showCategoryLabels)
   const setShowCategoryLabels = useAppStore((s) => s.setShowCategoryLabels)
@@ -158,7 +159,7 @@ export default function ColorBySection() {
           {categoryWarning && (
             <Alert
               title={categoryWarning}
-              type="warning"
+              type={categoryMap.length > 0 ? 'info' : 'warning'}
               showIcon
               style={{ marginTop: 8, fontSize: 12 }}
             />

--- a/packages/highperformer/src/store/reconcileSummaries.test.ts
+++ b/packages/highperformer/src/store/reconcileSummaries.test.ts
@@ -14,7 +14,7 @@ describe('buildRequiredPairs', () => {
 
   it('builds pairs for every variable x every group', () => {
     const obsData = new Map([
-      ['dataset', { codes: new Uint8Array(10), categoryMap: [{ label: 'A', color: [0, 0, 0] as [number, number, number] }] }],
+      ['dataset', { codes: new Uint16Array(10), categoryMap: [{ label: 'A', color: [0, 0, 0] as [number, number, number] }] }],
     ])
     const geneData = new Map([
       ['GENE1', new Float32Array(10)],
@@ -59,7 +59,7 @@ describe('buildRequiredPairs', () => {
 
   it('builds expressionByCategory pairs for each gene x obs x group', () => {
     const obsData = new Map([
-      ['cell_type', { codes: new Uint8Array(10), categoryMap: [
+      ['cell_type', { codes: new Uint16Array(10), categoryMap: [
         { label: 'A', color: [0, 0, 0] as [number, number, number] },
         { label: 'B', color: [1, 1, 1] as [number, number, number] },
       ] }],
@@ -86,7 +86,7 @@ describe('buildRequiredPairs', () => {
   })
 
   it('expressionByCategory pairs carry codes, numCategories, and expression', () => {
-    const codes = new Uint8Array([0, 1, 0])
+    const codes = new Uint16Array([0, 1, 0])
     const expression = new Float32Array([1, 2, 3])
     const obsData = new Map([
       ['ct', { codes, categoryMap: [
@@ -116,7 +116,7 @@ describe('buildRequiredPairs', () => {
 
   it('no expressionByCategory pairs when no genes', () => {
     const obsData = new Map([
-      ['ct', { codes: new Uint8Array(10), categoryMap: [{ label: 'A', color: [0, 0, 0] as [number, number, number] }] }],
+      ['ct', { codes: new Uint16Array(10), categoryMap: [{ label: 'A', color: [0, 0, 0] as [number, number, number] }] }],
     ])
     const groups = [{ id: -1, indices: new Uint32Array(10) }]
 
@@ -134,8 +134,8 @@ describe('reconcileSummaries', () => {
     cache.set('cat:dataset', new Map([[-1, new Uint32Array(3)]]))
 
     const pairs = [
-      { key: 'cat:dataset', groupId: -1, type: 'category' as const, codes: new Uint8Array(10), numCategories: 3, indices: new Uint32Array(10) },
-      { key: 'cat:dataset', groupId: 1, type: 'category' as const, codes: new Uint8Array(10), numCategories: 3, indices: new Uint32Array(5) },
+      { key: 'cat:dataset', groupId: -1, type: 'category' as const, codes: new Uint16Array(10), numCategories: 3, indices: new Uint32Array(10) },
+      { key: 'cat:dataset', groupId: 1, type: 'category' as const, codes: new Uint16Array(10), numCategories: 3, indices: new Uint32Array(5) },
     ]
 
     reconcileSummaries(pairs, cache, dispatchFn)
@@ -150,8 +150,8 @@ describe('reconcileSummaries', () => {
     cache.set('cat:dataset', new Map([[-1, new Uint32Array(3)], [1, new Uint32Array(3)], [2, new Uint32Array(3)]]))
 
     const pairs = [
-      { key: 'cat:dataset', groupId: -1, type: 'category' as const, codes: new Uint8Array(10), numCategories: 3, indices: new Uint32Array(10) },
-      { key: 'cat:dataset', groupId: 1, type: 'category' as const, codes: new Uint8Array(10), numCategories: 3, indices: new Uint32Array(5) },
+      { key: 'cat:dataset', groupId: -1, type: 'category' as const, codes: new Uint16Array(10), numCategories: 3, indices: new Uint32Array(10) },
+      { key: 'cat:dataset', groupId: 1, type: 'category' as const, codes: new Uint16Array(10), numCategories: 3, indices: new Uint32Array(5) },
     ]
 
     reconcileSummaries(pairs, cache, dispatchFn)
@@ -167,7 +167,7 @@ describe('reconcileSummaries', () => {
     cache.set('expr:GENE1', new Map([[-1, {} as unknown]]))
 
     const pairs = [
-      { key: 'cat:dataset', groupId: -1, type: 'category' as const, codes: new Uint8Array(10), numCategories: 3, indices: new Uint32Array(10) },
+      { key: 'cat:dataset', groupId: -1, type: 'category' as const, codes: new Uint16Array(10), numCategories: 3, indices: new Uint32Array(10) },
     ]
 
     reconcileSummaries(pairs, cache, dispatchFn)

--- a/packages/highperformer/src/store/reconcileSummaries.ts
+++ b/packages/highperformer/src/store/reconcileSummaries.ts
@@ -6,7 +6,7 @@ export interface SummaryPair {
   type: 'category' | 'expression' | 'expressionByCategory'
   indices: Uint32Array
   // Category-specific
-  codes?: Uint8Array
+  codes?: Uint16Array
   numCategories?: number
   // Expression-specific
   expression?: Float32Array
@@ -23,7 +23,7 @@ interface GroupLike {
  * indices produces one pair.
  */
 export function buildRequiredPairs(
-  obsData: Map<string, { codes: Uint8Array; categoryMap: { label: string; color: RGB }[] }>,
+  obsData: Map<string, { codes: Uint16Array; categoryMap: { label: string; color: RGB }[] }>,
   contData: Map<string, Float32Array>,
   geneData: Map<string, Float32Array>,
   groups: GroupLike[],

--- a/packages/highperformer/src/store/selectObsColumnTiers.test.ts
+++ b/packages/highperformer/src/store/selectObsColumnTiers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+
+// Mock the worker pool so rebuildColorBuffer's dispatch resolves harmlessly.
+vi.mock('../pool/WorkerPool', () => ({
+  WorkerPool: class { dispatch = vi.fn().mockResolvedValue({}); clearQueue = vi.fn(); dispose() {} },
+}))
+vi.mock('../workers/universal.worker.ts?worker', () => ({ default: class {} }))
+
+const { default: useAppStore } = await import('./useAppStore')
+
+function fakeAdataReturning(values: (string | number | null)[]) {
+  return { obsColumn: vi.fn().mockResolvedValue(values) } as unknown as never
+}
+
+describe('selectObsColumn cardinality tiers', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState())
+  })
+  afterEach(() => vi.clearAllMocks())
+
+  it('low cardinality: colors with no warning', async () => {
+    useAppStore.setState({ adata: fakeAdataReturning(['A', 'B', 'A', 'C']) })
+    useAppStore.getState().selectObsColumn('col')
+    await waitFor(() => expect(useAppStore.getState()._categoryCodes).not.toBeNull())
+    expect(useAppStore.getState().categoryWarning).toBeNull()
+  })
+
+  it('mid cardinality: colors AND sets a repeat note', async () => {
+    const values = Array.from({ length: 30 }, (_, i) => `c${i}`)
+    useAppStore.setState({ adata: fakeAdataReturning(values) })
+    useAppStore.getState().selectObsColumn('col')
+    await waitFor(() => expect(useAppStore.getState()._categoryCodes).not.toBeNull())
+    expect(useAppStore.getState().categoryWarning).toContain('colors repeat')
+  })
+
+  it('above the legend cap: colors but does NOT auto-pin to summary', async () => {
+    const values = Array.from({ length: 501 }, (_, i) => `c${i}`)
+    useAppStore.setState({ adata: fakeAdataReturning(values) })
+    useAppStore.getState().selectObsColumn('col')
+    await waitFor(() => expect(useAppStore.getState()._categoryCodes).not.toBeNull())
+    expect(useAppStore.getState().summaryObsColumns).not.toContain('col')
+  })
+
+  it('above the colorable ceiling: blocks (no codes) and warns', async () => {
+    const values = Array.from({ length: 65536 }, (_, i) => `c${i}`)
+    useAppStore.setState({ adata: fakeAdataReturning(values) })
+    useAppStore.getState().selectObsColumn('col')
+    await waitFor(() => expect(useAppStore.getState().categoryWarning).not.toBeNull())
+    expect(useAppStore.getState()._categoryCodes).toBeNull()
+    expect(useAppStore.getState().categoryWarning).toContain('too many to color')
+  })
+})

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -556,7 +556,7 @@ describe('useAppStore', () => {
       )
     })
 
-    it('shows warning when unique values exceed threshold', async () => {
+    it('shows repeat-color warning but still colors when unique values exceed palette size', async () => {
       const manyValues = Array.from({ length: 1001 }, (_, i) => `val_${i}`)
       const mockAdata = {
         obsColumn: vi.fn().mockResolvedValue(manyValues),
@@ -576,6 +576,31 @@ describe('useAppStore', () => {
 
       await vi.waitFor(() => {
         expect(useAppStore.getState().categoryWarning).toContain('1001')
+      })
+      // Colors repeat warning — coloring proceeds (dispatch is called)
+      expect(mockDispatch).toHaveBeenCalled()
+    })
+
+    it('blocks coloring and warns when unique values exceed the colorable ceiling', async () => {
+      const hugeValues = Array.from({ length: 65536 }, (_, i) => `val_${i}`)
+      const mockAdata = {
+        obsColumn: vi.fn().mockResolvedValue(hugeValues),
+      }
+      useAppStore.setState({
+        adata: mockAdata as any,
+        embeddingData: {
+          positions: new Float32Array(65536 * 2),
+          numPoints: 65536,
+          bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+        },
+        colorMode: 'category',
+      })
+      mockDispatch.mockClear()
+
+      useAppStore.getState().selectObsColumn('id_col')
+
+      await vi.waitFor(() => {
+        expect(useAppStore.getState().categoryWarning).toContain('too many to color')
       })
       // Should NOT dispatch a color buffer build
       expect(mockDispatch).not.toHaveBeenCalled()

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -210,7 +210,7 @@ describe('useAppStore', () => {
     })
 
     it('dispatches buildFromCategories in category mode', () => {
-      const codes = new Uint8Array([0, 1, 0])
+      const codes = new Uint16Array([0, 1, 0])
       useAppStore.setState({
         embeddingData: {
           positions: new Float32Array([0, 0, 1, 1, 2, 2]),
@@ -326,7 +326,7 @@ describe('useAppStore', () => {
           bounds: { minX: 0, maxX: 2, minY: 0, maxY: 2 },
         },
         colorMode: 'category',
-        _categoryCodes: new Uint8Array([0, 1, 2]),
+        _categoryCodes: new Uint16Array([0, 1, 2]),
       })
       mockDispatch.mockClear()
 
@@ -349,7 +349,7 @@ describe('useAppStore', () => {
           bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
         },
         colorMode: 'category',
-        _categoryCodes: new Uint8Array([0, 1]),
+        _categoryCodes: new Uint16Array([0, 1]),
         highlightedCategories: new Set([1]),
       })
       mockDispatch.mockClear()
@@ -373,7 +373,7 @@ describe('useAppStore', () => {
           bounds: { minX: 0, maxX: 2, minY: 0, maxY: 2 },
         },
         colorMode: 'category',
-        _categoryCodes: new Uint8Array([0, 1, 2]),
+        _categoryCodes: new Uint16Array([0, 1, 2]),
         highlightedCategories: new Set([0]),
       })
       mockDispatch.mockClear()
@@ -396,7 +396,7 @@ describe('useAppStore', () => {
           bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
         },
         colorMode: 'category',
-        _categoryCodes: new Uint8Array([0, 1]),
+        _categoryCodes: new Uint16Array([0, 1]),
         highlightedCategories: new Set([0, 1]),
       })
       mockDispatch.mockClear()
@@ -487,7 +487,7 @@ describe('useAppStore', () => {
 
   describe('setColorMode', () => {
     it('switches mode and rebuilds if cached data exists', () => {
-      const codes = new Uint8Array([0, 1])
+      const codes = new Uint16Array([0, 1])
       useAppStore.setState({
         embeddingData: {
           positions: new Float32Array([0, 0, 1, 1]),
@@ -592,7 +592,7 @@ describe('useAppStore', () => {
         },
         colorMode: 'category',
         selectedObsColumn: 'cluster',
-        _categoryCodes: new Uint8Array([0, 1]),
+        _categoryCodes: new Uint16Array([0, 1]),
         categoryMap: [{ label: 'A', color: [0, 0, 0] }],
         categoryWarning: 'some warning',
       })
@@ -1335,7 +1335,7 @@ describe('useAppStore', () => {
         } as any,
         summaryObsData: new Map([
           ["cell_type", {
-            codes: new Uint8Array([0, 0, 1, 1]),
+            codes: new Uint16Array([0, 0, 1, 1]),
             categoryMap: [
               { label: "T", color: [255, 0, 0] as [number, number, number] },
               { label: "B", color: [0, 255, 0] as [number, number, number] },

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -118,7 +118,7 @@ export interface AppState {
   geneLabelMap: Map<string, string> | null
 
   // Internal — cached data for rebuilds (not for UI consumption)
-  _categoryCodes: Uint8Array | null
+  _categoryCodes: Uint16Array | null
   _expressionData: Float32Array | null
   _colorAbort: AbortController | null
 
@@ -179,7 +179,7 @@ export interface AppState {
   summaryPanelOpen: boolean
   summaryObsColumns: string[]
   summaryGenes: string[]
-  summaryObsData: Map<string, { codes: Uint8Array; categoryMap: { label: string; color: RGB }[] }>
+  summaryObsData: Map<string, { codes: Uint16Array; categoryMap: { label: string; color: RGB }[] }>
   summaryObsContinuousData: Map<string, Float32Array>
   summaryGeneData: Map<string, Float32Array>
   summaryGeneRanges: Map<string, { min: number; max: number }>

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -6,7 +6,7 @@ import { flushSummaryQueue } from '../hooks/summaryScheduler'
 import UniversalWorker from '../workers/universal.worker.ts?worker'
 import type { ColorBufferResponse } from '../workers/colorBuffer.schemas'
 import type { RGB } from '../utils/colors'
-import { encodeCategories, MAX_CATEGORIES } from '../utils/categoryEncoding'
+import { encodeCategories, MAX_CATEGORIES, classifyCardinality, CATEGORY_LEGEND_LIST_CAP } from '../utils/categoryEncoding'
 
 export interface EmbeddingBounds {
   minX: number
@@ -1312,9 +1312,11 @@ const useAppStore = create<AppState>((set, get) => ({
       const valuesArray = Array.isArray(values) ? values : Array.from(values as Iterable<number>)
       const { codes, categoryMap, uniqueCount } = encodeCategories(valuesArray as (string | number | null)[])
 
-      if (uniqueCount > MAX_CATEGORIES) {
+      const { colorable, note } = classifyCardinality(uniqueCount)
+
+      if (!colorable) {
         set({
-          categoryWarning: `This column has ${uniqueCount} unique values (likely continuous). Please choose a categorical column.`,
+          categoryWarning: note,
           colorBufferLoading: false,
           _categoryCodes: null,
           categoryMap: [],
@@ -1326,18 +1328,21 @@ const useAppStore = create<AppState>((set, get) => ({
       set({
         _categoryCodes: codes,
         categoryMap,
-        categoryWarning: null,
+        categoryWarning: note,
         _colorAbort: null,
       })
       get().rebuildColorBuffer()
 
-      // Auto-pin to summary panel
-      const { summaryObsColumns, summaryObsData } = get()
-      if (!summaryObsColumns.includes(name)) {
-        const nextPinned = [...summaryObsColumns, name]
-        const nextData = new Map(summaryObsData)
-        nextData.set(name, { codes, categoryMap })
-        set({ summaryObsColumns: nextPinned, summaryObsData: nextData })
+      // Auto-pin to summary panel — but skip for very high cardinality, where the
+      // summary CategoryDotPlot would choke on a huge categoryMap.
+      if (uniqueCount <= CATEGORY_LEGEND_LIST_CAP) {
+        const { summaryObsColumns, summaryObsData } = get()
+        if (!summaryObsColumns.includes(name)) {
+          const nextPinned = [...summaryObsColumns, name]
+          const nextData = new Map(summaryObsData)
+          nextData.set(name, { codes, categoryMap })
+          set({ summaryObsColumns: nextPinned, summaryObsData: nextData })
+        }
       }
     })
   },

--- a/packages/highperformer/src/utils/categoryEncoding.test.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { encodeCategories, MAX_CATEGORIES } from './categoryEncoding'
+import { encodeCategories, MAX_CATEGORIES, classifyCardinality, MAX_COLORABLE_CATEGORIES, CATEGORY_LEGEND_LIST_CAP } from './categoryEncoding'
 import { CATEGORICAL_COLORS } from './colors'
 
 describe('encodeCategories', () => {
@@ -70,5 +70,33 @@ describe('encodeCategories', () => {
     expect(result.codes[256]).toBe(256)
     expect(result.codes[0]).toBe(0)
     expect(result.codes[256]).not.toBe(result.codes[0])
+  })
+})
+
+describe('classifyCardinality', () => {
+  it('colors with no note at or below the palette length', () => {
+    expect(classifyCardinality(CATEGORICAL_COLORS.length)).toEqual({ colorable: true, note: null })
+    expect(classifyCardinality(1)).toEqual({ colorable: true, note: null })
+  })
+
+  it('colors with a repeat note between palette length and the colorable ceiling', () => {
+    const r = classifyCardinality(CATEGORICAL_COLORS.length + 1)
+    expect(r.colorable).toBe(true)
+    expect(r.note).toContain('colors repeat')
+
+    const hi = classifyCardinality(MAX_COLORABLE_CATEGORIES)
+    expect(hi.colorable).toBe(true)
+    expect(hi.note).toContain('colors repeat')
+  })
+
+  it('blocks above the colorable ceiling', () => {
+    const r = classifyCardinality(MAX_COLORABLE_CATEGORIES + 1)
+    expect(r.colorable).toBe(false)
+    expect(r.note).toContain('too many to color')
+  })
+
+  it('exposes the expected constants', () => {
+    expect(MAX_COLORABLE_CATEGORIES).toBe(65535)
+    expect(CATEGORY_LEGEND_LIST_CAP).toBe(500)
   })
 })

--- a/packages/highperformer/src/utils/categoryEncoding.test.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.test.ts
@@ -7,7 +7,7 @@ describe('encodeCategories', () => {
     const values = ['A', 'B', 'A', 'C', 'B']
     const result = encodeCategories(values)
 
-    expect(result.codes).toBeInstanceOf(Uint8Array)
+    expect(result.codes).toBeInstanceOf(Uint16Array)
     expect(result.codes.length).toBe(5)
     // Same strings get same codes
     expect(result.codes[0]).toBe(result.codes[2]) // A === A
@@ -60,5 +60,15 @@ describe('encodeCategories', () => {
 
   it('exports MAX_CATEGORIES as 1000', () => {
     expect(MAX_CATEGORIES).toBe(1000)
+  })
+
+  it('assigns distinct codes beyond 256 categories (no Uint8 wrap)', () => {
+    const values = Array.from({ length: 300 }, (_, i) => `cat_${i}`)
+    const result = encodeCategories(values)
+    expect(result.uniqueCount).toBe(300)
+    // The 257th category (code 256) must be distinct from the first (code 0).
+    expect(result.codes[256]).toBe(256)
+    expect(result.codes[0]).toBe(0)
+    expect(result.codes[256]).not.toBe(result.codes[0])
   })
 })

--- a/packages/highperformer/src/utils/categoryEncoding.test.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.test.ts
@@ -47,12 +47,15 @@ describe('encodeCategories', () => {
     expect(result.codes.length).toBe(3)
   })
 
-  it('wraps colors via modulo for > 15 categories', () => {
-    const values = Array.from({ length: 20 }, (_, i) => `cat_${i}`)
+  it('wraps colors via modulo at the palette length', () => {
+    const n = CATEGORICAL_COLORS.length
+    const values = Array.from({ length: n + 3 }, (_, i) => `cat_${i}`)
     const result = encodeCategories(values)
-    expect(result.uniqueCount).toBe(20)
-    // Color at index 15 wraps to CATEGORICAL_COLORS[0]
-    expect(result.categoryMap[15].color).toEqual(CATEGORICAL_COLORS[0])
+    expect(result.uniqueCount).toBe(n + 3)
+    // The (n+1)th category recycles the first color.
+    expect(result.categoryMap[n].color).toEqual(CATEGORICAL_COLORS[0])
+    // The category just before the wrap uses the last palette color.
+    expect(result.categoryMap[n - 1].color).toEqual(CATEGORICAL_COLORS[n - 1])
   })
 
   it('exports MAX_CATEGORIES as 1000', () => {

--- a/packages/highperformer/src/utils/categoryEncoding.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.ts
@@ -2,6 +2,36 @@ import { CATEGORICAL_COLORS, type RGB } from './colors'
 
 export const MAX_CATEGORIES = 1000
 
+// Uint16 ceiling: above this, per-cell codes would wrap, so colorby is blocked.
+export const MAX_COLORABLE_CATEGORIES = 65535
+// Above this many categories, color the plot but suppress the (un-virtualized)
+// legend list and skip auto-pinning to the summary panel.
+export const CATEGORY_LEGEND_LIST_CAP = 500
+
+export interface CardinalityClass {
+  colorable: boolean
+  note: string | null
+}
+
+/**
+ * Decide how to handle a colorby column of the given distinct-value count.
+ * - <= palette length: color, no note.
+ * - <= MAX_COLORABLE_CATEGORIES: color with the recycled palette + a note.
+ * - otherwise: block (codes would wrap; likely an ID or continuous column).
+ */
+export function classifyCardinality(uniqueCount: number): CardinalityClass {
+  if (uniqueCount <= CATEGORICAL_COLORS.length) {
+    return { colorable: true, note: null }
+  }
+  if (uniqueCount <= MAX_COLORABLE_CATEGORIES) {
+    return { colorable: true, note: `${uniqueCount} values — colors repeat` }
+  }
+  return {
+    colorable: false,
+    note: `${uniqueCount} distinct values — too many to color; likely an ID or continuous column`,
+  }
+}
+
 export interface CategoryEncoding {
   codes: Uint16Array
   categoryMap: { label: string; color: RGB }[]

--- a/packages/highperformer/src/utils/categoryEncoding.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.ts
@@ -3,14 +3,14 @@ import { CATEGORICAL_COLORS, type RGB } from './colors'
 export const MAX_CATEGORIES = 1000
 
 export interface CategoryEncoding {
-  codes: Uint8Array
+  codes: Uint16Array
   categoryMap: { label: string; color: RGB }[]
   uniqueCount: number
 }
 
 export function encodeCategories(values: (string | number | null)[]): CategoryEncoding {
   const labelToCode = new Map<string, number>()
-  const codes = new Uint8Array(values.length)
+  const codes = new Uint16Array(values.length)
   const numColors = CATEGORICAL_COLORS.length
 
   for (let i = 0; i < values.length; i++) {

--- a/packages/highperformer/src/utils/colors.test.ts
+++ b/packages/highperformer/src/utils/colors.test.ts
@@ -93,17 +93,22 @@ describe('inferno scale', () => {
 })
 
 describe('CATEGORICAL_COLORS', () => {
-  it('has 15 colors', () => {
-    expect(CATEGORICAL_COLORS).toHaveLength(15)
+  it('has 24 colors', () => {
+    expect(CATEGORICAL_COLORS.length).toBe(24)
   })
 
-  it('each entry is an RGB triplet', () => {
-    for (const color of CATEGORICAL_COLORS) {
-      expect(color).toHaveLength(3)
-      color.forEach((v) => {
-        expect(v).toBeGreaterThanOrEqual(0)
-        expect(v).toBeLessThanOrEqual(255)
-      })
+  it('every entry is a valid RGB triple', () => {
+    for (const c of CATEGORICAL_COLORS) {
+      expect(c).toHaveLength(3)
+      for (const channel of c) {
+        expect(channel).toBeGreaterThanOrEqual(0)
+        expect(channel).toBeLessThanOrEqual(255)
+      }
     }
+  })
+
+  it('has no duplicate colors', () => {
+    const seen = new Set(CATEGORICAL_COLORS.map((c) => c.join(',')))
+    expect(seen.size).toBe(CATEGORICAL_COLORS.length)
   })
 })

--- a/packages/highperformer/src/utils/colors.ts
+++ b/packages/highperformer/src/utils/colors.ts
@@ -2,7 +2,9 @@ export type RGB = [number, number, number]
 
 export type ColorScale = RGB[]
 
-// Categorical color palette (similar to D3 category10)
+// Categorical color palette. First 15 are D3 category10 + 5 light variants
+// (kept stable so existing low-cardinality coloring is unchanged); the next 9
+// extend distinctness for higher-cardinality columns. Colors recycle beyond 24.
 export const CATEGORICAL_COLORS: RGB[] = [
   [31, 119, 180],   // #1f77b4
   [255, 127, 14],   // #ff7f0e
@@ -19,6 +21,15 @@ export const CATEGORICAL_COLORS: RGB[] = [
   [152, 223, 138],  // #98df8a
   [255, 152, 150],  // #ff9896
   [197, 176, 213],  // #c5b0d5
+  [57, 59, 121],    // #393b79
+  [99, 121, 57],    // #637939
+  [140, 109, 49],   // #8c6d31
+  [132, 60, 57],    // #843c39
+  [123, 65, 115],   // #7b4173
+  [82, 84, 163],    // #5254a3
+  [140, 162, 82],   // #8ca252
+  [189, 158, 57],   // #bd9e39
+  [173, 73, 74],    // #ad494a
 ]
 
 const VIRIDIS: ColorScale = [

--- a/packages/highperformer/src/workers/categoryCentroids.handler.test.ts
+++ b/packages/highperformer/src/workers/categoryCentroids.handler.test.ts
@@ -5,7 +5,7 @@ describe("computeCategoryCentroids", () => {
   it("computes the mean of points per category", () => {
     // Two categories: code 0 has points (0,0), (2,0); code 1 has points (10,10), (20,20).
     const positions = new Float32Array([0, 0, 2, 0, 10, 10, 20, 20]);
-    const codes = new Uint8Array([0, 0, 1, 1]);
+    const codes = new Uint16Array([0, 0, 1, 1]);
 
     const result = computeCategoryCentroids(positions, codes, 2);
 
@@ -15,7 +15,7 @@ describe("computeCategoryCentroids", () => {
 
   it("leaves empty categories at (0, 0) with count 0", () => {
     const positions = new Float32Array([5, 5]);
-    const codes = new Uint8Array([0]);
+    const codes = new Uint16Array([0]);
 
     const result = computeCategoryCentroids(positions, codes, 3);
 
@@ -25,7 +25,7 @@ describe("computeCategoryCentroids", () => {
 
   it("handles a single-category degenerate case", () => {
     const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
-    const codes = new Uint8Array([0, 0, 0]);
+    const codes = new Uint16Array([0, 0, 0]);
 
     const result = computeCategoryCentroids(positions, codes, 1);
 
@@ -38,7 +38,7 @@ describe("computeCategoryCentroids", () => {
     // 1M points, code 0, all at (1e6, 1e6). Float32 sum would lose precision.
     const numPoints = 1_000_000;
     const positions = new Float32Array(2 * numPoints);
-    const codes = new Uint8Array(numPoints);
+    const codes = new Uint16Array(numPoints);
     for (let i = 0; i < numPoints; i++) {
       positions[2 * i]     = 1e6;
       positions[2 * i + 1] = 1e6;
@@ -57,7 +57,7 @@ describe("computeCategoryCentroids", () => {
     const numPoints = 10_000;
     const numCategories = 5;
     const positions = new Float32Array(2 * numPoints);
-    const codes = new Uint8Array(numPoints);
+    const codes = new Uint16Array(numPoints);
     for (let i = 0; i < numPoints; i++) {
       positions[2 * i]     = rng() * 100;
       positions[2 * i + 1] = rng() * 100;

--- a/packages/highperformer/src/workers/categoryCentroids.handler.ts
+++ b/packages/highperformer/src/workers/categoryCentroids.handler.ts
@@ -13,7 +13,7 @@ import type { CategoryCentroidsResult } from "./categoryCentroids.schemas";
  */
 export function computeCategoryCentroids(
   positions: Float32Array,
-  codes: Uint8Array,
+  codes: Uint16Array,
   numCategories: number,
 ): CategoryCentroidsResult {
   const numPoints = codes.length;

--- a/packages/highperformer/src/workers/categoryCentroids.schemas.ts
+++ b/packages/highperformer/src/workers/categoryCentroids.schemas.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const CategoryCentroidsMessageSchema = z.object({
   type: z.literal("categoryCentroids"),
   positions: z.custom<Float32Array>((v) => v instanceof Float32Array),
-  codes: z.custom<Uint8Array>((v) => v instanceof Uint8Array),
+  codes: z.custom<Uint16Array>((v) => v instanceof Uint16Array),
   numCategories: z.number().int().positive(),
 });
 

--- a/packages/highperformer/src/workers/colorBuffer.handler.test.ts
+++ b/packages/highperformer/src/workers/colorBuffer.handler.test.ts
@@ -106,7 +106,7 @@ describe('colorBuffer handler', () => {
 
   describe('buildFromCategories', () => {
     it('maps category indices to categorical colors', () => {
-      const categories = new Uint8Array([0, 1, 2])
+      const categories = new Uint16Array([0, 1, 2])
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 3,
@@ -133,7 +133,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 1,
-        categories: new Uint8Array([CATEGORICAL_COLORS.length]),
+        categories: new Uint16Array([CATEGORICAL_COLORS.length]),
         alpha: 1.0,
         highlightedCodes: null,
         version: 1,
@@ -149,7 +149,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 1,
-        categories: new Uint8Array([0]),
+        categories: new Uint16Array([0]),
         alpha: 1.0,
         highlightedCodes: null,
         version: 99,
@@ -161,7 +161,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 2,
-        categories: new Uint8Array([0, 1]),
+        categories: new Uint16Array([0, 1]),
         alpha: 0.5,
         highlightedCodes: null,
         version: 1,
@@ -173,7 +173,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 3,
-        categories: new Uint8Array([0, 1, 2]),
+        categories: new Uint16Array([0, 1, 2]),
         alpha: 0.5,
         highlightedCodes: [1],
         version: 1,
@@ -209,7 +209,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 3,
-        categories: new Uint8Array([0, 1, 2]),
+        categories: new Uint16Array([0, 1, 2]),
         alpha: 0.5,
         highlightedCodes: [0, 2],
         version: 1,
@@ -236,7 +236,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 2,
-        categories: new Uint8Array([0, 1]),
+        categories: new Uint16Array([0, 1]),
         alpha: 0.8,
         highlightedCodes: [],
         version: 1,

--- a/packages/highperformer/src/workers/colorBuffer.handler.test.ts
+++ b/packages/highperformer/src/workers/colorBuffer.handler.test.ts
@@ -133,7 +133,7 @@ describe('colorBuffer handler', () => {
       const result = handleColorBufferMessage({
         type: 'buildFromCategories',
         numPoints: 1,
-        categories: new Uint8Array([15]),
+        categories: new Uint8Array([CATEGORICAL_COLORS.length]),
         alpha: 1.0,
         highlightedCodes: null,
         version: 1,

--- a/packages/highperformer/src/workers/colorBuffer.schemas.ts
+++ b/packages/highperformer/src/workers/colorBuffer.schemas.ts
@@ -24,7 +24,7 @@ const BuildFromExpressionMsgSchema = z.object({
 const BuildFromCategoriesMsgSchema = z.object({
   type: z.literal('buildFromCategories'),
   numPoints: z.number(),
-  categories: z.custom<Uint8Array>((v) => v instanceof Uint8Array),
+  categories: z.custom<Uint16Array>((v) => v instanceof Uint16Array),
   alpha: z.number(),
   highlightedCodes: z.array(z.number()).nullable(),
   version: z.number(),

--- a/packages/highperformer/src/workers/summary.handler.test.ts
+++ b/packages/highperformer/src/workers/summary.handler.test.ts
@@ -4,7 +4,7 @@ import { handleSummaryMessage } from './summary.handler'
 describe('summary handler', () => {
   describe('summarizeCategory', () => {
     it('tallies codes correctly for selected indices', () => {
-      const codes = new Uint8Array([0, 1, 2, 1, 0, 2])
+      const codes = new Uint16Array([0, 1, 2, 1, 0, 2])
       const indices = new Uint32Array([0, 1, 3, 4]) // codes: 0, 1, 1, 0
 
       const result = handleSummaryMessage({
@@ -25,7 +25,7 @@ describe('summary handler', () => {
     })
 
     it('returns zeros for empty indices', () => {
-      const codes = new Uint8Array([0, 1, 2])
+      const codes = new Uint16Array([0, 1, 2])
       const indices = new Uint32Array([])
 
       const result = handleSummaryMessage({
@@ -45,7 +45,7 @@ describe('summary handler', () => {
     it('echoes version in response', () => {
       const result = handleSummaryMessage({
         type: 'summarizeCategory',
-        codes: new Uint8Array([0]),
+        codes: new Uint16Array([0]),
         indices: new Uint32Array([0]),
         numCategories: 1,
         version: 42,
@@ -166,7 +166,7 @@ describe('summary handler', () => {
       // cat0: mean=2, expressing=1/2=0.5 (only val 4 > 0)
       // cat1: mean=0, expressing=0/2=0
       // cat2: mean=4, expressing=2/2=1.0
-      const codes = new Uint8Array([0, 0, 1, 1, 2, 2])
+      const codes = new Uint16Array([0, 0, 1, 1, 2, 2])
       const expression = new Float32Array([0, 4, 0, 0, 2, 6])
       const indices = new Uint32Array([0, 1, 2, 3, 4, 5])
 
@@ -195,7 +195,7 @@ describe('summary handler', () => {
     })
 
     it('handles log-normalized data with negative baseline', () => {
-      const codes = new Uint8Array([0, 0, 0])
+      const codes = new Uint16Array([0, 0, 0])
       const expression = new Float32Array([-1, -1, 2.5])
       const indices = new Uint32Array([0, 1, 2])
 
@@ -215,7 +215,7 @@ describe('summary handler', () => {
     })
 
     it('handles subset of indices', () => {
-      const codes = new Uint8Array([0, 1, 0, 1])
+      const codes = new Uint16Array([0, 1, 0, 1])
       const expression = new Float32Array([0, 5, 3, 10])
       const indices = new Uint32Array([1, 2])
 
@@ -242,7 +242,7 @@ describe('summary handler', () => {
       const result = handleSummaryMessage({
         type: 'summarizeExpressionByCategory',
         expression: new Float32Array([1, 2]),
-        codes: new Uint8Array([0, 1]),
+        codes: new Uint16Array([0, 1]),
         numCategories: 2,
         indices: new Uint32Array([]),
         version: 1,
@@ -259,7 +259,7 @@ describe('summary handler', () => {
       const result = handleSummaryMessage({
         type: 'summarizeExpressionByCategory',
         expression: new Float32Array([1]),
-        codes: new Uint8Array([0]),
+        codes: new Uint16Array([0]),
         numCategories: 1,
         indices: new Uint32Array([0]),
         version: 77,

--- a/packages/highperformer/src/workers/summary.schemas.ts
+++ b/packages/highperformer/src/workers/summary.schemas.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 const SummarizeCategoryMsgSchema = z.object({
   type: z.literal('summarizeCategory'),
-  codes: z.custom<Uint8Array>((v) => v instanceof Uint8Array),
+  codes: z.custom<Uint16Array>((v) => v instanceof Uint16Array),
   indices: z.custom<Uint32Array>((v) => v instanceof Uint32Array),
   numCategories: z.number(),
   version: z.number(),
@@ -22,7 +22,7 @@ const SummarizeExpressionMsgSchema = z.object({
 const SummarizeExpressionByCategoryMsgSchema = z.object({
   type: z.literal('summarizeExpressionByCategory'),
   expression: z.custom<Float32Array>((v) => v instanceof Float32Array),
-  codes: z.custom<Uint8Array>((v) => v instanceof Uint8Array),
+  codes: z.custom<Uint16Array>((v) => v instanceof Uint16Array),
   numCategories: z.number(),
   indices: z.custom<Uint32Array>((v) => v instanceof Uint32Array),
   version: z.number(),

--- a/packages/highperformer/src/workers/universal.worker.test.ts
+++ b/packages/highperformer/src/workers/universal.worker.test.ts
@@ -63,7 +63,7 @@ describe('universal worker', () => {
           _poolTaskId: 7,
           type: 'buildFromCategories',
           numPoints: 1,
-          categories: new Uint8Array([0]),
+          categories: new Uint16Array([0]),
           alpha: 1.0,
           highlightedCodes: null,
           version: 1,


### PR DESCRIPTION
Improves coloring the scatterplot by a high-cardinality obs category column (highperformer).

## What changed
- **Palette 15 → 24** — expanded `CATEGORICAL_COLORS` (first 15 preserved, so existing low-cardinality coloring is unchanged), halving color collisions.
- **Fix silent 256-category wrap** — per-cell codes were `Uint8Array` (cap 255), so the 257th distinct category merged into the first. Widened codes to `Uint16Array` (ceiling 65,535) across the encoder, store, and the color/summary/centroid worker schemas. RGBA output buffers stay `Uint8Array`; codes are CPU-side worker input, never a GPU attribute.
- **Tiered behavior** replacing the hard 1000-value block (`classifyCardinality`): ≤24 → color; ≤65,535 → color with a recycled palette + an informational "colors repeat" note; >65,535 → block with a warning.
- **UI guards** — the note renders as `info` when still colored / `warning` when blocked; the un-virtualized legend collapses to a compact summary above 500 categories, and auto-pin-to-summary is skipped above 500 (prevents freezing on pathological columns like a 927K-unique ID).

## Test plan
- [x] 494 highperformer tests pass (1 skipped); typecheck clean (no new errors)
- [x] Unit: no code-wrap past 256; `classifyCardinality` tiers; Alert info/warning; legend cap; auto-pin guard
- [ ] Manual: color spectrum by a mid-cardinality column (e.g. `donor_id`=41) → recycled colors + note; by `observation_joinid` (927K) → blocked with warning, no freeze

## Follow-up (not in this PR)
- On the blocked tier, `encodeCategories` still builds+discards a full codes array/categoryMap before rejecting — a wasted allocation worth optimizing for the pathological case.