### PR TITLE
feat: group datasets by collection in the catalog

### DIFF
--- a/.changeset/nervous-donkeys-shake.md
+++ b/.changeset/nervous-donkeys-shake.md
@@ -1,0 +1,18 @@
+---
+"@cbioportal-cell-explorer/highperformer": minor
+"@cbioportal-cell-explorer/api-client": minor
+---
+
+Group datasets by collection in the catalog.
+
+The catalog now opens on a Collections tab listing studies rather than a flat
+list of every dataset, with `/collections/:slug` giving each study its own page
+showing its description, publication link, and datasets. Datasets belonging to
+no collection remain reachable under an "Ungrouped" heading, and the previous
+flat list is still available under "All datasets".
+
+The dataset list moved out of `Home` into a reusable `DatasetList` component so
+the collection page and the catalog share one implementation of store probing
+and access resolution.
+
+`api-client` is regenerated against the backend's collection endpoints.

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -225,6 +225,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Collections Admin */
+        get: operations["list_collections_admin_api_admin_collections_get"];
+        put?: never;
+        /** Create Collection */
+        post: operations["create_collection_api_admin_collections_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/collections/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Collection */
+        put: operations["update_collection_api_admin_collections__slug__put"];
+        post?: never;
+        /** Delete Collection */
+        delete: operations["delete_collection_api_admin_collections__slug__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -313,6 +349,46 @@ export interface paths {
          * @description Get access credentials for a dataset.
          */
         post: operations["access_dataset_api_datasets__slug__access_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Collections
+         * @description List collections containing at least one dataset the caller can access.
+         */
+        get: operations["list_collections_api_collections_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/collections/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Collection
+         * @description Get one collection and the datasets in it the caller can access.
+         */
+        get: operations["get_collection_api_collections__slug__get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -427,6 +503,89 @@ export interface components {
             /** Reason */
             reason?: string | null;
         };
+        /** CollectionAdminListResponse */
+        CollectionAdminListResponse: {
+            /** Collections */
+            collections: components["schemas"]["CollectionAdminResponse"][];
+        };
+        /** CollectionAdminResponse */
+        CollectionAdminResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            /** Description */
+            description: string | null;
+            /** Publication Url */
+            publication_url: string | null;
+            /** Publication Citation */
+            publication_citation: string | null;
+        };
+        /** CollectionCreate */
+        CollectionCreate: {
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            /** Description */
+            description?: string | null;
+            /** Publication Url */
+            publication_url?: string | null;
+            /** Publication Citation */
+            publication_citation?: string | null;
+        };
+        /** CollectionDetail */
+        CollectionDetail: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Publication Url */
+            publication_url: string | null;
+            /** Publication Citation */
+            publication_citation: string | null;
+            /** Dataset Count */
+            dataset_count: number;
+            /** Datasets */
+            datasets: components["schemas"]["DatasetResponse"][];
+        };
+        /** CollectionListResponse */
+        CollectionListResponse: {
+            /** Collections */
+            collections: components["schemas"]["CollectionSummary"][];
+        };
+        /** CollectionSummary */
+        CollectionSummary: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Publication Url */
+            publication_url: string | null;
+            /** Publication Citation */
+            publication_citation: string | null;
+            /** Dataset Count */
+            dataset_count: number;
+        };
+        /** CollectionUpdate */
+        CollectionUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Slug */
+            slug?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Publication Url */
+            publication_url?: string | null;
+            /** Publication Citation */
+            publication_citation?: string | null;
+        };
         /** ContextResponse */
         ContextResponse: {
             /** Slug */
@@ -458,6 +617,8 @@ export interface components {
             id: string;
             /** Datasource Id */
             datasource_id: string;
+            /** Collection Id */
+            collection_id: string | null;
             /** Name */
             name: string;
             /** Slug */
@@ -479,10 +640,19 @@ export interface components {
             /** Chat Enabled */
             chat_enabled: boolean;
         };
+        /** DatasetCollectionRef */
+        DatasetCollectionRef: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+        };
         /** DatasetCreate */
         DatasetCreate: {
             /** Datasource Id */
             datasource_id: string;
+            /** Collection Id */
+            collection_id?: string | null;
             /** Name */
             name: string;
             /** Slug */
@@ -536,6 +706,7 @@ export interface components {
             default_view?: {
                 [key: string]: unknown;
             } | null;
+            collection?: components["schemas"]["DatasetCollectionRef"] | null;
         };
         /** DatasetUpdate */
         DatasetUpdate: {
@@ -557,6 +728,8 @@ export interface components {
             } | null;
             /** Chat Enabled */
             chat_enabled?: boolean | null;
+            /** Collection Id */
+            collection_id?: string | null;
         };
         /** DatasourceCreate */
         DatasourceCreate: {
@@ -1151,6 +1324,123 @@ export interface operations {
             };
         };
     };
+    list_collections_admin_api_admin_collections_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionAdminListResponse"];
+                };
+            };
+        };
+    };
+    create_collection_api_admin_collections_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CollectionCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionAdminResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_collection_api_admin_collections__slug__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CollectionUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionAdminResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_collection_api_admin_collections__slug__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     health_api_health_get: {
         parameters: {
             query?: never;
@@ -1262,6 +1552,57 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_collections_api_collections_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionListResponse"];
+                };
+            };
+        };
+    };
+    get_collection_api_collections__slug__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionDetail"];
                 };
             };
             /** @description Validation Error */

