### PR TITLE
ci: drop the test-app job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @cbioportal-cell-explorer/zarrstore test
 
-  test-app:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @cbioportal-cell-explorer/app test
-
   test-profiler:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
@@ -77,7 +64,7 @@ jobs:
       - run: pnpm --filter @cbioportal-cell-explorer/highperformer test
 
   build:
-    needs: [test-zarrstore, test-app, test-profiler, test-highperformer]
+    needs: [test-zarrstore, test-profiler, test-highperformer]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
`packages/app` is deprecated — highperformer replaced it, and the deployment image builds only highperformer (`pnpm --filter @cbioportal-cell-explorer/highperformer build` in cell-explorer-py's Dockerfile). So this job spends a runner on code that never ships.

It had also stopped being trustworthy. The same three files —`ExplorerLayout.test.jsx`, `ViewerContent.test.jsx`, `SidebarEmbeddingPicker.test.jsx` — fail with `Invalid Chai property: toBeInTheDocument` in CI while passing locally both from inside the package and via `pnpm --filter` from the root, and the result varies between runs on identical code. The install step succeeds, so it isn't dependency resolution; `setup-node`'s pnpm cache differing between runs is the likeliest culprit. Not worth chasing for a package we don't ship.

Also drops `test-app` from the `build` job's `needs` list — leaving a dangling job reference there would make the workflow invalid.

This unblocks #296, which is otherwise green.

Leaves `packages/app` in the tree; actually deleting it is a separate question, and worth checking dependents first — changesets still treats it as a dependent of `api-client` and `highperformer`.