### PR TITLE
Stop a focus ring appearing when a facet filter is clicked

### DIFF
--- a/.changeset/brave-otters-repeat.md
+++ b/.changeset/brave-otters-repeat.md
@@ -1,0 +1,10 @@
+---
+"@cbioportal-cell-explorer/highperformer": patch
+---
+
+Stop a focus ring appearing when a facet filter is clicked.
+
+The facet value rule used `:focus-within`, which matches mouse input too, so
+ticking a filter drew an outline around the whole row until focus moved
+elsewhere. It now uses `:has(:focus-visible)`, so the ring appears for keyboard
+navigation only.

--- a/packages/highperformer/src/index.css
+++ b/packages/highperformer/src/index.css
@@ -719,7 +719,10 @@ body {
 .ce-active-chip:focus-visible,
 .ce-active-clear:focus-visible,
 .ce-tab:focus-visible,
-.ce-facet-value:focus-within,
+/* :has(:focus-visible) rather than :focus-within — the focusable element is the
+   nested checkbox, but :focus-within also matches a mouse click, which drew a
+   box around the row every time a filter was ticked. */
+.ce-facet-value:has(:focus-visible),
 .ce-facet-clear:focus-visible,
 .ce-facet-more:focus-visible,
 .ce-cross-tab:focus-visible,


### PR DESCRIPTION
Follow-up to #304.

Clicking a facet filter drew a rectangle around the row and left it there until focus moved elsewhere.

The facet value rule used `:focus-within`, unlike every other focus rule on the page, which uses `:focus-visible`. Clicking a checkbox focuses it, so `:focus-within` matched mouse input too.

`:focus-visible` on the label would not have worked — the focusable element is the nested checkbox, not the label — so the rule is now `:has(:focus-visible)`, which matches only when that checkbox has a keyboard focus ring. The file already uses `:has()` elsewhere, so no new compatibility surface.

Verified both directions in the browser: clicking leaves no outline; tabbing to the same checkbox reports `matches(':has(:focus-visible)') === true` with `outlineStyle: solid`, and the ring is visible.

One line of CSS. 627 tests passing, build succeeds.