--- a/packages/highperformer/src/App.tsx
+++ b/packages/highperformer/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from 'antd'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ProfilePage } from '@cbioportal-cell-explorer/profiler'
 import Home from './pages/Home'
+import Collection from './pages/Collection'
 import View from './pages/View'
 import ZarrView from './pages/ZarrView'
 import useAppStore from './store/useAppStore'
@@ -43,6 +44,13 @@ function App() {
           <Layout style={{ minHeight: '100vh', background: '#fff' }}>
             <Content style={{ maxWidth: 960, margin: '0 auto', padding: '32px 24px' }}>
               <Home />
+            </Content>
+          </Layout>
+        } />
+        <Route path="/collections/:slug" element={
+          <Layout style={{ minHeight: '100vh', background: '#fff' }}>
+            <Content style={{ maxWidth: 960, margin: '0 auto', padding: '32px 24px' }}>
+              <Collection />
             </Content>
           </Layout>
         } />

--- a/packages/highperformer/src/components/DatasetList.test.tsx
+++ b/packages/highperformer/src/components/DatasetList.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('../api', () => ({ api: { GET: vi.fn(), POST: vi.fn().mockResolvedValue({ data: undefined }) } }))
+vi.mock('../utils/datasetProbe', () => ({ probeStore: vi.fn().mockResolvedValue({ ok: true, version: 3 }) }))
+
+import DatasetList from './DatasetList'
+
+afterEach(() => cleanup())
+
+const DATASET = {
+  slug: 'ds1',
+  name: 'Dataset One',
+  description: 'First one',
+  is_public: true,
+  url: 'https://cdn/ds1.zarr',
+  chat_enabled: false,
+}
+
+describe('DatasetList', () => {
+  it('renders a row per dataset with its name and description', () => {
+    render(<MemoryRouter><DatasetList datasets={[DATASET]} /></MemoryRouter>)
+    expect(screen.getByText('Dataset One')).toBeDefined()
+    expect(screen.getByText('First one')).toBeDefined()
+  })
+
+  it('shows the public access label', () => {
+    render(<MemoryRouter><DatasetList datasets={[DATASET]} /></MemoryRouter>)
+    expect(screen.getByText(/Public/)).toBeDefined()
+  })
+
+  it('renders the supplied empty text when there are no datasets', () => {
+    render(<MemoryRouter><DatasetList datasets={[]} emptyText="Nothing here" /></MemoryRouter>)
+    expect(screen.getByText('Nothing here')).toBeDefined()
+  })
+})

