### PR TITLE
feat(highperformer): continuous coloring for numeric obs columns

### DIFF
--- a/.changeset/continuous-obs-coloring.md
+++ b/.changeset/continuous-obs-coloring.md
@@ -1,0 +1,5 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+---
+
+Color numeric obs columns as a continuous gradient. Selecting a numeric obs column (e.g. `percent.rb`, `nCount_RNA`) now renders a 3-color continuous scale with a range legend instead of forcing categorical encoding and warning "likely continuous." Genuine categorical columns are unchanged; the high-cardinality block message for string columns is reworded accordingly.

--- a/packages/highperformer/src/components/ColorBySection.test.tsx
+++ b/packages/highperformer/src/components/ColorBySection.test.tsx
@@ -126,3 +126,29 @@ describe('ColorBySection — cardinality note', () => {
     expect(container.querySelector('.ant-alert-info')).toBeNull()
   })
 })
+
+describe('ColorBySection — obs-continuous', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState())
+    useAppStore.setState({
+      obsColumnNames: ['percent.rb'],
+      colorMode: 'obs-continuous',
+      selectedObsColumn: 'percent.rb',
+      obsContinuousRange: { min: 0, max: 5 },
+      _obsContinuousData: new Float32Array([0, 5]),
+    } as any)
+  })
+
+  it('shows the continuous legend with the obs column label and range', () => {
+    render(<ColorBySection />)
+    expect(screen.getAllByText('percent.rb').length).toBeGreaterThan(0)
+    expect(screen.getByText('0.00')).toBeDefined()
+    expect(screen.getByText('5.00')).toBeDefined()
+  })
+
+  it('keeps the Category toggle active (not Gene) in obs-continuous mode', () => {
+    const { container } = render(<ColorBySection />)
+    const selected = container.querySelector('.ant-segmented-item-selected')
+    expect(selected?.textContent).toContain('Category')
+  })
+})

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -80,6 +80,8 @@ export default function ColorBySection() {
   const setShowCategoryLabels = useAppStore((s) => s.setShowCategoryLabels)
   const categoryLabelsObsColumn = useAppStore((s) => s.categoryLabelsObsColumn)
   const setCategoryLabelsObsColumn = useAppStore((s) => s.setCategoryLabelsObsColumn)
+  const expressionRange = useAppStore((s) => s.expressionRange)
+  const colorScaleName = useAppStore((s) => s.colorScaleName)
 
   // Mirror View.tsx's effectiveLabelColumn so the hint logic stays in sync.
   const effectiveLabelColumn =
@@ -256,7 +258,13 @@ export default function ColorBySection() {
       </div>
 
       {colorMode === 'category' && <CategoricalLegend />}
-      {colorMode === 'gene' && <ContinuousLegend />}
+      {colorMode === 'gene' && (
+        <ContinuousLegend
+          range={expressionRange}
+          scale={COLOR_SCALES[colorScaleName] || COLOR_SCALES.viridis}
+          label={colorScaleName}
+        />
+      )}
     </div>
   )
 }

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -3,7 +3,7 @@ import { Segmented, Select, Tag, Alert, Button, Popover, Space, Switch } from 'a
 import { SettingOutlined } from '@ant-design/icons'
 import useAppStore from '../store/useAppStore'
 import type { ColorMode } from '../store/useAppStore'
-import { COLOR_SCALES } from '../utils/colors'
+import { COLOR_SCALES, OBS_CONTINUOUS_SCALE_NAME } from '../utils/colors'
 import CategoricalLegend from './CategoricalLegend'
 import ContinuousLegend from './ContinuousLegend'
 
