### PR TITLE
chore: release colorby coloring changes as patch (0.5.2)

### DIFF
--- a/.changeset/continuous-obs-coloring.md
+++ b/.changeset/continuous-obs-coloring.md
@@ -1,5 +1,5 @@
 ---
-"@cbioportal-cell-explorer/highperformer": minor
+"@cbioportal-cell-explorer/highperformer": patch
 ---
 
 Color numeric obs columns as a continuous gradient. Selecting a numeric obs column (e.g. `percent.rb`, `nCount_RNA`) now renders a 3-color continuous scale with a range legend instead of forcing categorical encoding and warning "likely continuous." Genuine categorical columns are unchanged; the high-cardinality block message for string columns is reworded accordingly.

--- a/.changeset/high-cardinality-categorical-coloring.md
+++ b/.changeset/high-cardinality-categorical-coloring.md
@@ -1,5 +1,5 @@
 ---
-"@cbioportal-cell-explorer/highperformer": minor
+"@cbioportal-cell-explorer/highperformer": patch
 ---
 
 Improve coloring by high-cardinality obs categories. Expand the categorical palette to 24 colors, fix a silent code-wrap that merged categories past 256 (codes are now Uint16, ceiling 65,535), and replace the hard 1000-value block with tiered behavior: color with a recycled palette (and an informational "colors repeat" note) up to 65,535 distinct values, block above that. The on-plot legend collapses to a compact summary above 500 categories instead of rendering every row.


### PR DESCRIPTION
Lower the pending highperformer changesets (#291 high-cardinality coloring, #293 continuous obs coloring) from minor to patch. Framing the arc as fixes/refinements to the existing colorby feature → releases as 0.5.2 rather than 0.6.0. Regenerates the pending Version Packages PR (#294).