--- a/packages/highperformer/src/components/DatasetList.tsx
+++ b/packages/highperformer/src/components/DatasetList.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { Button, List, Tooltip, Typography } from 'antd'
+import { ApartmentOutlined, LinkOutlined } from '@ant-design/icons'
+import { probeStore } from '../utils/datasetProbe'
+import useAppStore from '../store/useAppStore'
+
+const ENABLE_ZARR_VIEW = import.meta.env.VITE_ENABLE_ZARR_VIEW === 'true'
+
+interface ProbeResult {
+  status: 'pending' | 'ok' | 'error'
+  version?: number
+}
+
+function StatusLine({ probe, isPublic }: { probe?: ProbeResult; isPublic: boolean }) {
+  const accessLabel = isPublic ? 'Public' : 'Private'
+  const accessColor = isPublic ? '#52c41a' : '#faad14'
+
+  let reachLabel: string
+  let reachColor: string
+  if (!probe) {
+    reachLabel = isPublic ? '' : 'Requires authentication'
+    reachColor = '#999'
+  } else if (probe.status === 'pending') {
+    reachLabel = 'Checking...'
+    reachColor = '#999'
+  } else if (probe.status === 'ok') {
+    reachLabel = probe.version ? `Reachable (v${probe.version})` : 'Reachable'
+    reachColor = '#52c41a'
+  } else {
+    reachLabel = 'Unreachable'
+    reachColor = '#ff4d4f'
+  }
+
+  return (
+    <div style={{ fontSize: 11, marginTop: 4 }}>
+      <span style={{ color: accessColor }}>● {accessLabel}</span>
+      {reachLabel && (
+        <>
+          <span style={{ color: '#ccc', margin: '0 6px' }}>·</span>
+          <span style={{ color: reachColor }}>{reachLabel}</span>
+        </>
+      )}
+    </div>
+  )
+}
+
+interface ResolvedAccess {
+  url: string
+  token?: string
+}
+
+type CatalogDataset = ReturnType<typeof useAppStore.getState>['catalogDatasets'][number]
+
+export default function DatasetList({
+  datasets,
+  emptyText,
+}: {
+  datasets: CatalogDataset[]
+  emptyText?: React.ReactNode
+}) {
+  const navigate = useNavigate()
+  const [probeResults, setProbeResults] = useState<Map<string, ProbeResult>>(new Map())
+  const [resolvedAccess, setResolvedAccess] = useState<Map<string, ResolvedAccess>>(new Map())
+
+  // Resolve access for private datasets, then probe all datasets
+  useEffect(() => {
+    const controller = new AbortController()
+
+    // Probe public datasets directly
+    for (const ds of datasets) {
+      if (ds.url) {
+        const url = ds.url
+        setProbeResults((prev) => {
+          if (prev.has(ds.slug)) return prev
+          return new Map(prev).set(ds.slug, { status: 'pending' })
+        })
+        setResolvedAccess((prev) => new Map(prev).set(ds.slug, { url }))
+
+        probeStore(url, controller.signal)
+          .then((result) => {
+            if (controller.signal.aborted) return
+            setProbeResults((prev) => new Map(prev).set(ds.slug, result.ok
+              ? { status: 'ok', version: result.version }
+              : { status: 'error' },
+            ))
+          })
+          .catch(() => {
+            if (controller.signal.aborted) return
+            setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
+          })
+      }
+    }
+
+    // Resolve private datasets via /access, then probe with token
+    const resolvePrivate = async () => {
+      const { api } = await import('../api')
+      for (const ds of datasets) {
+        if (ds.url || controller.signal.aborted) continue
+
+        setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'pending' }))
+
+        try {
+          const { data } = await api.POST('/api/datasets/{slug}/access', {
+            params: { path: { slug: ds.slug } },
+          })
+          if (controller.signal.aborted || !data) continue
+
+          const access: ResolvedAccess = { url: data.url }
+          if (data.credential_type === 'bearer_token' && data.token) {
+            access.token = data.token
+          }
+          setResolvedAccess((prev) => new Map(prev).set(ds.slug, access))
+
+          // Probe with auth headers if needed
+          const headers: Record<string, string> = {}
+          if (access.token) {
+            headers['Authorization'] = `Bearer ${access.token}`
+          }
+
+          try {
+            const result = await probeStore(data.url, controller.signal, Object.keys(headers).length > 0 ? headers : undefined)
+            if (controller.signal.aborted) continue
+            setProbeResults((prev) => new Map(prev).set(ds.slug, result.ok
+              ? { status: 'ok', version: result.version }
+              : { status: 'error' },
+            ))
+          } catch {
+            if (!controller.signal.aborted) {
+              setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
+            }
+          }
+        } catch {
+          if (!controller.signal.aborted) {
+            setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
+          }
+        }
+      }
+    }
+
+    resolvePrivate()
+    return () => controller.abort()
+  }, [datasets])
+
+  const handleOpen = (slug: string) => {
+    navigate(`/view?dataset=${encodeURIComponent(slug)}`)
+  }
+
+  return (
+    <div>
+      {datasets.length > 0 ? (
+        <List
+          bordered
+          dataSource={datasets}
+          renderItem={(item) => {
+            const probe = probeResults.get(item.slug)
+            const access = resolvedAccess.get(item.slug)
+            const displayUrl = item.url ?? access?.url
+            return (
+              <List.Item
+                style={{ cursor: 'pointer' }}
+                onClick={() => handleOpen(item.slug)}
+                actions={displayUrl ? [
+                  ...(ENABLE_ZARR_VIEW ? [
+                    <Tooltip key="inspect" title="Inspect Zarr structure">
+                      <Link to={`/zarr_view?url=${encodeURIComponent(displayUrl)}`} onClick={(e) => e.stopPropagation()}>
+                        <Button type="text" icon={<ApartmentOutlined />} />
+                      </Link>
+                    </Tooltip>,
+                  ] : []),
+                  <Tooltip key="copy" title="Copy zarr URL">
+                    <Button
+                      type="text"
+                      icon={<LinkOutlined />}
+                      onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(displayUrl) }}
+                    />
+                  </Tooltip>,
+                ] : []}
+              >
+                <div style={{ flex: 1 }}>
+                  <Typography.Text strong>{item.name}</Typography.Text>
+                  {item.description && (
+                    <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
+                  )}
+                  {displayUrl && (
+                    <div><Typography.Text type="secondary" style={{ fontSize: 11, fontFamily: 'monospace' }}>{displayUrl}</Typography.Text></div>
+                  )}
+                  <StatusLine probe={probe} isPublic={item.is_public} />
+                </div>
+              </List.Item>
+            )
+          }}
+        />
+      ) : (
+        <Typography.Text type="secondary">{emptyText}</Typography.Text>
+      )}
+    </div>
+  )
+}