@@ -82,6 +82,7 @@ export default function ColorBySection() {
   const setCategoryLabelsObsColumn = useAppStore((s) => s.setCategoryLabelsObsColumn)
   const expressionRange = useAppStore((s) => s.expressionRange)
   const colorScaleName = useAppStore((s) => s.colorScaleName)
+  const obsContinuousRange = useAppStore((s) => s.obsContinuousRange)
 
   // Mirror View.tsx's effectiveLabelColumn so the hint logic stays in sync.
   const effectiveLabelColumn =
@@ -119,14 +120,22 @@ export default function ColorBySection() {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
         <div style={{ fontSize: 12, fontWeight: 600, color: '#666', textTransform: 'uppercase' }}>Color By</div>
         <Segmented
-          value={colorMode}
-          onChange={(value) => setColorMode(value as ColorMode)}
+          value={colorMode === 'gene' ? 'gene' : 'category'}
+          onChange={(value) => {
+            if (value === 'gene') {
+              setColorMode('gene')
+            } else if (selectedObsColumn) {
+              selectObsColumn(selectedObsColumn)
+            } else {
+              setColorMode('category')
+            }
+          }}
           size="small"
           options={[{ value: 'category', label: 'Category' }, { value: 'gene', label: 'Gene' }]}
         />
       </div>
 
-      {colorMode === 'category' && (
+      {colorMode !== 'gene' && (
         <div style={{ marginBottom: 8 }}>
           <div style={{ fontSize: 11, fontWeight: 600, color: '#888', textTransform: 'uppercase', marginBottom: 4 }}>
             Category {selectedObsColumn && <span style={{ fontWeight: 400, textTransform: 'none' }}>(max 1)</span>}
@@ -258,6 +267,13 @@ export default function ColorBySection() {
       </div>
 
       {colorMode === 'category' && <CategoricalLegend />}
+      {colorMode === 'obs-continuous' && (
+        <ContinuousLegend
+          range={obsContinuousRange}
+          scale={COLOR_SCALES[OBS_CONTINUOUS_SCALE_NAME]}
+          label={selectedObsColumn ?? ''}
+        />
+      )}
       {colorMode === 'gene' && (
         <ContinuousLegend
           range={expressionRange}

--- a/packages/highperformer/src/components/ColorBySection.tsx
+++ b/packages/highperformer/src/components/ColorBySection.tsx
@@ -278,7 +278,7 @@ export default function ColorBySection() {
         <ContinuousLegend
           range={expressionRange}
           scale={COLOR_SCALES[colorScaleName] || COLOR_SCALES.viridis}
-          label={colorScaleName}
+          label={colorScaleName.charAt(0).toUpperCase() + colorScaleName.slice(1)}
         />
       )}
     </div>

--- a/packages/highperformer/src/components/ContinuousLegend.test.tsx
+++ b/packages/highperformer/src/components/ContinuousLegend.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import ContinuousLegend from './ContinuousLegend'
+
+afterEach(() => cleanup())
+
+describe('ContinuousLegend (props-based)', () => {
+  it('renders the label and range from props', () => {
+    render(
+      <ContinuousLegend
+        range={{ min: 0.12, max: 3.45 }}
+        scale={[[0, 0, 0], [255, 255, 255]]}
+        label="percent.rb"
+      />,
+    )
+    expect(screen.getByText('percent.rb')).toBeDefined()
+    expect(screen.getByText('0.12')).toBeDefined()
+    expect(screen.getByText('3.45')).toBeDefined()
+  })
+
+  it('returns nothing when range is null', () => {
+    const { container } = render(
+      <ContinuousLegend range={null} scale={[[0, 0, 0]]} label="x" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/packages/highperformer/src/components/ContinuousLegend.tsx
+++ b/packages/highperformer/src/components/ContinuousLegend.tsx
@@ -1,13 +1,14 @@
-import useAppStore from '../store/useAppStore'
-import { COLOR_SCALES } from '../utils/colors'
+import type { ColorScale } from '../utils/colors'
 
-export default function ContinuousLegend() {
-  const expressionRange = useAppStore((s) => s.expressionRange)
-  const colorScaleName = useAppStore((s) => s.colorScaleName)
+interface ContinuousLegendProps {
+  range: { min: number; max: number } | null
+  scale: ColorScale
+  label: string
+}
 
-  if (!expressionRange) return null
+export default function ContinuousLegend({ range, scale, label }: ContinuousLegendProps) {
+  if (!range) return null
 
-  const scale = COLOR_SCALES[colorScaleName] || COLOR_SCALES.viridis
   // Sample 5 evenly spaced stops for the CSS gradient
   const stops = [0, 0.25, 0.5, 0.75, 1].map((t) => {
     const idx = t * (scale.length - 1)
@@ -24,19 +25,11 @@ export default function ContinuousLegend() {
 
   return (
     <div style={{ marginTop: 8 }}>
-      <div style={{ fontSize: 11, marginBottom: 4, color: '#888' }}>
-        {colorScaleName.charAt(0).toUpperCase() + colorScaleName.slice(1)}
-      </div>
-      <div
-        style={{
-          height: 12,
-          borderRadius: 3,
-          background: gradient,
-        }}
-      />
+      <div style={{ fontSize: 11, marginBottom: 4, color: '#888' }}>{label}</div>
+      <div style={{ height: 12, borderRadius: 3, background: gradient }} />
       <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, marginTop: 2 }}>
-        <span>{expressionRange.min.toFixed(2)}</span>
-        <span>{expressionRange.max.toFixed(2)}</span>
+        <span>{range.min.toFixed(2)}</span>
+        <span>{range.max.toFixed(2)}</span>
       </div>
     </div>
   )

--- a/packages/highperformer/src/store/obsContinuousRender.test.ts
+++ b/packages/highperformer/src/store/obsContinuousRender.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { OBS_CONTINUOUS_SCALE_NAME } from '../utils/colors'
+
+const dispatchMock = vi.fn().mockResolvedValue({ type: 'colorBuffer', buffer: new Uint8Array(0), version: 1 })
+vi.mock('../pool/WorkerPool', () => ({
+  WorkerPool: class { dispatch = dispatchMock; clearQueue = vi.fn(); dispose() {} },
+}))
+vi.mock('../workers/universal.worker.ts?worker', () => ({ default: class {} }))
+
+const { default: useAppStore } = await import('./useAppStore')
+
+describe('rebuildColorBuffer — obs-continuous mode', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState())
+    dispatchMock.mockClear()
+  })
+
+  it('dispatches buildFromExpression with the obs-continuous scale', () => {
+    useAppStore.setState({
+      embeddingData: { positions: new Float32Array([0, 0, 1, 1]), numPoints: 2, bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 } },
+      opacity: 0.7,
+      colorMode: 'obs-continuous',
+      _obsContinuousData: new Float32Array([0.1, 0.9]),
+      obsContinuousRange: { min: 0.1, max: 0.9 },
+    } as never)
+
+    useAppStore.getState().rebuildColorBuffer()
+
+    expect(dispatchMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'buildFromExpression',
+      numPoints: 2,
+      min: 0.1,
+      max: 0.9,
+      scaleName: OBS_CONTINUOUS_SCALE_NAME,
+    }))
+  })
+})

--- a/packages/highperformer/src/store/selectObsColumnBlockClears.test.ts
+++ b/packages/highperformer/src/store/selectObsColumnBlockClears.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+
+const dispatchMock = vi.fn().mockResolvedValue({ type: 'colorBuffer', buffer: new Uint8Array(0), version: 1 })
+vi.mock('../pool/WorkerPool', () => ({
+  WorkerPool: class { dispatch = dispatchMock; clearQueue = vi.fn(); dispose() {} },
+}))
+vi.mock('../workers/universal.worker.ts?worker', () => ({ default: class {} }))
+
+const { default: useAppStore } = await import('./useAppStore')
+
+function fakeAdata(values: unknown) {
+  return { obsColumn: vi.fn().mockResolvedValue(values) } as unknown as never
+}
+
+describe('selectObsColumn — blocked high-cardinality column clears the plot', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState())
+    dispatchMock.mockClear()
+  })
+  afterEach(() => vi.clearAllMocks())
+
+  it('clears colors (dispatches buildDefault) and warns when a column is too high-cardinality', async () => {
+    useAppStore.setState({
+      adata: fakeAdata(Array.from({ length: 65536 }, (_, i) => `c${i}`)),
+      embeddingData: { positions: new Float32Array([0, 0, 1, 1]), numPoints: 2, bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 } },
+    })
+    useAppStore.getState().selectObsColumn('observation_joinid')
+    await waitFor(() => expect(useAppStore.getState().categoryWarning).not.toBeNull())
+    expect(useAppStore.getState().categoryWarning).toContain('too many to color')
+    expect(useAppStore.getState()._categoryCodes).toBeNull()
+    // The plot must be reset to the default (uncolored) render, not left on the prior coloring.
+    expect(dispatchMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'buildDefault' }))
+  })
+})

--- a/packages/highperformer/src/store/selectObsColumnNumeric.test.ts
+++ b/packages/highperformer/src/store/selectObsColumnNumeric.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+
+vi.mock('../pool/WorkerPool', () => ({
+  WorkerPool: class { dispatch = vi.fn().mockResolvedValue({ type: 'colorBuffer', buffer: new Uint8Array(0), version: 1 }); clearQueue = vi.fn(); dispose() {} },
+}))
+vi.mock('../workers/universal.worker.ts?worker', () => ({ default: class {} }))
+
+const { default: useAppStore } = await import('./useAppStore')
+
+function fakeAdata(values: unknown) {
+  return { obsColumn: vi.fn().mockResolvedValue(values) } as unknown as never
+}
+
+describe('selectObsColumn numeric detection', () => {
+  beforeEach(() => { useAppStore.setState(useAppStore.getInitialState()) })
+  afterEach(() => vi.clearAllMocks())
+
+  it('numeric (TypedArray) column → obs-continuous with data and range, no warning', async () => {
+    useAppStore.setState({ adata: fakeAdata(new Float32Array([0.2, 0.8, 0.5])) })
+    useAppStore.getState().selectObsColumn('percent.rb')
+    await waitFor(() => expect(useAppStore.getState().colorMode).toBe('obs-continuous'))
+    const s = useAppStore.getState()
+    expect(s._obsContinuousData).toBeInstanceOf(Float32Array)
+    expect(s.obsContinuousRange!.min).toBeCloseTo(0.2, 5)
+    expect(s.obsContinuousRange!.max).toBeCloseTo(0.8, 5)
+    expect(s.categoryWarning).toBeNull()
+    expect(s._categoryCodes).toBeNull()
+  })
+
+  it('string column → categorical (colorMode stays category, codes set)', async () => {
+    useAppStore.setState({ adata: fakeAdata(['A', 'B', 'A']) })
+    useAppStore.getState().selectObsColumn('cell_type')
+    await waitFor(() => expect(useAppStore.getState()._categoryCodes).not.toBeNull())
+    expect(useAppStore.getState().colorMode).toBe('category')
+    expect(useAppStore.getState()._obsContinuousData).toBeNull()
+  })
+})

--- a/packages/highperformer/src/store/selectObsColumnNumeric.test.ts
+++ b/packages/highperformer/src/store/selectObsColumnNumeric.test.ts
@@ -35,4 +35,19 @@ describe('selectObsColumn numeric detection', () => {
     expect(useAppStore.getState().colorMode).toBe('category')
     expect(useAppStore.getState()._obsContinuousData).toBeNull()
   })
+
+  it('switching from a numeric column back to a categorical one resets to category mode and clears obs data', async () => {
+    // First color by a numeric column → obs-continuous.
+    useAppStore.setState({ adata: fakeAdata(new Float32Array([0.2, 0.8, 0.5])) })
+    useAppStore.getState().selectObsColumn('percent.mt')
+    await waitFor(() => expect(useAppStore.getState().colorMode).toBe('obs-continuous'))
+
+    // Then color by a categorical column — must switch back to category, not linger on the gradient.
+    useAppStore.setState({ adata: fakeAdata(['A', 'B', 'A']) })
+    useAppStore.getState().selectObsColumn('cell_type')
+    await waitFor(() => expect(useAppStore.getState()._categoryCodes).not.toBeNull())
+    expect(useAppStore.getState().colorMode).toBe('category')
+    expect(useAppStore.getState()._obsContinuousData).toBeNull()
+    expect(useAppStore.getState().obsContinuousRange).toBeNull()
+  })
 })

