### PR TITLE
chore: release collections as patch (0.5.3) not minor

### DIFF
--- a/.changeset/nervous-donkeys-shake.md
+++ b/.changeset/nervous-donkeys-shake.md
@@ -1,6 +1,6 @@
 ---
-"@cbioportal-cell-explorer/highperformer": minor
-"@cbioportal-cell-explorer/api-client": minor
+"@cbioportal-cell-explorer/highperformer": patch
+"@cbioportal-cell-explorer/api-client": patch
 ---
 
 Group datasets by collection in the catalog.


### PR DESCRIPTION
Downgrades the collections changeset from minor to patch, matching how 6da7feb handled the colorby changesets.

Result: highperformer 0.5.2 -> 0.5.3, api-client 0.2.1 -> 0.2.2 (app follows at patch as a dependent).

Version Packages (#298) will regenerate with these levels once this lands.