--- a/packages/highperformer/src/pages/Collection.test.tsx
+++ b/packages/highperformer/src/pages/Collection.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const getMock = vi.fn()
+vi.mock('../api', () => ({ api: { GET: getMock, POST: vi.fn().mockResolvedValue({ data: undefined }) } }))
+vi.mock('../utils/datasetProbe', () => ({ probeStore: vi.fn().mockResolvedValue({ ok: true, version: 3 }) }))
+
+import Collection from './Collection'
+
+const DETAIL = {
+  slug: 'a-study',
+  name: 'A Study',
+  description: 'About it',
+  publication_url: 'https://example.org/paper',
+  publication_citation: 'Author et al. 2025',
+  dataset_count: 1,
+  datasets: [
+    {
+      slug: 'ds1',
+      name: 'Dataset One',
+      description: null,
+      is_public: true,
+      url: 'https://cdn/ds1.zarr',
+      chat_enabled: false,
+    },
+  ],
+}
+
+function renderAt(slug: string) {
+  render(
+    <MemoryRouter initialEntries={[`/collections/${slug}`]}>
+      <Routes>
+        <Route path="/collections/:slug" element={<Collection />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Collection page', () => {
+  beforeEach(() => getMock.mockReset())
+  afterEach(cleanup)
+
+  it('renders the name, description and datasets', async () => {
+    getMock.mockResolvedValue({ data: DETAIL })
+    renderAt('a-study')
+    await waitFor(() => expect(screen.getByText('A Study')).toBeDefined())
+    expect(screen.getByText('About it')).toBeDefined()
+    expect(screen.getByText('Dataset One')).toBeDefined()
+  })
+
+  it('renders the publication as a link with the citation as its text', async () => {
+    getMock.mockResolvedValue({ data: DETAIL })
+    renderAt('a-study')
+    await waitFor(() => expect(screen.getByText('A Study')).toBeDefined())
+    const link = screen.getByRole('link', { name: /Author et al\. 2025/ })
+    expect(link.getAttribute('href')).toBe('https://example.org/paper')
+  })
+
+  it('requests the slug from the route', async () => {
+    getMock.mockResolvedValue({ data: DETAIL })
+    renderAt('a-study')
+    await waitFor(() =>
+      expect(getMock).toHaveBeenCalledWith('/api/collections/{slug}', {
+        params: { path: { slug: 'a-study' } },
+      }),
+    )
+  })
+
+  it('shows a not-found message when the API returns no data', async () => {
+    getMock.mockResolvedValue({ data: undefined, error: { detail: 'Collection not found' } })
+    renderAt('missing')
+    await waitFor(() => expect(screen.getByText(/not found/i)).toBeDefined())
+  })
+
+  it('shows the same not-found message when the request throws', async () => {
+    // ...Once, deliberately. A persistent rejecting mock stays installed past
+    // the assertion, and a later call during teardown produces a second
+    // rejection that nothing awaits — vitest then fails the file on an
+    // unhandled error even though the component caught the first one. Scoping
+    // it to the single call the component makes avoids that.
+    getMock.mockImplementationOnce(async () => {
+      throw new Error('network')
+    })
+    renderAt('a-study')
+    await waitFor(() => expect(screen.getByText(/not found/i)).toBeDefined())
+  })
+})

--- a/packages/highperformer/src/pages/Collection.tsx
+++ b/packages/highperformer/src/pages/Collection.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { Typography } from 'antd'
+import DatasetList from '../components/DatasetList'
+import useAppStore from '../store/useAppStore'
+
+type CatalogDataset = ReturnType<typeof useAppStore.getState>['catalogDatasets'][number]
+
+interface CollectionDetail {
+  slug: string
+  name: string
+  description: string | null
+  publication_url: string | null
+  publication_citation: string | null
+  dataset_count: number
+  datasets: CatalogDataset[]
+}
+
+export default function Collection() {
+  const { slug } = useParams<{ slug: string }>()
+  const [collection, setCollection] = useState<CollectionDetail | null>(null)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    if (!slug) return
+    let cancelled = false
+
+    const load = async () => {
+      try {
+        const { api } = await import('../api')
+        const { data } = await api.GET('/api/collections/{slug}', {
+          params: { path: { slug } },
+        })
+        if (cancelled) return
+        // The API returns 404 both for an unknown slug and for one whose
+        // datasets the caller cannot see. Treat them identically — telling
+        // them apart would confirm that a gated collection exists.
+        if (data) setCollection(data as CollectionDetail)
+        else setNotFound(true)
+      } catch {
+        if (!cancelled) setNotFound(true)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [slug])
+
+  if (notFound) {
+    return (
+      <div>
+        <Link to="/">← Back to datasets</Link>
+        <Typography.Paragraph style={{ marginTop: 24 }}>
+          Collection not found.
+        </Typography.Paragraph>
+      </div>
+    )
+  }
+
+  if (!collection) {
+    return <div />
+  }
+
+  return (
+    <div>
+      <Link to="/">← Back to datasets</Link>
+      <h2 style={{ marginTop: 16, marginBottom: 8 }}>{collection.name}</h2>
+      {collection.description && (
+        <Typography.Paragraph type="secondary">{collection.description}</Typography.Paragraph>
+      )}
+      {collection.publication_url && (
+        <Typography.Paragraph>
+          <a href={collection.publication_url} target="_blank" rel="noreferrer">
+            {collection.publication_citation ?? collection.publication_url}
+          </a>
+        </Typography.Paragraph>
+      )}
+      <DatasetList datasets={collection.datasets} emptyText="No datasets available" />
+    </div>
+  )
+}

--- a/packages/highperformer/src/pages/CollectionsTab.test.tsx
+++ b/packages/highperformer/src/pages/CollectionsTab.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../api', () => ({ api: { GET: vi.fn().mockResolvedValue({ data: undefined }), POST: vi.fn().mockResolvedValue({ data: undefined }) } }))
+vi.mock('../utils/datasetProbe', () => ({ probeStore: vi.fn().mockResolvedValue({ ok: true, version: 3 }) }))
+
+import useAppStore from '../store/useAppStore'
+import { CollectionsTab } from './Home'
+
+afterEach(() => cleanup())
+
+const COLLECTION = {
+  slug: 'a-study',
+  name: 'A Study',
+  description: 'About it',
+  publication_url: null,
+  publication_citation: null,
+  dataset_count: 3,
+}
+
+const UNGROUPED = {
+  slug: 'solo',
+  name: 'Solo Dataset',
+  description: null,
+  is_public: true,
+  url: 'https://cdn/solo.zarr',
+  chat_enabled: false,
+}
+
+function renderTab() {
+  render(<MemoryRouter><CollectionsTab /></MemoryRouter>)
+}
+
+describe('CollectionsTab', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      collections: [],
+      catalogDatasets: [],
+      fetchCollections: vi.fn().mockResolvedValue(undefined) as never,
+    })
+  })
+
+  it('lists each collection with its name, description and dataset count', () => {
+    useAppStore.setState({ collections: [COLLECTION] })
+    renderTab()
+    expect(screen.getByText('A Study')).toBeDefined()
+    expect(screen.getByText('About it')).toBeDefined()
+    expect(screen.getByText(/3 datasets/)).toBeDefined()
+  })
+
+  it('links each collection to its page', () => {
+    useAppStore.setState({ collections: [COLLECTION] })
+    renderTab()
+    const link = screen.getByRole('link', { name: /A Study/ })
+    expect(link.getAttribute('href')).toBe('/collections/a-study')
+  })
+
+  it('shows datasets with no collection under an Ungrouped heading', () => {
+    useAppStore.setState({ collections: [COLLECTION], catalogDatasets: [UNGROUPED] })
+    renderTab()
+    expect(screen.getByText('Ungrouped')).toBeDefined()
+    expect(screen.getByText('Solo Dataset')).toBeDefined()
+  })
+
+  it('omits the Ungrouped section when every dataset belongs to a collection', () => {
+    useAppStore.setState({
+      collections: [COLLECTION],
+      catalogDatasets: [{ ...UNGROUPED, collection: { slug: 'a-study', name: 'A Study' } }],
+    })
+    renderTab()
+    expect(screen.queryByText('Ungrouped')).toBeNull()
+  })
+
+  it('uses the singular for a collection with one dataset', () => {
+    useAppStore.setState({ collections: [{ ...COLLECTION, dataset_count: 1 }] })
+    renderTab()
+    expect(screen.getByText(/1 dataset(?!s)/)).toBeDefined()
+  })
+})