--- a/packages/highperformer/src/store/useAppStore.test.ts
+++ b/packages/highperformer/src/store/useAppStore.test.ts
@@ -602,8 +602,9 @@ describe('useAppStore', () => {
       await vi.waitFor(() => {
         expect(useAppStore.getState().categoryWarning).toContain('too many to color')
       })
-      // Should NOT dispatch a color buffer build
-      expect(mockDispatch).not.toHaveBeenCalled()
+      // Resets the plot to the default (uncolored) render so the view matches the
+      // warning instead of lingering on the previous coloring.
+      expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'buildDefault' }))
     })
   })
 

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -6,6 +6,7 @@ import { flushSummaryQueue } from '../hooks/summaryScheduler'
 import UniversalWorker from '../workers/universal.worker.ts?worker'
 import type { ColorBufferResponse } from '../workers/colorBuffer.schemas'
 import type { RGB } from '../utils/colors'
+import { OBS_CONTINUOUS_SCALE_NAME } from '../utils/colors'
 import { encodeCategories, MAX_CATEGORIES, classifyCardinality, CATEGORY_LEGEND_LIST_CAP } from '../utils/categoryEncoding'
 
 export interface EmbeddingBounds {
@@ -26,7 +27,7 @@ import type { components } from '@cbioportal-cell-explorer/api-client'
 export type BackendInfo = components['schemas']['InfoResponse']
 export type User = components['schemas']['User']
 
-export type ColorMode = 'category' | 'gene'
+export type ColorMode = 'category' | 'gene' | 'obs-continuous'
 
 // Selection types
 export type SelectionTool = 'pan' | 'rectangle' | 'lasso'
@@ -120,6 +121,8 @@ export interface AppState {
   // Internal — cached data for rebuilds (not for UI consumption)
   _categoryCodes: Uint16Array | null
   _expressionData: Float32Array | null
+  _obsContinuousData: Float32Array | null
+  obsContinuousRange: { min: number; max: number } | null
   _colorAbort: AbortController | null
 
   // Legend highlight
@@ -446,6 +449,8 @@ const useAppStore = create<AppState>((set, get) => ({
   // Internal
   _categoryCodes: null,
   _expressionData: null,
+  _obsContinuousData: null,
+  obsContinuousRange: null,
   _colorAbort: null,
 
   // Selection
@@ -1141,6 +1146,7 @@ const useAppStore = create<AppState>((set, get) => ({
       colorMode: 'category', selectedObsColumn: null, selectedGene: null,
       obsColumnNames: [], varNames: [], categoryMap: [], expressionRange: null,
       categoryWarning: null, _categoryCodes: null, _expressionData: null,
+      _obsContinuousData: null, obsContinuousRange: null,
       varColumns: [], geneLabelColumn: null, geneLabelMap: null,
       selectionGroups: [], selectionFilterBuffer: null, selectionTool: 'pan', selectionDisplayMode: 'dim',
       customGroupColumn: null, customGroupIds: [], customGroupUnmatched: [], customGroupWarning: null, customGroupLoading: false, customGroupRecomputing: false, customGroupIndexMap: {}, customGroupEnabledIds: new Set(), customGroupCommittedCount: 0,
@@ -1228,7 +1234,7 @@ const useAppStore = create<AppState>((set, get) => ({
   },
 
   rebuildColorBuffer: () => {
-    const { embeddingData, opacity, colorMode, _categoryCodes, _expressionData, expressionRange, colorScaleName } = get()
+    const { embeddingData, opacity, colorMode, _categoryCodes, _expressionData, expressionRange, colorScaleName, _obsContinuousData, obsContinuousRange } = get()
     if (!embeddingData) return
 
     colorBuildVersion++
@@ -1255,6 +1261,17 @@ const useAppStore = create<AppState>((set, get) => ({
         max: expressionRange.max,
         alpha: opacity,
         scaleName: colorScaleName,
+        version,
+      }
+    } else if (colorMode === 'obs-continuous' && _obsContinuousData && obsContinuousRange) {
+      message = {
+        type: 'buildFromExpression',
+        numPoints: embeddingData.numPoints,
+        expression: _obsContinuousData,
+        min: obsContinuousRange.min,
+        max: obsContinuousRange.max,
+        alpha: opacity,
+        scaleName: OBS_CONTINUOUS_SCALE_NAME,
         version,
       }
     } else {
@@ -1290,6 +1307,8 @@ const useAppStore = create<AppState>((set, get) => ({
     if (mode === 'category' && get()._categoryCodes) {
       get().rebuildColorBuffer()
     } else if (mode === 'gene' && get()._expressionData) {
+      get().rebuildColorBuffer()
+    } else if (mode === 'obs-continuous' && get()._obsContinuousData) {
       get().rebuildColorBuffer()
     }
   },

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -1353,19 +1353,28 @@ const useAppStore = create<AppState>((set, get) => ({
 
       if (!colorable) {
         set({
+          colorMode: 'category',
           categoryWarning: note,
           colorBufferLoading: false,
           _categoryCodes: null,
           categoryMap: [],
+          _obsContinuousData: null,
+          obsContinuousRange: null,
           _colorAbort: null,
         })
+        // Reset the plot to the default (uncolored) render so the view matches
+        // the warning instead of lingering on the previous coloring.
+        get().rebuildColorBuffer()
         return
       }
 
       set({
+        colorMode: 'category',
         _categoryCodes: codes,
         categoryMap,
         categoryWarning: note,
+        _obsContinuousData: null,
+        obsContinuousRange: null,
         _colorAbort: null,
       })
       get().rebuildColorBuffer()

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -1328,6 +1328,24 @@ const useAppStore = create<AppState>((set, get) => ({
     })
 
     adata.obsColumn(name, abortController.signal).then((values) => {
+      const isTypedArray = ArrayBuffer.isView(values) && !(values instanceof DataView)
+      if (isTypedArray) {
+        const floats = values instanceof Float32Array ? values : new Float32Array(values as ArrayLike<number>)
+        const range = computeRange(floats)
+        set({
+          colorMode: 'obs-continuous',
+          _obsContinuousData: floats,
+          obsContinuousRange: range,
+          _categoryCodes: null,
+          categoryMap: [],
+          categoryWarning: null,
+          colorBufferLoading: false,
+          _colorAbort: null,
+        })
+        get().rebuildColorBuffer()
+        return
+      }
+
       const valuesArray = Array.isArray(values) ? values : Array.from(values as Iterable<number>)
       const { codes, categoryMap, uniqueCount } = encodeCategories(valuesArray as (string | number | null)[])
 
@@ -1371,7 +1389,10 @@ const useAppStore = create<AppState>((set, get) => ({
     if (_colorAbort) _colorAbort.abort()
     set({
       selectedObsColumn: null,
+      colorMode: 'category',
       _categoryCodes: null,
+      _obsContinuousData: null,
+      obsContinuousRange: null,
       categoryMap: [],
       categoryWarning: null,
       highlightedCategories: new Set(),

--- a/packages/highperformer/src/utils/categoryEncoding.test.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.test.ts
@@ -99,4 +99,10 @@ describe('classifyCardinality', () => {
     expect(MAX_COLORABLE_CATEGORIES).toBe(65535)
     expect(CATEGORY_LEGEND_LIST_CAP).toBe(500)
   })
+
+  it('block message does not mention "continuous" (numeric cols are handled elsewhere)', () => {
+    const r = classifyCardinality(MAX_COLORABLE_CATEGORIES + 1)
+    expect(r.colorable).toBe(false)
+    expect(r.note).not.toContain('continuous')
+  })
 })

--- a/packages/highperformer/src/utils/categoryEncoding.ts
+++ b/packages/highperformer/src/utils/categoryEncoding.ts
@@ -28,7 +28,7 @@ export function classifyCardinality(uniqueCount: number): CardinalityClass {
   }
   return {
     colorable: false,
-    note: `${uniqueCount} distinct values — too many to color; likely an ID or continuous column`,
+    note: `${uniqueCount} distinct values — too many to color`,
   }
 }
 

--- a/packages/highperformer/src/utils/colors.test.ts
+++ b/packages/highperformer/src/utils/colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { interpolateColorScale, COLOR_SCALES, CATEGORICAL_COLORS } from './colors'
+import { interpolateColorScale, COLOR_SCALES, CATEGORICAL_COLORS, OBS_CONTINUOUS_SCALE_NAME } from './colors'
 
 describe('interpolateColorScale', () => {
   const scale = COLOR_SCALES.viridis
@@ -89,6 +89,24 @@ describe('inferno scale', () => {
     expect(r0).toBeGreaterThanOrEqual(0)
     expect(r1).toBeGreaterThanOrEqual(0)
     expect(r0).not.toBe(r1)
+  })
+})
+
+describe('obs-continuous scale', () => {
+  it('is registered in COLOR_SCALES under its exported name', () => {
+    const scale = COLOR_SCALES[OBS_CONTINUOUS_SCALE_NAME]
+    expect(scale).toBeDefined()
+    expect(scale.length).toBe(3)
+  })
+
+  it('is a valid RGB scale', () => {
+    for (const c of COLOR_SCALES[OBS_CONTINUOUS_SCALE_NAME]) {
+      expect(c).toHaveLength(3)
+      for (const channel of c) {
+        expect(channel).toBeGreaterThanOrEqual(0)
+        expect(channel).toBeLessThanOrEqual(255)
+      }
+    }
   })
 })
 

--- a/packages/highperformer/src/utils/colors.ts
+++ b/packages/highperformer/src/utils/colors.ts
@@ -84,11 +84,20 @@ const INFERNO: ColorScale = [
   [252, 255, 164],
 ]
 
+const OBS_SEQUENTIAL: ColorScale = [
+  [255, 255, 204],  // #ffffcc low
+  [253, 141, 60],   // #fd8d3c mid
+  [128, 0, 38],     // #800026 high
+]
+
+export const OBS_CONTINUOUS_SCALE_NAME = 'obs-sequential'
+
 export const COLOR_SCALES: Record<string, ColorScale> = {
   viridis: VIRIDIS,
   magma: MAGMA,
   plasma: PLASMA,
   inferno: INFERNO,
+  [OBS_CONTINUOUS_SCALE_NAME]: OBS_SEQUENTIAL,
 }
 
 /**


### PR DESCRIPTION
Color numeric obs columns as a continuous gradient instead of forcing categorical encoding (which mislabeled continuous columns like `percent.rb` as "likely continuous, can't color"). Highperformer only.

**Stacked on #291** (base is `feature/high-cardinality-coloring`; retarget to main after #291 merges).

## What changed
- Numeric obs columns (zarr TypedArray) → new isolated `colorMode: 'obs-continuous'`, rendered via the existing `buildFromExpression` worker with a new 3-color sequential scale + a range legend. String columns keep the existing categorical tiers; the gene path is untouched (its legend is now props-driven).
- `ContinuousLegend` is parametrized so gene and obs both use it.
- The high-cardinality block message drops "continuous" (numeric columns no longer reach it).
- Fixes found in local testing: switching numeric → categorical now recolors (mode was left stuck on obs-continuous); the >65,535 block now resets the plot to default so the view matches its warning.

## Test plan
- [x] 506 highperformer tests pass (1 skipped); typecheck clean (no new errors)
- [x] Manually verified on spectrum (:8001): `percent.mt`/`percent.rb`/`nCount_RNA` → gradient + legend, no warning; switch to `author_cell_type` → recolors categorical; `observation_joinid` → blocked, plot clears, no "continuous" in message