--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Input, Button, List, Tooltip, Typography, Tabs } from 'antd'
-import { ApartmentOutlined, CopyOutlined, DeleteOutlined, LinkOutlined } from '@ant-design/icons'
+import { ApartmentOutlined, DeleteOutlined, LinkOutlined } from '@ant-design/icons'
 import { loadDatasets, saveDatasets } from '../utils/datasets'
 import { probeStore } from '../utils/datasetProbe'
 import useAppStore from '../store/useAppStore'
 import UserAvatar from '../components/UserAvatar'
+import DatasetList from '../components/DatasetList'
 
 const ENABLE_ZARR_VIEW = import.meta.env.VITE_ENABLE_ZARR_VIEW === 'true'
 
@@ -47,156 +48,20 @@ function StatusLine({ probe, isPublic }: { probe?: ProbeResult; isPublic: boolea
   )
 }
 
-interface ResolvedAccess {
-  url: string
-  token?: string
-}
-
 function CatalogTab() {
   const catalogDatasets = useAppStore((s) => s.catalogDatasets)
-  const openCatalogDataset = useAppStore((s) => s.openCatalogDataset)
   const backendInfo = useAppStore((s) => s.backendInfo)
   const user = useAppStore((s) => s.user)
-  const navigate = useNavigate()
-  const [probeResults, setProbeResults] = useState<Map<string, ProbeResult>>(new Map())
-  const [resolvedAccess, setResolvedAccess] = useState<Map<string, ResolvedAccess>>(new Map())
-
-  // Resolve access for private datasets, then probe all datasets
-  useEffect(() => {
-    const controller = new AbortController()
-
-    // Probe public datasets directly
-    for (const ds of catalogDatasets) {
-      if (ds.url) {
-        const url = ds.url
-        setProbeResults((prev) => {
-          if (prev.has(ds.slug)) return prev
-          return new Map(prev).set(ds.slug, { status: 'pending' })
-        })
-        setResolvedAccess((prev) => new Map(prev).set(ds.slug, { url }))
-
-        probeStore(url, controller.signal)
-          .then((result) => {
-            if (controller.signal.aborted) return
-            setProbeResults((prev) => new Map(prev).set(ds.slug, result.ok
-              ? { status: 'ok', version: result.version }
-              : { status: 'error' },
-            ))
-          })
-          .catch(() => {
-            if (controller.signal.aborted) return
-            setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
-          })
-      }
-    }
-
-    // Resolve private datasets via /access, then probe with token
-    const resolvePrivate = async () => {
-      const { api } = await import('../api')
-      for (const ds of catalogDatasets) {
-        if (ds.url || controller.signal.aborted) continue
-
-        setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'pending' }))
-
-        try {
-          const { data } = await api.POST('/api/datasets/{slug}/access', {
-            params: { path: { slug: ds.slug } },
-          })
-          if (controller.signal.aborted || !data) continue
-
-          const access: ResolvedAccess = { url: data.url }
-          if (data.credential_type === 'bearer_token' && data.token) {
-            access.token = data.token
-          }
-          setResolvedAccess((prev) => new Map(prev).set(ds.slug, access))
-
-          // Probe with auth headers if needed
-          const headers: Record<string, string> = {}
-          if (access.token) {
-            headers['Authorization'] = `Bearer ${access.token}`
-          }
-
-          try {
-            const result = await probeStore(data.url, controller.signal, Object.keys(headers).length > 0 ? headers : undefined)
-            if (controller.signal.aborted) continue
-            setProbeResults((prev) => new Map(prev).set(ds.slug, result.ok
-              ? { status: 'ok', version: result.version }
-              : { status: 'error' },
-            ))
-          } catch {
-            if (!controller.signal.aborted) {
-              setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
-            }
-          }
-        } catch {
-          if (!controller.signal.aborted) {
-            setProbeResults((prev) => new Map(prev).set(ds.slug, { status: 'error' }))
-          }
-        }
-      }
-    }
-
-    resolvePrivate()
-    return () => controller.abort()
-  }, [catalogDatasets])
-
-  const handleOpen = (slug: string) => {
-    navigate(`/view?dataset=${encodeURIComponent(slug)}`)
-  }
 
   return (
-    <div>
-      {catalogDatasets.length > 0 ? (
-        <List
-          bordered
-          dataSource={catalogDatasets}
-          renderItem={(item) => {
-            const probe = probeResults.get(item.slug)
-            const access = resolvedAccess.get(item.slug)
-            const displayUrl = item.url ?? access?.url
-            return (
-              <List.Item
-                style={{ cursor: 'pointer' }}
-                onClick={() => handleOpen(item.slug)}
-                actions={displayUrl ? [
-                  ...(ENABLE_ZARR_VIEW ? [
-                    <Tooltip key="inspect" title="Inspect Zarr structure">
-                      <Link to={`/zarr_view?url=${encodeURIComponent(displayUrl)}`} onClick={(e) => e.stopPropagation()}>
-                        <Button type="text" icon={<ApartmentOutlined />} />
-                      </Link>
-                    </Tooltip>,
-                  ] : []),
-                  <Tooltip key="copy" title="Copy zarr URL">
-                    <Button
-                      type="text"
-                      icon={<LinkOutlined />}
-                      onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(displayUrl) }}
-                    />
-                  </Tooltip>,
-                ] : []}
-              >
-                <div style={{ flex: 1 }}>
-                  <Typography.Text strong>{item.name}</Typography.Text>
-                  {item.description && (
-                    <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.description}</Typography.Text></div>
-                  )}
-                  {displayUrl && (
-                    <div><Typography.Text type="secondary" style={{ fontSize: 11, fontFamily: 'monospace' }}>{displayUrl}</Typography.Text></div>
-                  )}
-                  <StatusLine probe={probe} isPublic={item.is_public} />
-                </div>
-              </List.Item>
-            )
-          }}
-        />
-      ) : (
-        <Typography.Text type="secondary">
-          {!user && backendInfo?.auth_enabled
-            ? 'Sign in to see more datasets'
-            : 'No datasets available'}
-        </Typography.Text>
-      )}
-    </div>
+    <DatasetList
+      datasets={catalogDatasets}
+      emptyText={
+        !user && backendInfo?.auth_enabled
+          ? 'Sign in to see more datasets'
+          : 'No datasets available'
+      }
+    />
   )
 }
 

--- a/packages/highperformer/src/pages/Home.tsx
+++ b/packages/highperformer/src/pages/Home.tsx
@@ -48,6 +48,59 @@ function StatusLine({ probe, isPublic }: { probe?: ProbeResult; isPublic: boolea
   )
 }
 
+export function CollectionsTab() {
+  const collections = useAppStore((s) => s.collections)
+  const catalogDatasets = useAppStore((s) => s.catalogDatasets)
+  const fetchCollections = useAppStore((s) => s.fetchCollections)
+
+  useEffect(() => {
+    fetchCollections()
+  }, [fetchCollections])
+
+  const ungrouped = catalogDatasets.filter((d) => !d.collection)
+
+  return (
+    <div>
+      {collections.length > 0 ? (
+        <List
+          bordered
+          dataSource={collections}
+          renderItem={(item) => (
+            <List.Item>
+              <div style={{ flex: 1 }}>
+                <Link to={`/collections/${encodeURIComponent(item.slug)}`}>
+                  <Typography.Text strong>{item.name}</Typography.Text>
+                </Link>
+                {item.description && (
+                  <div>
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      {item.description}
+                    </Typography.Text>
+                  </div>
+                )}
+                <div style={{ fontSize: 11, marginTop: 4 }}>
+                  <Typography.Text type="secondary">
+                    {item.dataset_count} dataset{item.dataset_count === 1 ? '' : 's'}
+                  </Typography.Text>
+                </div>
+              </div>
+            </List.Item>
+          )}
+        />
+      ) : (
+        <Typography.Text type="secondary">No collections available</Typography.Text>
+      )}
+
+      {ungrouped.length > 0 && (
+        <div style={{ marginTop: 24 }}>
+          <Typography.Title level={5}>Ungrouped</Typography.Title>
+          <DatasetList datasets={ungrouped} />
+        </div>
+      )}
+    </div>
+  )
+}
+
 function CatalogTab() {
   const catalogDatasets = useAppStore((s) => s.catalogDatasets)
   const backendInfo = useAppStore((s) => s.backendInfo)
@@ -193,7 +246,7 @@ function MyUrlsTab() {
 function Home() {
   const backendInfo = useAppStore((s) => s.backendInfo)
   const backendProbed = useAppStore((s) => s.backendProbed)
-  const [activeTab, setActiveTab] = useState('catalog')
+  const [activeTab, setActiveTab] = useState('collections')
 
   if (!backendProbed) {
     return (
@@ -217,7 +270,8 @@ function Home() {
           activeKey={activeTab}
           onChange={setActiveTab}
           items={[
-            { key: 'catalog', label: 'Catalog', children: <CatalogTab /> },
+            { key: 'collections', label: 'Collections', children: <CollectionsTab /> },
+            { key: 'catalog', label: 'All datasets', children: <CatalogTab /> },
             { key: 'urls', label: 'My URLs', children: <MyUrlsTab /> },
           ]}
         />

--- a/packages/highperformer/src/store/fetchCollections.test.ts
+++ b/packages/highperformer/src/store/fetchCollections.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getMock = vi.fn()
+vi.mock('../api', () => ({ api: { GET: getMock, POST: vi.fn() } }))
+
+import useAppStore from './useAppStore'
+
+const COLLECTION = {
+  slug: 'a-study',
+  name: 'A Study',
+  description: 'About it',
+  publication_url: 'https://example.org/paper',
+  publication_citation: 'Author et al. 2025',
+  dataset_count: 3,
+}
+
+describe('fetchCollections', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    useAppStore.setState({ collections: [] })
+  })
+
+  it('stores the collections the API returns', async () => {
+    getMock.mockResolvedValue({ data: { collections: [COLLECTION] } })
+    await useAppStore.getState().fetchCollections()
+    expect(useAppStore.getState().collections).toEqual([COLLECTION])
+    expect(getMock).toHaveBeenCalledWith('/api/collections')
+  })
+
+  it('keeps the existing collections when the request fails', async () => {
+    useAppStore.setState({ collections: [COLLECTION] })
+    getMock.mockRejectedValue(new Error('backend down'))
+    await useAppStore.getState().fetchCollections()
+    expect(useAppStore.getState().collections).toEqual([COLLECTION])
+  })
+
+  it('keeps the existing collections when the response has no body', async () => {
+    useAppStore.setState({ collections: [COLLECTION] })
+    getMock.mockResolvedValue({ data: undefined })
+    await useAppStore.getState().fetchCollections()
+    expect(useAppStore.getState().collections).toEqual([COLLECTION])
+  })
+})

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -224,6 +224,17 @@ export interface AppState {
   fetchCatalog: () => Promise<void>
   openCatalogDataset: (slug: string) => Promise<void>
 
+  // Collections
+  collections: Array<{
+    slug: string
+    name: string
+    description: string | null
+    publication_url: string | null
+    publication_citation: string | null
+    dataset_count: number
+  }>
+  fetchCollections: () => Promise<void>
+
   // UI visibility toggles (for embedded mode)
   showHeader: boolean
   showLeftSidebar: boolean
@@ -514,6 +525,17 @@ const useAppStore = create<AppState>((set, get) => ({
       if (data?.datasets) set({ catalogDatasets: data.datasets })
     } catch {
       // Backend unavailable or request failed — keep existing catalog
+    }
+  },
+
+  collections: [],
+  fetchCollections: async () => {
+    try {
+      const { api } = await import('../api')
+      const { data } = await api.GET('/api/collections')
+      if (data?.collections) set({ collections: data.collections })
+    } catch {
+      // Backend unavailable or request failed — keep existing collections
     }
   },
 

--- a/packages/highperformer/src/store/useAppStore.ts
+++ b/packages/highperformer/src/store/useAppStore.ts
@@ -220,6 +220,7 @@ export interface AppState {
     url: string | null
     chat_enabled: boolean
     default_view?: Record<string, unknown> | null
+    collection?: { slug: string; name: string } | null
   }>
   fetchCatalog: () => Promise<void>
   openCatalogDataset: (slug: string) => Promise<void>

--- a/packages/highperformer/src/test/setup.ts
+++ b/packages/highperformer/src/test/setup.ts
@@ -6,3 +6,15 @@ globalThis.ResizeObserver ??= class {
   unobserve() {}
   disconnect() {}
 };
+
+// Stub matchMedia for antd components (e.g. List) that use responsive breakpoint hooks
+globalThis.matchMedia ??= ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+})) as typeof window.matchMedia;


### PR DESCRIPTION
Shows datasets grouped under the study they came from, with a page per collection, instead of one flat list of 76 — 32 of which are samples from a single breast-cancer study.

Backend counterpart is cBioPortal/cell-explorer-py#177, already merged and deployed (`b57c781`). The 8 collections exist in production with all 71 HTAN datasets assigned, so this has real data to render.

## What's here

| Commit | |
|---|---|
| `798c082` | Regenerate `api-client` from the backend spec; `collections` + `fetchCollections` on the store |
| `350f6d6` | Extract `DatasetList` out of `Home.tsx` — pure refactor |
| `ef3bdee` | Collections tab with an "Ungrouped" section |
| `776a7af` | `/collections/:slug` page |

**Tabs are now `Collections | All datasets | My URLs`**, defaulting to Collections. `All datasets` is today's flat list, unchanged. The 5 datasets that belong to no collection (`spectrum`, `egfr-all-cells`, the three atlases) appear under "Ungrouped" so nothing becomes unreachable.

**`DatasetList` extraction** was the enabling change: `CatalogTab` owned access resolution for private datasets, store probing, and list rendering in one place, and both the Collections tab and the collection page need all three. `Home.tsx` went 366 → 231 lines. No behaviour change — the existing suite is the spec for that commit.

**The collection page fetches from `GET /api/collections/{slug}`** rather than filtering the store, so a deep link works on a cold load with an empty store.

## One thing worth reviewing carefully

The API returns **404 both for a collection that does not exist and for one whose datasets you cannot see** — deliberately, since a 403 would confirm a gated study exists. The page renders identical output for both, and two tests pin that. Please don't "improve" it later with a friendlier "you don't have access to this collection" message; that would undo the backend's non-disclosure guarantee.

## Testing

`pnpm test` → **522 passed, 1 skipped** (506 before this branch). `pnpm build` clean.

`pnpm typecheck` reports 16 errors — all pre-existing on `main` (`AnnDataStore.ts`, `WhyPanel.tsx`, `SelectionOverlay.tsx`, `View.tsx`, `useAppStore.ts`, and 3 that moved from `Home.tsx` into `DatasetList.tsx` with the refactor). Count is unchanged; this branch adds none.

Added a `matchMedia` stub to `src/test/setup.ts` — antd's `List` needs it under jsdom and no prior test exercised that path.

## Deploy note

The frontend is baked into the backend image at build time (`cell-explorer-py`'s Dockerfile clones this repo's `main`), and its CI only triggers on push/PR to that repo's `main`. **Merging this alone will not ship the UI** — it needs a backend `main` push, or a re-run of that repo's CI, to rebuild the image.

## Follow-up, not in this PR

All 8 collections currently have empty descriptions and publication links. They're populated from `collections.yaml` in `cell-explorer-scripts` and need a manual pass.